### PR TITLE
feat(api): standardise error response shape with requestId (#373)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,8 @@ import { targetsRouter } from './routes/targets.js';
 import { securityHeaders } from './middleware/security.js';
 import { globalLimiter, writeMethodLimiter, authLimiter } from './middleware/rateLimiter.js';
 import { requireCsrf } from './middleware/csrf.js';
+import { requestId } from './middleware/requestId.js';
+import { errorHandler, normalizeErrorResponses } from './middleware/errorHandler.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -52,7 +54,24 @@ app.use(securityHeaders);
 app.use(cors({ origin: config.corsOrigin, credentials: true }));
 app.use(cookieParser());
 app.use(express.json());
-app.use(httpLogger({ logger }));
+// Assign a UUID to every incoming request BEFORE pino-http so the logger
+// picks it up via `req.id`. The same id is echoed as `X-Request-Id` and
+// surfaced in the canonical error response shape for log correlation.
+app.use(requestId);
+app.use(
+  httpLogger({
+    logger,
+    // pino-http reads `req.id` from the request — the `requestId` middleware
+    // above always assigns one, so log lines are correlated with the same
+    // UUID we echo back to clients in the `X-Request-Id` header.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    genReqId: (req: any) => req.id ?? '',
+  }),
+);
+// Normalise any legacy `{error: 'string'}` response bodies emitted by
+// routes that haven't been migrated to throw AppError yet so every API
+// error response conforms to the canonical shape.
+app.use('/api', normalizeErrorResponses);
 
 // Silence /favicon.ico requests with 204 No Content.  Without this, requests
 // that don't match a static file in production fall through to the SPA
@@ -113,6 +132,13 @@ if (config.env === 'production') {
     res.json({ name: 'cpcrm-api', status: 'ok' });
   });
 }
+
+// Global error-handling middleware — must be registered LAST so it catches
+// errors thrown from any handler (including the SPA fallback) and converts
+// them into the canonical `{ error: { code, message, details?, requestId } }`
+// payload. Express 5 forwards both synchronous and async thrown errors here
+// automatically.
+app.use(errorHandler);
 
 // Run database migrations, backfill seed data, then start the HTTP server.
 runMigrations()

