### PR TITLE
feat: configure helmet with strict CSP for Descope auth flows

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,6 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
-import helmet from 'helmet';
 import pinoHttp from 'pino-http';
 import type { Options, HttpLogger } from 'pino-http';
 import { fileURLToPath } from 'node:url';
@@ -31,6 +30,7 @@ import { componentRegistryRouter } from './routes/adminPageLayouts.js';
 import { pageLayoutsRouter } from './routes/pageLayouts.js';
 import { adminTargetsRouter } from './routes/adminTargets.js';
 import { targetsRouter } from './routes/targets.js';
+import { securityHeaders } from './middleware/security.js';
 import { globalLimiter, writeMethodLimiter, authLimiter } from './middleware/rateLimiter.js';
 import { requireCsrf } from './middleware/csrf.js';
 
@@ -48,7 +48,7 @@ app.set('trust proxy', config.trustProxy);
 type PinoHttpFactory = (opts: Options) => HttpLogger;
 const httpLogger = pinoHttp as unknown as PinoHttpFactory;
 
-app.use(helmet());
+app.use(securityHeaders);
 app.use(cors({ origin: config.corsOrigin, credentials: true }));
 app.use(cookieParser());
 app.use(express.json());

--- a/apps/api/src/middleware/__tests__/security.test.ts
+++ b/apps/api/src/middleware/__tests__/security.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import { createServer } from 'node:http';
+import { securityHeaders } from '../security.js';
+
+/**
+ * Starts a minimal Express app with the security middleware and returns
+ * a function to make requests against it. The server is closed after
+ * the callback runs.
+ */
+async function requestWithHeaders(): Promise<Record<string, string>> {
+  const app = express();
+  app.use(securityHeaders);
+  app.get('/', (_req, res) => res.json({ ok: true }));
+
+  const server = createServer(app);
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to bind server'));
+        return;
+      }
+
+      const port = address.port;
+      fetch(`http://127.0.0.1:${port}/`)
+        .then((res) => {
+          const headers: Record<string, string> = {};
+          res.headers.forEach((value, key) => {
+            headers[key] = value;
+          });
+          server.close();
+          resolve(headers);
+        })
+        .catch((err) => {
+          server.close();
+          reject(err);
+        });
+    });
+  });
+}
+
+describe('security middleware (helmet + CSP)', () => {
+  it('sets the Content-Security-Policy header', async () => {
+    const headers = await requestWithHeaders();
+    expect(headers['content-security-policy']).toBeDefined();
+  });
+
+  it('includes self as default-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("default-src 'self'");
+  });
+
+  it('allows Descope domains in script-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("script-src 'self' https://descope.com https://*.descope.com");
+  });
+
+  it('allows unsafe-inline and Google Fonts in style-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+  });
+
+  it('allows data URIs and HTTPS images in img-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("img-src 'self' data: https:");
+  });
+
+  it('allows Descope API domains in connect-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("connect-src 'self' https://*.descope.com https://api.descope.com");
+  });
+
+  it('allows Descope iframes in frame-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain('frame-src https://*.descope.com');
+  });
+
+  it('allows Google Fonts in font-src', async () => {
+    const headers = await requestWithHeaders();
+    const csp = headers['content-security-policy'];
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
+  });
+
+  it('sets X-Content-Type-Options to nosniff', async () => {
+    const headers = await requestWithHeaders();
+    expect(headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets X-Frame-Options header', async () => {
+    const headers = await requestWithHeaders();
+    expect(headers['x-frame-options']).toBeDefined();
+  });
+
+  it('removes X-Powered-By header', async () => {
+    const headers = await requestWithHeaders();
+    expect(headers['x-powered-by']).toBeUndefined();
+  });
+});

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -1,0 +1,27 @@
+import helmet from 'helmet';
+import type { RequestHandler } from 'express';
+
+/**
+ * Helmet middleware configured with a strict Content Security Policy.
+ *
+ * CSP directives are tuned for:
+ * - Descope auth flows (script loading, API calls, iframes)
+ * - Google Fonts (stylesheet + font file loading)
+ * - CSS modules (requires 'unsafe-inline' for style injection)
+ *
+ * Applied to all responses. In production the API also serves the SPA,
+ * so the CSP protects rendered HTML pages.
+ */
+export const securityHeaders: RequestHandler = helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", 'https://descope.com', 'https://*.descope.com'],
+      styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+      imgSrc: ["'self'", 'data:', 'https:'],
+      connectSrc: ["'self'", 'https://*.descope.com', 'https://api.descope.com'],
+      frameSrc: ['https://*.descope.com'],
+      fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+    },
+  },
+}) as RequestHandler;


### PR DESCRIPTION
## Summary

- Extract helmet configuration into dedicated `middleware/security.ts` with a strict Content Security Policy tuned for Descope auth, Google Fonts, and CSS modules
- Fix CSP violations that blocked Descope API calls (e.g. `/v1/auth/try-refresh`) when the default `'self'`-only policy was active
- Add 11 tests verifying all CSP directives and other helmet security headers

## CSP Directives

| Directive | Sources |
|---|---|
| `default-src` | `'self'` |
| `script-src` | `'self'`, `https://descope.com`, `https://*.descope.com` |
| `style-src` | `'self'`, `'unsafe-inline'`, `https://fonts.googleapis.com` |
| `img-src` | `'self'`, `data:`, `https:` |
| `connect-src` | `'self'`, `https://*.descope.com`, `https://api.descope.com` |
| `frame-src` | `https://*.descope.com` |
| `font-src` | `'self'`, `https://fonts.gstatic.com` |

## Test plan

- [x] 11 new tests verify CSP header presence and all directive values
- [x] Tests verify other helmet headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-Powered-By` removal)
- [x] All 1159 existing API tests pass with zero regressions
- [x] TypeScript typecheck clean

Closes #362

https://claude.ai/code/session_012GgBNCC1Sd4i7a7TBv4e8B