--- a/apps/api/src/lib/__tests__/appError.test.ts
+++ b/apps/api/src/lib/__tests__/appError.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { AppError, isAppError } from '../appError.js';
+
+describe('AppError', () => {
+  it('constructs with code, statusCode, message, and optional details', () => {
+    const err = new AppError('VALIDATION_ERROR', 400, 'Bad input', {
+      fieldErrors: { email: 'invalid' },
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.code).toBe('VALIDATION_ERROR');
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe('Bad input');
+    expect(err.details).toEqual({ fieldErrors: { email: 'invalid' } });
+    expect(err.name).toBe('AppError');
+  });
+
+  it('validation() helper produces a 400 VALIDATION_ERROR', () => {
+    const err = AppError.validation('Bad input');
+    expect(err.code).toBe('VALIDATION_ERROR');
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe('Bad input');
+  });
+
+  it('notFound() helper produces a 404 NOT_FOUND', () => {
+    const err = AppError.notFound('Missing');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('conflict() helper produces a 409 CONFLICT', () => {
+    const err = AppError.conflict('Already exists');
+    expect(err.code).toBe('CONFLICT');
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('unauthenticated() helper produces a 401 UNAUTHENTICATED', () => {
+    const err = AppError.unauthenticated();
+    expect(err.code).toBe('UNAUTHENTICATED');
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toBe('Authentication required');
+  });
+
+  it('forbidden() helper produces a 403 FORBIDDEN', () => {
+    const err = AppError.forbidden();
+    expect(err.code).toBe('FORBIDDEN');
+    expect(err.statusCode).toBe(403);
+  });
+
+  it('isAppError identifies AppError instances', () => {
+    expect(isAppError(new AppError('X', 400, 'x'))).toBe(true);
+    expect(isAppError(new Error('nope'))).toBe(false);
+    expect(isAppError(null)).toBe(false);
+    expect(isAppError({ code: 'X', statusCode: 400, message: 'x' })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/api/src/lib/appError.ts
+++ b/apps/api/src/lib/appError.ts
@@ -1,0 +1,111 @@
+/**
+ * AppError — a typed error class used throughout the API to produce
+ * structured error responses.
+ *
+ * All API error responses must conform to the shape:
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "Human-readable summary",
+ *     "details": { "fieldErrors": { "email": "invalid format" } },
+ *     "requestId": "uuid"
+ *   }
+ * }
+ * ```
+ *
+ * Routes should `throw new AppError(...)` on failure and let the global
+ * error middleware in `middleware/errorHandler.ts` format the response.
+ * Express 5 forwards both synchronous and async thrown errors to the
+ * error middleware automatically.
+ */
+
+/** Machine-readable error codes emitted by the API. */
+export type AppErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'UNAUTHENTICATED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'DELETE_BLOCKED'
+  | 'RATE_LIMITED'
+  | 'CSRF_INVALID'
+  | 'INTERNAL_ERROR'
+  | (string & {});
+
+/**
+ * Structured error payload used by every API error response.
+ *
+ * `details` is intentionally loose so individual error codes can carry
+ * payload-specific metadata. The most common use is `fieldErrors`
+ * (a map of field name to message) for validation failures.
+ */
+export interface AppErrorDetails {
+  /** Field-level validation errors keyed by input name. */
+  fieldErrors?: Record<string, string>;
+  /** Additional context — kept open for error-code-specific fields. */
+  [key: string]: unknown;
+}
+
+/**
+ * Error class thrown by route handlers and services. The global error
+ * middleware converts instances of {@link AppError} into the canonical
+ * response shape defined above.
+ */
+export class AppError extends Error {
+  public readonly code: AppErrorCode;
+  public readonly statusCode: number;
+  public readonly details?: AppErrorDetails;
+
+  constructor(
+    code: AppErrorCode,
+    statusCode: number,
+    message: string,
+    details?: AppErrorDetails,
+  ) {
+    super(message);
+    this.name = 'AppError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+
+  /** Convenience constructor for 400 VALIDATION_ERROR. */
+  static validation(message: string, details?: AppErrorDetails): AppError {
+    return new AppError('VALIDATION_ERROR', 400, message, details);
+  }
+
+  /** Convenience constructor for 404 NOT_FOUND. */
+  static notFound(message: string, details?: AppErrorDetails): AppError {
+    return new AppError('NOT_FOUND', 404, message, details);
+  }
+
+  /** Convenience constructor for 409 CONFLICT. */
+  static conflict(message: string, details?: AppErrorDetails): AppError {
+    return new AppError('CONFLICT', 409, message, details);
+  }
+
+  /** Convenience constructor for 401 UNAUTHENTICATED. */
+  static unauthenticated(
+    message = 'Authentication required',
+    details?: AppErrorDetails,
+  ): AppError {
+    return new AppError('UNAUTHENTICATED', 401, message, details);
+  }
+
+  /** Convenience constructor for 403 FORBIDDEN. */
+  static forbidden(
+    message = 'Permission denied',
+    details?: AppErrorDetails,
+  ): AppError {
+    return new AppError('FORBIDDEN', 403, message, details);
+  }
+}
+
+/**
+ * Type guard used by the error middleware and tests.
+ */
+export function isAppError(value: unknown): value is AppError {
+  return value instanceof AppError;
+}

--- a/apps/api/src/middleware/__tests__/errorHandler.test.ts
+++ b/apps/api/src/middleware/__tests__/errorHandler.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { z } from 'zod';
+import { AppError } from '../../lib/appError.js';
+import { errorHandler, normalizeErrorResponses } from '../errorHandler.js';
+import { requestId } from '../requestId.js';
+
+/**
+ * Build a minimal express app with the full error pipeline wired up so we
+ * can exercise the middleware end-to-end over a real HTTP connection.
+ */
+function buildApp(
+  register: (app: express.Express) => void,
+): Promise<{ server: Server; url: string }> {
+  const app = express();
+  app.use(express.json());
+  app.use(requestId);
+  app.use(normalizeErrorResponses);
+  register(app);
+  app.use(errorHandler);
+
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Failed to bind test server'));
+        return;
+      }
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('errorHandler middleware', () => {
+  it('formats thrown AppError into the canonical shape with requestId', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/boom', (_req, _res, next) => {
+        next(AppError.notFound('Widget not found'));
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/boom`);
+      expect(res.status).toBe(404);
+      expect(res.headers.get('X-Request-Id')).toBeTruthy();
+      const body = (await res.json()) as {
+        error: {
+          code: string;
+          message: string;
+          requestId?: string;
+          details?: unknown;
+        };
+      };
+      expect(body.error.code).toBe('NOT_FOUND');
+      expect(body.error.message).toBe('Widget not found');
+      expect(body.error.requestId).toBe(res.headers.get('X-Request-Id'));
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('formats a VALIDATION_ERROR with fieldErrors details', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/validate', (_req, _res, next) => {
+        next(
+          AppError.validation('Request validation failed', {
+            fieldErrors: { email: 'invalid format' },
+          }),
+        );
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/validate`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        error: { code: string; details?: { fieldErrors?: unknown } };
+      };
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+      expect(body.error.details?.fieldErrors).toEqual({
+        email: 'invalid format',
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('converts thrown ZodError into a 400 VALIDATION_ERROR with fieldErrors', async () => {
+    const schema = z.object({
+      email: z.string().email(),
+      age: z.number().int().min(18),
+    });
+    const { server, url } = await buildApp((app) => {
+      app.post('/z', (req, _res, next) => {
+        try {
+          schema.parse(req.body);
+        } catch (e) {
+          next(e);
+          return;
+        }
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/z`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'not-an-email', age: 10 }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        error: {
+          code: string;
+          message: string;
+          details?: { fieldErrors?: Record<string, string> };
+        };
+      };
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+      expect(body.error.details?.fieldErrors).toBeDefined();
+      expect(Object.keys(body.error.details!.fieldErrors!)).toEqual(
+        expect.arrayContaining(['email', 'age']),
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('maps legacy service errors (Error with .code) to the correct status', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/legacy', (_req, _res, next) => {
+        const err = new Error('Duplicate api name') as Error & {
+          code?: string;
+        };
+        err.code = 'CONFLICT';
+        next(err);
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/legacy`);
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe('CONFLICT');
+      expect(body.error.message).toBe('Duplicate api name');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('returns 500 INTERNAL_ERROR for unknown errors without leaking internals', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/kaboom', (_req, _res, next) => {
+        next(new Error('Internals leak: password=hunter2'));
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/kaboom`);
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(body.error.message).toBe('An unexpected error occurred');
+      // Make absolutely sure no stack trace or secret leaked.
+      expect(JSON.stringify(body)).not.toContain('hunter2');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('every response includes an X-Request-Id header (including success)', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/ok', (_req, res) => res.json({ ok: true }));
+    });
+
+    try {
+      const res = await fetch(`${url}/ok`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('X-Request-Id')).toBeTruthy();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('honours an incoming X-Request-Id header from upstream proxies', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/ok', (_req, res) => res.json({ ok: true }));
+    });
+
+    try {
+      const incoming = 'abc-123-deadbeef';
+      const res = await fetch(`${url}/ok`, {
+        headers: { 'X-Request-Id': incoming },
+      });
+      expect(res.headers.get('X-Request-Id')).toBe(incoming);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+describe('normalizeErrorResponses middleware', () => {
+  it('rewrites legacy {error: "string"} responses into the canonical shape', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/legacy', (_req, res) => {
+        res.status(403).json({ error: 'CSRF token mismatch' });
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/legacy`);
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: { code: string; message: string; requestId?: string };
+      };
+      expect(body.error.code).toBe('FORBIDDEN');
+      expect(body.error.message).toBe('CSRF token mismatch');
+      expect(body.error.requestId).toBe(res.headers.get('X-Request-Id'));
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('preserves top-level code on legacy responses', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/legacy', (_req, res) => {
+        res.status(409).json({ error: 'Duplicate', code: 'CONFLICT' });
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/legacy`);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe('CONFLICT');
+      expect(body.error.message).toBe('Duplicate');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('carries legacy fieldErrors into error.details.fieldErrors', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/legacy', (_req, res) => {
+        res.status(422).json({
+          error: 'Validation failed',
+          fieldErrors: { email: 'invalid' },
+        });
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/legacy`);
+      const body = (await res.json()) as {
+        error: { code: string; details?: { fieldErrors?: unknown } };
+      };
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+      expect(body.error.details?.fieldErrors).toEqual({ email: 'invalid' });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('leaves 2xx responses untouched', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/ok', (_req, res) => res.json({ id: 1, name: 'alice' }));
+    });
+
+    try {
+      const res = await fetch(`${url}/ok`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ id: 1, name: 'alice' });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('only rewrites legacy bodies once when already canonical', async () => {
+    const { server, url } = await buildApp((app) => {
+      app.get('/already', (_req, res) => {
+        res.status(400).json({
+          error: {
+            code: 'CUSTOM',
+            message: 'I formatted this myself',
+          },
+        });
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/already`);
+      const body = (await res.json()) as {
+        error: { code: string; message: string; requestId?: string };
+      };
+      expect(body.error.code).toBe('CUSTOM');
+      expect(body.error.message).toBe('I formatted this myself');
+      // requestId injected but nothing else touched.
+      expect(body.error.requestId).toBe(res.headers.get('X-Request-Id'));
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+describe('requestId middleware', () => {
+  it('assigns req.id and echoes it as X-Request-Id', async () => {
+    const captured: Array<string | undefined> = [];
+    const { server, url } = await buildApp((app) => {
+      app.get('/', (req, res) => {
+        captured.push(req.id as string | undefined);
+        res.json({ id: req.id });
+      });
+    });
+
+    try {
+      const res = await fetch(`${url}/`);
+      const header = res.headers.get('X-Request-Id');
+      expect(header).toBeTruthy();
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe(header);
+      expect(captured[0]).toBe(header);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,0 +1,285 @@
+import type { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+import { AppError, isAppError } from '../lib/appError.js';
+import { logger } from '../lib/logger.js';
+import { getRequestId } from './requestId.js';
+
+/**
+ * Canonical error payload returned by every API error response.
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "Human-readable summary",
+ *     "details": { "fieldErrors": { "email": "invalid format" } },
+ *     "requestId": "uuid"
+ *   }
+ * }
+ * ```
+ */
+export interface ApiErrorPayload {
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+    requestId?: string;
+  };
+}
+
+/**
+ * Build the canonical error payload for a given thrown value.
+ *
+ * Exported so other middleware (e.g. the response normalizer that
+ * rewrites legacy `{error: 'string'}` bodies) can share the exact same
+ * formatting rules.
+ */
+export function toErrorPayload(
+  err: unknown,
+  requestId: string | undefined,
+): { statusCode: number; payload: ApiErrorPayload } {
+  // Zod errors are treated as 400 VALIDATION_ERROR with field-level errors.
+  if (err instanceof ZodError) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of err.issues) {
+      const path = issue.path.join('.') || '_';
+      if (!(path in fieldErrors)) {
+        fieldErrors[path] = issue.message;
+      }
+    }
+    return {
+      statusCode: 400,
+      payload: {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: { fieldErrors },
+          requestId,
+        },
+      },
+    };
+  }
+
+  if (isAppError(err)) {
+    return {
+      statusCode: err.statusCode,
+      payload: {
+        error: {
+          code: err.code,
+          message: err.message,
+          details: err.details as Record<string, unknown> | undefined,
+          requestId,
+        },
+      },
+    };
+  }
+
+  // Services in this codebase frequently throw `Error` instances with a
+  // `.code` property attached (e.g. VALIDATION_ERROR, NOT_FOUND, CONFLICT).
+  // Translate these to a sensible status code so existing services keep
+  // working without being rewritten.
+  const maybe = err as Error & { code?: string; statusCode?: number } | undefined;
+  if (maybe && typeof maybe === 'object' && typeof maybe.code === 'string') {
+    const statusCode = maybe.statusCode ?? statusCodeFromCode(maybe.code);
+    if (statusCode) {
+      return {
+        statusCode,
+        payload: {
+          error: {
+            code: maybe.code,
+            message: maybe.message ?? 'Request failed',
+            requestId,
+          },
+        },
+      };
+    }
+  }
+
+  // Unknown error — return 500 without leaking internals.
+  return {
+    statusCode: 500,
+    payload: {
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'An unexpected error occurred',
+        requestId,
+      },
+    },
+  };
+}
+
+/**
+ * Map a known string code to a default HTTP status. Returns `undefined`
+ * for codes we do not recognise so the caller can fall back to 500.
+ */
+function statusCodeFromCode(code: string): number | undefined {
+  switch (code) {
+    case 'VALIDATION_ERROR':
+      return 400;
+    case 'UNAUTHENTICATED':
+      return 401;
+    case 'FORBIDDEN':
+      return 403;
+    case 'NOT_FOUND':
+      return 404;
+    case 'CONFLICT':
+      return 409;
+    case 'DELETE_BLOCKED':
+      return 400;
+    case 'RATE_LIMITED':
+      return 429;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Express error-handling middleware.
+ *
+ * Must be registered AFTER all routes. Converts any thrown error into
+ * the canonical {@link ApiErrorPayload} shape and logs unexpected errors
+ * at error level with the request id for log correlation.
+ */
+export function errorHandler(
+  err: unknown,
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
+): void {
+  const requestId = getRequestId(req);
+  const { statusCode, payload } = toErrorPayload(err, requestId);
+
+  // Log 5xx errors — 4xx are client-visible and intentional.
+  if (statusCode >= 500) {
+    logger.error({ err, requestId, path: req.path }, 'Unhandled error in request');
+  }
+
+  // If the response has already been partially sent we cannot safely
+  // rewrite the body; delegate to Express' default handler.
+  if (res.headersSent) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    _next(err);
+    return;
+  }
+
+  res.status(statusCode).json(payload);
+}
+
+/**
+ * Middleware that wraps `res.json` so existing routes which still call
+ * `res.status(x).json({ error: 'string' })` (or similar legacy shapes)
+ * are automatically rewritten into the canonical {@link ApiErrorPayload}
+ * shape. This lets us enforce the contract across all 240+ legacy call
+ * sites without touching every route in a single PR.
+ *
+ * New code should throw {@link AppError} instead of building responses
+ * manually; that path goes through {@link errorHandler}.
+ */
+export function normalizeErrorResponses(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const originalJson = res.json.bind(res);
+  res.json = function normalizedJson(body: unknown): Response {
+    const status = res.statusCode;
+    // Only rewrite error responses.
+    if (status < 400) {
+      return originalJson(body);
+    }
+    // Already in canonical shape — just inject requestId if missing.
+    if (isCanonicalErrorBody(body)) {
+      const requestId = getRequestId(req);
+      if (requestId && !body.error.requestId) {
+        body.error.requestId = requestId;
+      }
+      return originalJson(body);
+    }
+    const normalized = normalizeLegacyErrorBody(body, status, getRequestId(req));
+    return originalJson(normalized);
+  };
+  next();
+}
+
+function isCanonicalErrorBody(
+  body: unknown,
+): body is ApiErrorPayload & { error: { code: string; message: string; requestId?: string } } {
+  if (!body || typeof body !== 'object') return false;
+  const maybe = (body as { error?: unknown }).error;
+  if (!maybe || typeof maybe !== 'object') return false;
+  const err = maybe as { code?: unknown; message?: unknown };
+  return typeof err.code === 'string' && typeof err.message === 'string';
+}
+
+/**
+ * Normalize a legacy error body (any 4xx/5xx body that isn't already in
+ * the canonical shape) into {@link ApiErrorPayload}.
+ */
+function normalizeLegacyErrorBody(
+  body: unknown,
+  statusCode: number,
+  requestId: string | undefined,
+): ApiErrorPayload {
+  const record = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>;
+
+  // `error` can be a string (`{error: 'msg'}`) or an object (e.g. helmet's
+  // malformed-json handler). Handle both.
+  let message = 'Request failed';
+  const rawError = record.error;
+  if (typeof rawError === 'string') {
+    message = rawError;
+  } else if (typeof record.message === 'string') {
+    message = record.message;
+  }
+
+  // Some legacy routes include a top-level `code` alongside `error`.
+  const rawCode = record.code;
+  const code =
+    typeof rawCode === 'string'
+      ? rawCode
+      : defaultCodeForStatus(statusCode);
+
+  // Preserve any ancillary fields the old body carried as `details`.
+  const details: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'error' || key === 'message' || key === 'code') continue;
+    details[key] = value;
+  }
+  // fieldErrors is the canonical location; accept common aliases.
+  if (record.fieldErrors && !details.fieldErrors) {
+    details.fieldErrors = record.fieldErrors;
+  } else if (record.field_errors && !details.fieldErrors) {
+    details.fieldErrors = record.field_errors;
+  }
+
+  return {
+    error: {
+      code,
+      message,
+      details: Object.keys(details).length > 0 ? details : undefined,
+      requestId,
+    },
+  };
+}
+
+function defaultCodeForStatus(status: number): string {
+  switch (status) {
+    case 400:
+      return 'VALIDATION_ERROR';
+    case 401:
+      return 'UNAUTHENTICATED';
+    case 403:
+      return 'FORBIDDEN';
+    case 404:
+      return 'NOT_FOUND';
+    case 409:
+      return 'CONFLICT';
+    case 422:
+      return 'VALIDATION_ERROR';
+    case 429:
+      return 'RATE_LIMITED';
+    default:
+      return status >= 500 ? 'INTERNAL_ERROR' : 'CLIENT_ERROR';
+  }
+}

--- a/apps/api/src/middleware/requestId.ts
+++ b/apps/api/src/middleware/requestId.ts
@@ -1,0 +1,43 @@
+import type { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'node:crypto';
+
+const REQUEST_ID_HEADER = 'X-Request-Id';
+
+/**
+ * Generates a UUID for every incoming request and:
+ *
+ *   - Stores it on `req.id` so `pino-http` picks it up for log correlation
+ *   - Echoes it back as the `X-Request-Id` response header so clients and
+ *     downstream proxies can tie logs to a single request
+ *
+ * If the client already sent an `X-Request-Id` header (e.g. a load balancer
+ * in front of the API) we honour it instead of generating a new one.
+ *
+ * Note: Express's own type for `Request.id` is `ReqId = string | object`
+ * (from `@types/pino-http`), so we read/write through an `any` cast to
+ * sidestep the structural mismatch.
+ */
+export function requestId(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const incoming = req.header(REQUEST_ID_HEADER);
+  const id = incoming && incoming.length <= 128 ? incoming : randomUUID();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (req as any).id = id;
+  res.setHeader(REQUEST_ID_HEADER, id);
+  next();
+}
+
+/**
+ * Reads the request id from a request (or returns `undefined` if none is
+ * present — e.g. when the middleware was bypassed in a test).
+ */
+export function getRequestId(req: Request): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const id: unknown = (req as any).id;
+  if (typeof id === 'string') return id;
+  if (typeof id === 'number') return String(id);
+  return undefined;
+}

--- a/apps/web/src/lib/__tests__/apiClient.test.ts
+++ b/apps/web/src/lib/__tests__/apiClient.test.ts
@@ -394,6 +394,42 @@ describe('apiErrorFromResponse', () => {
     expect(err.message).toBe('Server Error');
     expect(err.code).toBe('SERVER_ERROR');
   });
+
+  it('parses the canonical error shape (error.code / error.message / error.requestId)', async () => {
+    const response = jsonResponse(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Request validation failed',
+          details: { fieldErrors: { email: 'invalid format' } },
+          requestId: 'req-uuid-123',
+        },
+      },
+      { status: 400 },
+    );
+    const err = await apiErrorFromResponse(response);
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('VALIDATION_ERROR');
+    expect(err.message).toBe('Request validation failed');
+    expect(err.fieldErrors).toEqual({ email: ['invalid format'] });
+    expect(err.requestId).toBe('req-uuid-123');
+  });
+
+  it('reads requestId from the X-Request-Id header when not in the body', async () => {
+    const response = {
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      headers: new Headers({
+        'content-type': 'application/json',
+        'x-request-id': 'header-req-id',
+      }),
+      json: async () => ({}),
+      text: async () => '{}',
+    } as unknown as Response;
+    const err = await apiErrorFromResponse(response);
+    expect(err.requestId).toBe('header-req-id');
+  });
 });
 
 describe('clearServerSession', () => {

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -35,6 +35,13 @@ export class ApiError extends Error {
   public readonly status: number;
   public readonly code: string;
   public readonly fieldErrors: FieldErrors;
+  /**
+   * Request correlation id emitted by the API in the canonical error
+   * payload (`error.requestId`) and mirrored in the `X-Request-Id`
+   * response header.  Undefined when the server did not provide one —
+   * e.g. for network-level failures.
+   */
+  public readonly requestId?: string;
   public readonly body: unknown;
 
   constructor(init: {
@@ -42,6 +49,7 @@ export class ApiError extends Error {
     code?: string;
     message: string;
     fieldErrors?: FieldErrors;
+    requestId?: string;
     body?: unknown;
   }) {
     super(init.message);
@@ -49,6 +57,7 @@ export class ApiError extends Error {
     this.status = init.status;
     this.code = init.code ?? fallbackCodeFromStatus(init.status);
     this.fieldErrors = init.fieldErrors ?? {};
+    this.requestId = init.requestId;
     this.body = init.body;
   }
 
@@ -96,9 +105,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function extractFieldErrors(body: unknown): FieldErrors | undefined {
-  if (!isRecord(body)) return undefined;
-  const raw = body.fieldErrors ?? body.field_errors ?? body.errors;
+function normaliseFieldErrors(raw: unknown): FieldErrors | undefined {
   if (!isRecord(raw)) return undefined;
   const out: FieldErrors = {};
   for (const [key, value] of Object.entries(raw)) {
@@ -112,7 +119,45 @@ function extractFieldErrors(body: unknown): FieldErrors | undefined {
 }
 
 /**
+ * Extract field-level validation errors from a response body.
+ *
+ * Prefers the canonical API error shape (`error.details.fieldErrors`)
+ * and falls back to the legacy top-level `fieldErrors` / `field_errors`
+ * / `errors` keys for backward compatibility with un-migrated routes.
+ */
+function extractFieldErrors(body: unknown): FieldErrors | undefined {
+  if (!isRecord(body)) return undefined;
+  // Canonical shape: body.error.details.fieldErrors
+  if (isRecord(body.error)) {
+    const details = body.error.details;
+    if (isRecord(details)) {
+      const canonical = normaliseFieldErrors(details.fieldErrors);
+      if (canonical) return canonical;
+    }
+  }
+  // Legacy fallbacks
+  return normaliseFieldErrors(
+    body.fieldErrors ?? body.field_errors ?? body.errors,
+  );
+}
+
+/**
  * Build an {@link ApiError} from a failed HTTP response.
+ *
+ * Understands the canonical error payload shape:
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "Human-readable summary",
+ *     "details": { "fieldErrors": { "email": "invalid format" } },
+ *     "requestId": "uuid"
+ *   }
+ * }
+ * ```
+ *
+ * as well as legacy shapes (`{error: "string"}`, `{error: "string", code: "..."}`).
  */
 export async function apiErrorFromResponse(
   response: Response,
@@ -120,12 +165,38 @@ export async function apiErrorFromResponse(
   const body = await safeReadBody(response);
   let message: string | undefined;
   let code: string | undefined;
+  let requestId: string | undefined;
 
   if (isRecord(body)) {
-    const errVal = body.error ?? body.message;
-    if (typeof errVal === 'string') message = errVal;
-    const codeVal = body.code;
-    if (typeof codeVal === 'string') code = codeVal;
+    // Canonical shape — `error` is an object.
+    if (isRecord(body.error)) {
+      const errObj = body.error;
+      if (typeof errObj.message === 'string') message = errObj.message;
+      if (typeof errObj.code === 'string') code = errObj.code;
+      if (typeof errObj.requestId === 'string') requestId = errObj.requestId;
+    } else if (typeof body.error === 'string') {
+      // Legacy shape — `error` is a bare string.
+      message = body.error;
+    } else if (typeof body.message === 'string') {
+      message = body.message;
+    }
+
+    if (!code && typeof body.code === 'string') {
+      // Legacy shape — top-level `code` alongside `error` string.
+      code = body.code;
+    }
+  }
+
+  // `X-Request-Id` header is always present when the API serves the
+  // request, even for responses whose body omits the canonical shape.
+  // Guarded against mocked Response objects in tests that may omit
+  // `headers` entirely.
+  if (!requestId) {
+    const headerId =
+      response.headers && typeof response.headers.get === 'function'
+        ? response.headers.get('X-Request-Id')
+        : null;
+    if (headerId) requestId = headerId;
   }
 
   return new ApiError({
@@ -133,6 +204,7 @@ export async function apiErrorFromResponse(
     code,
     message: message ?? response.statusText ?? `HTTP ${response.status}`,
     fieldErrors: extractFieldErrors(body),
+    requestId,
     body,
   });
 }


### PR DESCRIPTION
Closes #373 (Issue 2.5: Standardize API error response shape).

## Summary

Introduces the canonical API error payload:

```json
{
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "Human-readable summary",
    "details": { "fieldErrors": { "email": "invalid format" } },
    "requestId": "uuid"
  }
}
```

and wires it into every API response — including the 240+ legacy `res.status(x).json({error: 'string'})` call sites — without a risky big-bang rewrite of every route.

## Changes

**Backend (`apps/api`)**
- `lib/appError.ts` — `AppError` class with `code`, `statusCode`, `details`, plus `validation` / `notFound` / `conflict` / `unauthenticated` / `forbidden` helper constructors.
- `middleware/errorHandler.ts`
  - Global Express error-handling middleware: translates thrown `AppError`, `ZodError`, and legacy service errors (plain `Error` with a `.code` property — e.g. `VALIDATION_ERROR`, `NOT_FOUND`, `CONFLICT`) into the canonical shape. Unknown errors become a 500 `INTERNAL_ERROR` without leaking internals. 5xx are logged with the request id.
  - `normalizeErrorResponses` middleware wraps `res.json` so the 240+ legacy `{error: 'string'}` call sites are automatically rewritten into the canonical shape at runtime. This lets the contract be enforced across every existing route without touching 25 files in one PR. New code is expected to `throw new AppError(...)` instead.
- `middleware/requestId.ts` — generates a UUID for every request (honouring an upstream `X-Request-Id` header if present), stores it on `req.id` for `pino-http` log correlation, and echoes it back as the `X-Request-Id` response header. Every response (success or error) now carries this header.
- `index.ts` — wires the new middleware in the correct order: `requestId` before `pino-http`, `normalizeErrorResponses` before routes, `errorHandler` as the final middleware after routes and the SPA fallback.

**Frontend (`apps/web`)**
- `lib/apiClient.ts` — `ApiError` now carries a `requestId` field. `apiErrorFromResponse` prefers the canonical shape (`error.code` / `error.message` / `error.details.fieldErrors` / `error.requestId`) and falls back to the `X-Request-Id` response header, while still supporting the legacy `{error: "string"}` / `{error, code, fieldErrors}` shapes for any un-migrated route.

**Tests**
- `apps/api/src/lib/__tests__/appError.test.ts` — unit tests for `AppError` and its helpers.
- `apps/api/src/middleware/__tests__/errorHandler.test.ts` — end-to-end tests over a real HTTP server covering:
  - thrown `AppError` → canonical shape with `requestId`
  - `VALIDATION_ERROR` with `fieldErrors` details
  - thrown `ZodError` → 400 with field-level errors
  - legacy `Error` with `.code` property → correct status mapping
  - unknown errors → 500 `INTERNAL_ERROR` without leaking internals
  - every response carries `X-Request-Id` (including success)
  - honours upstream `X-Request-Id` headers
  - `normalizeErrorResponses` rewrites legacy shapes (`{error: "string"}`, `{error, code}`, `{error, fieldErrors}`)
  - canonical bodies are left alone, `requestId` still injected
  - 2xx responses are untouched
- `apps/web/src/lib/__tests__/apiClient.test.ts` — new cases for the canonical shape and `X-Request-Id` header fallback.

## Acceptance criteria (from #373)
- [x] All error responses conform to the shape (via `errorHandler` + `normalizeErrorResponses`).
- [x] `requestId` present on all responses (`X-Request-Id` header + `error.requestId` body field).
- [x] Frontend shows field-level errors from `details.fieldErrors` (new parser in `apiClient.ts`).
- [x] Test coverage for the error middleware.

## Test plan
- [x] `cd apps/api && npm run typecheck` — clean
- [x] `cd apps/api && npm test` — 1237 passed
- [x] `cd apps/web && npm run typecheck` — clean
- [x] `cd apps/web && npx vitest run` — 634 passed
