### PR TITLE
Introduce /api/v1 versioning with /api legacy alias

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -7,8 +7,12 @@
   },
   "servers": [
     {
+      "url": "/api/v1",
+      "description": "API base path (versioned)"
+    },
+    {
       "url": "/api",
-      "description": "API base path"
+      "description": "Legacy unversioned alias (deprecated — see ADR-005)"
     }
   ],
   "security": [

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import pinoHttp from 'pino-http';
@@ -70,10 +71,6 @@ app.use(
     genReqId: (req: any) => req.id ?? '',
   }),
 );
-// Normalise any legacy `{error: 'string'}` response bodies emitted by
-// routes that haven't been migrated to throw AppError yet so every API
-// error response conforms to the canonical shape.
-app.use('/api', normalizeErrorResponses);
 
 // Silence /favicon.ico requests with 204 No Content.  Without this, requests
 // that don't match a static file in production fall through to the SPA
@@ -83,17 +80,35 @@ app.get('/favicon.ico', (_req, res) => {
   res.status(204).end();
 });
 
-// All API routes are mounted under /api so they co-exist with the frontend on
-// the same origin without path conflicts.
-app.use('/api', globalLimiter);
-app.use('/api', writeMethodLimiter);
+// ─── API router (mounted under /api/v1 and legacy /api) ─────────────────────
+//
+// Every API route is registered on a single Express router that is mounted
+// twice:
+//   - `/api/v1` — the canonical versioned prefix (issue #375).
+//   - `/api`    — a legacy alias that emits a `Deprecation: true` header and
+//                 a `Link: </api/v1/...>; rel="successor-version"` header on
+//                 every response so clients can discover the new prefix.
+//
+// The versioning policy (including the minimum six-month deprecation window
+// for breaking changes) is documented in `docs/architecture/adr-005-api-versioning.md`.
+
+const apiRouter = express.Router({ mergeParams: true });
+
+// Normalise any legacy `{error: 'string'}` response bodies emitted by
+// routes that haven't been migrated to throw AppError yet so every API
+// error response conforms to the canonical shape.
+apiRouter.use(normalizeErrorResponses);
+
+// Rate limiting applies to every API request.
+apiRouter.use(globalLimiter);
+apiRouter.use(writeMethodLimiter);
 
 // Auth session routes handle cookie-based session establishment and CSRF token
 // provisioning.  They must be mounted *before* the CSRF middleware because:
-//   - POST /api/auth/session is what *creates* the CSRF cookie
-//   - GET  /api/auth/csrf-token is what *refreshes* it
-//   - DELETE /api/auth/session tears down the session (no CSRF needed)
-app.use('/api/auth', authSessionRouter);
+//   - POST /auth/session is what *creates* the CSRF cookie
+//   - GET  /auth/csrf-token is what *refreshes* it
+//   - DELETE /auth/session tears down the session (no CSRF needed)
+apiRouter.use('/auth', authSessionRouter);
 
 // Serve OpenAPI documentation in dev/staging (not production)
 if (config.env !== 'production') {
@@ -102,45 +117,69 @@ if (config.env !== 'production') {
     const openapiDoc = JSON.parse(readFileSync(openapiPath, 'utf-8'));
 
     // Serve the raw OpenAPI spec as JSON
-    app.get('/api/openapi.json', (_req, res) => {
+    apiRouter.get('/openapi.json', (_req, res) => {
       res.json(openapiDoc);
     });
 
     // Serve Swagger UI
-    app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(openapiDoc, {
-      customSiteTitle: 'CPCRM API Documentation',
-      customCss: '.swagger-ui .topbar { display: none }',
-    }));
+    apiRouter.use(
+      '/docs',
+      swaggerUi.serve,
+      swaggerUi.setup(openapiDoc, {
+        customSiteTitle: 'CPCRM API Documentation',
+        customCss: '.swagger-ui .topbar { display: none }',
+      }),
+    );
 
-    logger.info('OpenAPI documentation available at /api/docs');
+    logger.info('OpenAPI documentation available at /api/v1/docs');
   } catch (err) {
     logger.warn({ err }, 'OpenAPI spec not found - run build to generate it');
   }
 }
 
 // CSRF protection for all other state-changing API requests.
-app.use('/api', requireCsrf);
+apiRouter.use(requireCsrf);
 
-app.use('/api/me', authLimiter);
-app.use('/api/health', healthRouter);
-app.use('/api/me', meRouter);
-app.use('/api/organisations', organisationsRouter);
-app.use('/api/accounts', accountsRouter);
-app.use('/api/profile', profileRouter);
-app.use('/api/admin/objects', adminObjectsRouter);
-app.use('/api/admin/relationships', adminRelationshipsRouter);
-app.use('/api/admin/pipelines', adminPipelinesRouter);
-app.use('/api/objects/:apiName/records', recordsRouter);
-app.use('/api/objects/:apiName/page-layout', pageLayoutsRouter);
-app.use('/api/records', recordRelationshipsRouter);
-app.use('/api/admin/stages/:stageId/gates', adminStageGatesRouter);
-app.use('/api/pipelines', pipelineAnalyticsRouter);
-app.use('/api/admin/users', adminUsersRouter);
-app.use('/api/platform/tenants', platformTenantsRouter);
-app.use('/api/admin/tenant-settings', adminTenantSettingsRouter);
-app.use('/api/admin/component-registry', componentRegistryRouter);
-app.use('/api/admin/targets', adminTargetsRouter);
-app.use('/api/targets', targetsRouter);
+apiRouter.use('/me', authLimiter);
+apiRouter.use('/health', healthRouter);
+apiRouter.use('/me', meRouter);
+apiRouter.use('/organisations', organisationsRouter);
+apiRouter.use('/accounts', accountsRouter);
+apiRouter.use('/profile', profileRouter);
+apiRouter.use('/admin/objects', adminObjectsRouter);
+apiRouter.use('/admin/relationships', adminRelationshipsRouter);
+apiRouter.use('/admin/pipelines', adminPipelinesRouter);
+apiRouter.use('/objects/:apiName/records', recordsRouter);
+apiRouter.use('/objects/:apiName/page-layout', pageLayoutsRouter);
+apiRouter.use('/records', recordRelationshipsRouter);
+apiRouter.use('/admin/stages/:stageId/gates', adminStageGatesRouter);
+apiRouter.use('/pipelines', pipelineAnalyticsRouter);
+apiRouter.use('/admin/users', adminUsersRouter);
+apiRouter.use('/platform/tenants', platformTenantsRouter);
+apiRouter.use('/admin/tenant-settings', adminTenantSettingsRouter);
+apiRouter.use('/admin/component-registry', componentRegistryRouter);
+apiRouter.use('/admin/targets', adminTargetsRouter);
+apiRouter.use('/targets', targetsRouter);
+
+/**
+ * Tags every legacy `/api/...` response with RFC 8594 deprecation headers so
+ * clients can discover the successor (`/api/v1/...`) without changes to the
+ * response body.  Removing this alias is a breaking change and must follow the
+ * deprecation policy in `docs/architecture/adr-005-api-versioning.md`.
+ */
+function legacyApiDeprecationHeaders(req: Request, res: Response, next: NextFunction): void {
+  res.setHeader('Deprecation', 'true');
+  res.setHeader('Link', `</api/v1${req.url}>; rel="successor-version"`);
+  next();
+}
+
+// Canonical v1 mount — registered first so `/api/v1/...` requests never fall
+// through to the legacy alias below.
+app.use('/api/v1', apiRouter);
+
+// Legacy alias — kept until the deprecation window elapses.  Emits a
+// `Deprecation` header on every response so clients can detect the usage.
+app.use('/api', legacyApiDeprecationHeaders, apiRouter);
 
 if (config.env === 'production') {
   // In production the CI pipeline copies the built frontend to public/ alongside

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,5 @@
 import 'dotenv/config';
 import express from 'express';
-import type { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import pinoHttp from 'pino-http';
@@ -38,6 +37,7 @@ import { globalLimiter, writeMethodLimiter, authLimiter } from './middleware/rat
 import { requireCsrf } from './middleware/csrf.js';
 import { requestId } from './middleware/requestId.js';
 import { errorHandler, normalizeErrorResponses } from './middleware/errorHandler.js';
+import { createLegacyApiAlias, installApiTerminal404 } from './lib/apiVersioning.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -161,25 +161,19 @@ apiRouter.use('/admin/component-registry', componentRegistryRouter);
 apiRouter.use('/admin/targets', adminTargetsRouter);
 apiRouter.use('/targets', targetsRouter);
 
-/**
- * Tags every legacy `/api/...` response with RFC 8594 deprecation headers so
- * clients can discover the successor (`/api/v1/...`) without changes to the
- * response body.  Removing this alias is a breaking change and must follow the
- * deprecation policy in `docs/architecture/adr-005-api-versioning.md`.
- */
-function legacyApiDeprecationHeaders(req: Request, res: Response, next: NextFunction): void {
-  res.setHeader('Deprecation', 'true');
-  res.setHeader('Link', `</api/v1${req.url}>; rel="successor-version"`);
-  next();
-}
+// Terminal 404 for the shared API router — must be the LAST middleware
+// registered on `apiRouter`. See `lib/apiVersioning.ts` for the rationale.
+installApiTerminal404(apiRouter);
 
-// Canonical v1 mount — registered first so `/api/v1/...` requests never fall
-// through to the legacy alias below.
+// Canonical v1 mount — registered first so `/api/v1/...` requests are
+// dispatched through the versioned prefix without touching the legacy alias.
 app.use('/api/v1', apiRouter);
 
-// Legacy alias — kept until the deprecation window elapses.  Emits a
-// `Deprecation` header on every response so clients can detect the usage.
-app.use('/api', legacyApiDeprecationHeaders, apiRouter);
+// Legacy `/api` alias — kept until the deprecation window elapses. The
+// middleware short-circuits any `/api/v1/...` request that somehow falls
+// through the versioned mount, and stamps RFC 8594/8288 deprecation
+// headers on responses served from the genuine legacy surface.
+app.use('/api', createLegacyApiAlias(apiRouter));
 
 if (config.env === 'production') {
   // In production the CI pipeline copies the built frontend to public/ alongside

--- a/apps/api/src/lib/__tests__/apiVersioning.test.ts
+++ b/apps/api/src/lib/__tests__/apiVersioning.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import {
+  createLegacyApiAlias,
+  installApiTerminal404,
+} from '../apiVersioning.js';
+import { errorHandler, normalizeErrorResponses } from '../../middleware/errorHandler.js';
+import { requestId } from '../../middleware/requestId.js';
+
+/**
+ * Builds a minimal Express app that mirrors the `/api/v1` + legacy `/api`
+ * mount pattern used by `src/index.ts`, wired against a tiny stub router
+ * that only exposes `GET /health`. The goal is to exercise the mount
+ * semantics (header stamping, fallthrough, terminal 404, error formatting)
+ * in isolation — without booting the real app, hitting the database, or
+ * stubbing Descope.
+ */
+function buildApp(): Promise<{ server: Server; url: string }> {
+  const app = express();
+  app.use(express.json());
+  app.use(requestId);
+  app.use(normalizeErrorResponses);
+
+  const apiRouter = express.Router();
+  apiRouter.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+  installApiTerminal404(apiRouter);
+
+  // Versioned mount must be registered first so /api/v1 traffic is never
+  // touched by the legacy alias middleware.
+  app.use('/api/v1', apiRouter);
+  app.use('/api', createLegacyApiAlias(apiRouter));
+
+  // Production-style SPA fallback — returns index.html for any unmatched
+  // path. The /api/v1 terminal 404 must prevent versioned API misses from
+  // reaching this handler.
+  app.use((_req, res) => {
+    res.type('html').send('<html>spa index</html>');
+  });
+
+  app.use(errorHandler);
+
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Failed to bind test server'));
+        return;
+      }
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('API versioning mount pattern', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  describe('/api/v1 (versioned)', () => {
+    it('serves matched routes without Deprecation headers', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/v1/health`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBeNull();
+      expect(res.headers.get('Link')).toBeNull();
+      await expect(res.json()).resolves.toEqual({ status: 'ok' });
+    });
+
+    it('returns the canonical 404 payload for unknown routes', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/v1/does-not-exist`);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get('Deprecation')).toBeNull();
+      expect(res.headers.get('Link')).toBeNull();
+      expect(res.headers.get('content-type')).toMatch(/application\/json/);
+
+      const body = (await res.json()) as {
+        error: { code: string; message: string; requestId?: string };
+      };
+      expect(body.error.code).toBe('NOT_FOUND');
+      expect(body.error.message).toContain('/api/v1/does-not-exist');
+      expect(body.error.requestId).toBeTypeOf('string');
+    });
+
+    it('does not fall through to the SPA index.html for missed routes', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/v1/does-not-exist`);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get('content-type')).not.toMatch(/text\/html/);
+    });
+  });
+
+  describe('/api (legacy alias)', () => {
+    it('serves matched routes and stamps deprecation headers', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/health`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBe('true');
+      expect(res.headers.get('Link')).toBe(
+        '</api/v1/health>; rel="successor-version"',
+      );
+      await expect(res.json()).resolves.toEqual({ status: 'ok' });
+    });
+
+    it('preserves query strings in the successor-version Link header', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/health?limit=1`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Link')).toBe(
+        '</api/v1/health?limit=1>; rel="successor-version"',
+      );
+    });
+
+    it('returns a canonical 404 (with deprecation headers) for unknown legacy routes', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/nope`);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get('Deprecation')).toBe('true');
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('/api/v1 fallthrough guard', () => {
+    it('never stamps /api/v1 requests with deprecation headers, even on 404', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      // Several variations that previously could have leaked through:
+      const cases = [
+        '/api/v1/unknown',
+        '/api/v1/health/nested',
+        '/api/v1/health?foo=bar',
+      ];
+      for (const path of cases) {
+        const res = await fetch(`${built.url}${path}`);
+        expect(
+          res.headers.get('Deprecation'),
+          `Deprecation header leaked on ${path}`,
+        ).toBeNull();
+        const link = res.headers.get('Link');
+        expect(link, `Link header leaked on ${path}`).toBeNull();
+      }
+    });
+
+    it('never emits a malformed /api/v1/v1/... successor Link on /api/v1 misses', async () => {
+      const built = await buildApp();
+      server = built.server;
+
+      const res = await fetch(`${built.url}/api/v1/does-not-exist`);
+
+      expect(res.headers.get('Link')).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/lib/apiVersioning.ts
+++ b/apps/api/src/lib/apiVersioning.ts
@@ -1,0 +1,88 @@
+import type { NextFunction, Request, Response, Router } from 'express';
+import { AppError } from './appError.js';
+
+/**
+ * API versioning primitives shared by `index.ts` and the integration tests
+ * that exercise the `/api/v1` + legacy `/api` mount pattern.  Keeping the
+ * behaviour here (rather than inline in `index.ts`) lets tests construct a
+ * minimal Express app against the exact same functions without having to
+ * mock the full startup pipeline.
+ *
+ * See `docs/architecture/adr-005-api-versioning.md` for the policy.
+ */
+
+/**
+ * Extracts the URL path from `req.originalUrl`, discarding any query string
+ * so prefix checks (e.g. `/api/v1?foo=1`) match as intended.
+ */
+function pathnameOf(originalUrl: string): string {
+  const q = originalUrl.indexOf('?');
+  return q === -1 ? originalUrl : originalUrl.slice(0, q);
+}
+
+/**
+ * Installs a terminal 404 middleware on the given API router.
+ *
+ * Without this, unmatched requests would fall through the router entirely
+ * and — in production — hit the SPA static-file fallback, which answers
+ * with `index.html` using an HTML content-type. That is the wrong response
+ * shape for an API consumer and masks client-side routing bugs.
+ *
+ * The handler throws `AppError.notFound` so the global error middleware
+ * emits the canonical `{ error: { code, message, requestId } }` payload.
+ *
+ * Must be called **after** all real routes have been mounted on the router,
+ * otherwise the 404 will fire before any handler has a chance to match.
+ */
+export function installApiTerminal404(router: Router): void {
+  router.use((req: Request, _res: Response, next: NextFunction): void => {
+    next(
+      AppError.notFound(
+        `API route not found: ${req.method} ${req.originalUrl}`,
+      ),
+    );
+  });
+}
+
+/**
+ * Builds the middleware mounted at the legacy `/api` prefix.
+ *
+ * Two responsibilities:
+ *
+ *  1. Skip requests whose `originalUrl` already begins with `/api/v1`.
+ *     In principle those requests are always handled by the versioned
+ *     mount (which is registered first and has its own terminal 404), but
+ *     a misconfigured future mount ordering or a programmer error could
+ *     cause one to fall through here. Without this guard, Express would
+ *     re-enter the shared router via the legacy mount, incorrectly stamp
+ *     `Deprecation: true` onto the response, and emit a malformed
+ *     `Link: </api/v1/v1/...>` successor. By short-circuiting with
+ *     `next()` we send those requests on to the next app-level
+ *     middleware (ultimately the global error handler).
+ *
+ *  2. For genuine `/api/...` traffic, stamp the RFC 8288 `Link` header
+ *     (with an RFC 5829 `rel="successor-version"` relation type) and the
+ *     RFC 8594 `Deprecation` header onto the response, then hand the
+ *     request to the shared `apiRouter`.
+ *
+ * Removing this alias is a breaking change and must follow the deprecation
+ * policy in `docs/architecture/adr-005-api-versioning.md`.
+ */
+export function createLegacyApiAlias(
+  apiRouter: Router,
+): (req: Request, res: Response, next: NextFunction) => void {
+  return function legacyApiAlias(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    const pathname = pathnameOf(req.originalUrl);
+    if (pathname === '/api/v1' || pathname.startsWith('/api/v1/')) {
+      next();
+      return;
+    }
+    res.setHeader('Deprecation', 'true');
+    res.setHeader('Link', `</api/v1${req.url}>; rel="successor-version"`);
+    apiRouter(req, res, next);
+  };
+}

--- a/apps/api/src/lib/openapi.ts
+++ b/apps/api/src/lib/openapi.ts
@@ -113,8 +113,12 @@ export function generateOpenAPIDocument() {
     },
     servers: [
       {
+        url: '/api/v1',
+        description: 'API base path (versioned)',
+      },
+      {
         url: '/api',
-        description: 'API base path',
+        description: 'Legacy unversioned alias (deprecated — see ADR-005)',
       },
     ],
     security: [

--- a/apps/web/src/__tests__/CreateAccountPage.test.tsx
+++ b/apps/web/src/__tests__/CreateAccountPage.test.tsx
@@ -108,7 +108,7 @@ describe('CreateAccountPage', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/api/accounts',
+        '/api/v1/accounts',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({
@@ -131,7 +131,7 @@ describe('CreateAccountPage', () => {
 
     const postCall = vi
       .mocked(fetch)
-      .mock.calls.find(([url, init]) => url === '/api/accounts' && init?.method === 'POST');
+      .mock.calls.find(([url, init]) => url === '/api/v1/accounts' && init?.method === 'POST');
     expect(postCall).toBeDefined();
     expect(postCall![1]?.credentials).toBe('include');
     const postHeaders = new Headers(postCall![1]?.headers);
@@ -156,7 +156,7 @@ describe('CreateAccountPage', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/api/accounts',
+        '/api/v1/accounts',
         expect.objectContaining({
           body: expect.stringContaining('"industry":"Technology"'),
         }),
@@ -236,7 +236,7 @@ describe('CreateAccountPage', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/api/accounts',
+        '/api/v1/accounts',
         expect.objectContaining({
           body: expect.stringContaining('"industry":"Space Exploration"'),
         }),

--- a/apps/web/src/__tests__/CreateRecordPage.test.tsx
+++ b/apps/web/src/__tests__/CreateRecordPage.test.tsx
@@ -45,7 +45,7 @@ function mockFetchWithFields(fields: Array<{
 }> = []) {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
     // Admin objects list
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
       return Promise.resolve({
         ok: true,
         json: async () => [
@@ -99,7 +99,7 @@ function mockFetchWithFields(fields: Array<{
     }
 
     // Create record
-    if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records$/)) {
+    if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records$/)) {
       return Promise.resolve({
         ok: true,
         json: async () => ({ id: 'new-record-uuid' }),
@@ -202,7 +202,7 @@ describe('CreateRecordPage', () => {
 
     await waitFor(() => {
       const createCalls = fetchMock.mock.calls.filter(
-        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).match(/\/api\/objects\/[^/]+\/records$/),
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).match(/\/api\/v1\/objects\/[^/]+\/records$/),
       );
       expect(createCalls.length).toBeGreaterThan(0);
     });
@@ -223,14 +223,14 @@ describe('CreateRecordPage', () => {
 
     // Override fetch for the create call to return an error
     fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
-      if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records$/) && opts?.method === 'POST') {
+      if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records$/) && opts?.method === 'POST') {
         return Promise.resolve({
           ok: false,
           json: async () => ({ error: "Field 'Email' must be a valid email" }),
         } as Response);
       }
       // Return default responses for other calls
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
         return Promise.resolve({
           ok: true,
           json: async () => [
@@ -268,7 +268,7 @@ describe('CreateRecordPage', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/fields') && !url.includes('/layouts')) {
           return Promise.resolve({
             ok: true,
             json: async () => [],

--- a/apps/web/src/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/__tests__/DashboardPage.test.tsx
@@ -14,13 +14,13 @@ function mockFetchCounts(opportunityTotal = 0, accountTotal = 0) {
   vi.stubGlobal(
     'fetch',
     vi.fn().mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/objects/opportunity')) {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity')) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ total: opportunityTotal }),
         });
       }
-      if (typeof url === 'string' && url.includes('/api/objects/account')) {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/account')) {
         return Promise.resolve({
           ok: true,
           json: async () => ({ total: accountTotal }),

--- a/apps/web/src/__tests__/FieldBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/FieldBuilderPage.test.tsx
@@ -864,7 +864,7 @@ describe('FieldBuilderPage', () => {
     });
 
     const reorderCall = mockFetch.mock.calls[1];
-    expect(reorderCall[0]).toBe('/api/admin/objects/obj-1/fields/reorder');
+    expect(reorderCall[0]).toBe('/api/v1/admin/objects/obj-1/fields/reorder');
     expect(reorderCall[1].method).toBe('PATCH');
   });
 

--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -118,42 +118,42 @@ const mockOverdue = [
 
 function mockFetch() {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
-    if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
       return Promise.resolve({
         ok: true,
         json: async () => mockPipeline,
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
       return Promise.resolve({
         ok: true,
         json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/objects/opportunity/records')) {
+    if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
       return Promise.resolve({
         ok: true,
         json: async () => mockRecords,
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/summary')) {
+    if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
       return Promise.resolve({
         ok: true,
         json: async () => mockSummary,
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/velocity')) {
+    if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
       return Promise.resolve({
         ok: true,
         json: async () => mockVelocity,
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/overdue')) {
+    if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
       return Promise.resolve({
         ok: true,
         json: async () => mockOverdue,
@@ -280,7 +280,7 @@ describe('KanbanBoard', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
             json: async () => [],
@@ -340,37 +340,37 @@ describe('KanbanBoard', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockPipeline,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
             json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/objects/opportunity/records')) {
+        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
           return Promise.resolve({
             ok: true,
             json: async () => unassignedRecords,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/summary')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockSummary,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/velocity')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockVelocity,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/overdue')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
           return Promise.resolve({
             ok: true,
             json: async () => [],
@@ -443,31 +443,31 @@ describe('KanbanBoard', () => {
         } as Response);
       }
       // Fall back to existing mock responses
-      if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockPipeline,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
         return Promise.resolve({
           ok: true,
           json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/summary')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockSummary,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/velocity')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockVelocity,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/overdue')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockOverdue,
@@ -529,31 +529,31 @@ describe('KanbanBoard', () => {
           }),
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockPipeline,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
         return Promise.resolve({
           ok: true,
           json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/summary')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockSummary,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/velocity')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockVelocity,
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/overdue')) {
+      if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
         return Promise.resolve({
           ok: true,
           json: async () => mockOverdue,
@@ -618,37 +618,37 @@ describe('KanbanBoard', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockPipeline,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
             json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/objects/opportunity/records')) {
+        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
           return Promise.resolve({
             ok: true,
             json: async () => stageRecords,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/summary')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockSummary,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/velocity')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
           return Promise.resolve({
             ok: true,
             json: async () => mockVelocity,
           } as Response);
         }
-        if (typeof url === 'string' && url.includes('/api/pipelines/pipe-1/overdue')) {
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
           return Promise.resolve({
             ok: true,
             json: async () => [],

--- a/apps/web/src/__tests__/OrganisationProvisioningPage.test.tsx
+++ b/apps/web/src/__tests__/OrganisationProvisioningPage.test.tsx
@@ -78,7 +78,7 @@ describe('OrganisationProvisioningPage', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/api/organisations',
+        '/api/v1/organisations',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ name: 'Acme Corp', description: 'Our main org' }),
@@ -88,7 +88,7 @@ describe('OrganisationProvisioningPage', () => {
 
     const postCall = vi
       .mocked(fetch)
-      .mock.calls.find(([url, init]) => url === '/api/organisations' && init?.method === 'POST');
+      .mock.calls.find(([url, init]) => url === '/api/v1/organisations' && init?.method === 'POST');
     expect(postCall).toBeDefined();
     expect(postCall![1]?.credentials).toBe('include');
     const postHeaders = new Headers(postCall![1]?.headers);

--- a/apps/web/src/__tests__/ProfilePage.test.tsx
+++ b/apps/web/src/__tests__/ProfilePage.test.tsx
@@ -124,7 +124,7 @@ describe('ProfilePage', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/api/profile',
+        '/api/v1/profile',
         expect.objectContaining({ method: 'PUT' }),
       );
     });

--- a/apps/web/src/__tests__/RecordCreatePage.test.tsx
+++ b/apps/web/src/__tests__/RecordCreatePage.test.tsx
@@ -132,7 +132,7 @@ function mockFetch(overrides: {
 
   const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
     // Admin objects list
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts') && !url.includes('/relationships') && !url.includes('/fields')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts') && !url.includes('/relationships') && !url.includes('/fields')) {
       return Promise.resolve({
         ok: true,
         json: async () => objects,
@@ -172,7 +172,7 @@ function mockFetch(overrides: {
     }
 
     // Create record
-    if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records$/) && init?.method === 'POST') {
+    if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records$/) && init?.method === 'POST') {
       if (overrides.createError) {
         return Promise.resolve({
           ok: false,
@@ -197,7 +197,7 @@ function mockFetch(overrides: {
     }
 
     // Records search (for relationship dropdown)
-    if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\?/)) {
+    if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\?/)) {
       return Promise.resolve({
         ok: true,
         json: async () => ({
@@ -413,7 +413,7 @@ describe('RecordCreatePage', () => {
       const createCall = calls.find(
         (c: unknown[]) =>
           typeof c[0] === 'string' &&
-          (c[0] as string).match(/\/api\/objects\/account\/records$/) &&
+          (c[0] as string).match(/\/api\/v1\/objects\/account\/records$/) &&
           (c[1] as RequestInit)?.method === 'POST',
       );
       expect(createCall).toBeDefined();

--- a/apps/web/src/__tests__/RecordDetailPage.test.tsx
+++ b/apps/web/src/__tests__/RecordDetailPage.test.tsx
@@ -60,7 +60,7 @@ function makeRecordResponse(overrides: Partial<{
 function mockFetch(recordResponse?: ReturnType<typeof makeRecordResponse>) {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
     // Admin objects list
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
       return Promise.resolve({
         ok: true,
         json: async () => [
@@ -120,7 +120,7 @@ function mockFetch(recordResponse?: ReturnType<typeof makeRecordResponse>) {
     }
 
     // Single record
-    if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+    if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
       return Promise.resolve({
         ok: true,
         json: async () => recordResponse ?? makeRecordResponse(),
@@ -228,7 +228,7 @@ describe('RecordDetailPage', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
           return Promise.resolve({
             ok: true,
             json: async () => [
@@ -236,7 +236,7 @@ describe('RecordDetailPage', () => {
             ],
           } as Response);
         }
-        if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+        if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
           return Promise.resolve({
             ok: false,
             status: 404,
@@ -362,7 +362,7 @@ describe('RecordDetailPage', () => {
 
     // Add mock for field definitions fetch
     fetchMock.mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts') && !url.includes('/fields')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts') && !url.includes('/fields')) {
         return Promise.resolve({
           ok: true,
           json: async () => [
@@ -396,7 +396,7 @@ describe('RecordDetailPage', () => {
           json: async () => [{ id: 'layout-1', objectId: 'obj-1', name: 'Default Form', layoutType: 'form', isDefault: true }],
         } as Response);
       }
-      if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+      if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
         return Promise.resolve({
           ok: true,
           json: async () => record,
@@ -465,7 +465,7 @@ describe('RecordDetailPage', () => {
 
     // Mock without layouts to test field fallback
     const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
         return Promise.resolve({
           ok: true,
           json: async () => [
@@ -476,7 +476,7 @@ describe('RecordDetailPage', () => {
       if (typeof url === 'string' && url.includes('/layouts')) {
         return Promise.resolve({ ok: true, json: async () => [] } as Response);
       }
-      if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+      if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
         return Promise.resolve({
           ok: true,
           json: async () => record,
@@ -502,7 +502,7 @@ describe('RecordDetailPage', () => {
     });
 
     const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
         return Promise.resolve({
           ok: true,
           json: async () => [
@@ -513,7 +513,7 @@ describe('RecordDetailPage', () => {
       if (typeof url === 'string' && url.includes('/layouts')) {
         return Promise.resolve({ ok: true, json: async () => [] } as Response);
       }
-      if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+      if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
         return Promise.resolve({
           ok: true,
           json: async () => record,
@@ -557,7 +557,7 @@ describe('RecordDetailPage', () => {
 
     function mockLeadFetch(leadRecord: ReturnType<typeof makeRecordResponse>) {
       const fetchMock = vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
           return Promise.resolve({
             ok: true,
             json: async () => [
@@ -586,7 +586,7 @@ describe('RecordDetailPage', () => {
             ],
           } as Response);
         }
-        if (typeof url === 'string' && url.match(/\/api\/objects\/[^/]+\/records\/[^/?]+$/)) {
+        if (typeof url === 'string' && url.match(/\/api\/v1\/objects\/[^/]+\/records\/[^/?]+$/)) {
           return Promise.resolve({
             ok: true,
             json: async () => leadRecord,

--- a/apps/web/src/__tests__/RecordListPage.test.tsx
+++ b/apps/web/src/__tests__/RecordListPage.test.tsx
@@ -53,7 +53,7 @@ function makeRecordsResponse(
 
 function mockFetch(recordsResponse?: ReturnType<typeof makeRecordsResponse>) {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
       // Admin objects list
       return Promise.resolve({
         ok: true,
@@ -98,7 +98,7 @@ function mockFetch(recordsResponse?: ReturnType<typeof makeRecordsResponse>) {
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/objects/')) {
+    if (typeof url === 'string' && url.includes('/api/v1/objects/')) {
       // Records list
       return Promise.resolve({
         ok: true,
@@ -191,7 +191,7 @@ describe('RecordListPage', () => {
     // Use a custom mock where layouts return an empty list so columns
     // fall back to record field definitions (the path this test covers).
     const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
         return Promise.resolve({
           ok: true,
           json: async () => [{ id: 'obj-1', apiName: 'account' }],
@@ -203,7 +203,7 @@ describe('RecordListPage', () => {
           json: async () => [],
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/objects/')) {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/')) {
         return Promise.resolve({
           ok: true,
           json: async () => response,
@@ -266,7 +266,7 @@ describe('RecordListPage', () => {
       () => {
         const calls = fetchMock.mock.calls;
         const recordsCalls = calls.filter(
-          (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('/api/objects/'),
+          (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('/api/v1/objects/'),
         );
         const lastCall = recordsCalls[recordsCalls.length - 1];
         expect(String(lastCall[0])).toContain('search=acme');
@@ -365,7 +365,7 @@ describe('RecordListPage', () => {
     };
 
     const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+      if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
         return Promise.resolve({
           ok: true,
           json: async () => [{ id: 'obj-1', apiName: 'account' }],
@@ -411,7 +411,7 @@ describe('RecordListPage', () => {
           ],
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/objects/')) {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/')) {
         return Promise.resolve({
           ok: true,
           json: async () => response,

--- a/apps/web/src/__tests__/StageFieldRenderer.test.tsx
+++ b/apps/web/src/__tests__/StageFieldRenderer.test.tsx
@@ -49,7 +49,7 @@ describe('StageFieldRenderer', () => {
   function setupFetch(overrides?: { moveResponse?: { ok: boolean; status?: number; body?: unknown } }) {
     const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
       // Pipeline list
-      if (typeof url === 'string' && url === '/api/admin/pipelines') {
+      if (typeof url === 'string' && url === '/api/v1/admin/pipelines') {
         return Promise.resolve({
           ok: true,
           json: async () => MOCK_PIPELINES,
@@ -57,7 +57,7 @@ describe('StageFieldRenderer', () => {
       }
 
       // Pipeline detail
-      if (typeof url === 'string' && url.match(/\/api\/admin\/pipelines\//)) {
+      if (typeof url === 'string' && url.match(/\/api\/v1\/admin\/pipelines\//)) {
         return Promise.resolve({
           ok: true,
           json: async () => MOCK_PIPELINE_DETAIL,

--- a/apps/web/src/__tests__/ViewToggle.test.tsx
+++ b/apps/web/src/__tests__/ViewToggle.test.tsx
@@ -41,14 +41,14 @@ function makeRecordsResponse(total = 0) {
 
 function mockFetchWithPipeline() {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
       return Promise.resolve({
         ok: true,
         json: async () => [{ id: 'obj-1', apiName: 'opportunity' }],
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/admin/pipelines/pipe-1')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
       return Promise.resolve({
         ok: true,
         json: async () => ({
@@ -62,7 +62,7 @@ function mockFetchWithPipeline() {
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
       return Promise.resolve({
         ok: true,
         json: async () => [{ id: 'pipe-1', object_id: 'obj-1' }],
@@ -76,7 +76,7 @@ function mockFetchWithPipeline() {
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/objects/')) {
+    if (typeof url === 'string' && url.includes('/api/v1/objects/')) {
       return Promise.resolve({
         ok: true,
         json: async () => makeRecordsResponse(),
@@ -92,14 +92,14 @@ function mockFetchWithPipeline() {
 
 function mockFetchWithoutPipeline() {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
-    if (typeof url === 'string' && url.includes('/api/admin/objects') && !url.includes('/layouts')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
       return Promise.resolve({
         ok: true,
         json: async () => [{ id: 'obj-1', apiName: 'opportunity' }],
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/admin/pipelines')) {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
       return Promise.resolve({
         ok: true,
         json: async () => [],
@@ -113,7 +113,7 @@ function mockFetchWithoutPipeline() {
       } as Response);
     }
 
-    if (typeof url === 'string' && url.includes('/api/objects/')) {
+    if (typeof url === 'string' && url.includes('/api/v1/objects/')) {
       return Promise.resolve({
         ok: true,
         json: async () => makeRecordsResponse(),

--- a/apps/web/src/components/AccountSearchDropdown.tsx
+++ b/apps/web/src/components/AccountSearchDropdown.tsx
@@ -58,7 +58,7 @@ export function AccountSearchDropdown({
       try {
         const params = new URLSearchParams({ limit: '10' });
         if (search.trim()) params.set('search', search.trim());
-        const response = await api.request(`/api/accounts?${params.toString()}`);
+        const response = await api.request(`/api/v1/accounts?${params.toString()}`);
         if (response.ok) {
           const data = (await response.json()) as { data: AccountOption[] };
           setOptions(data.data);

--- a/apps/web/src/components/InlineRecordForm.tsx
+++ b/apps/web/src/components/InlineRecordForm.tsx
@@ -68,7 +68,7 @@ export function InlineRecordForm({
       setLoading(true);
       try {
         // Get the object definition to find the ID
-        const objRes = await api.request('/api/admin/objects');
+        const objRes = await api.request('/api/v1/admin/objects');
         if (cancelled || !objRes.ok) {
           setLoading(false);
           return;
@@ -86,7 +86,7 @@ export function InlineRecordForm({
 
         // Fetch field definitions
         const fieldsRes = await api.request(
-          `/api/admin/objects/${obj.id}/fields`,
+          `/api/v1/admin/objects/${obj.id}/fields`,
         );
         if (cancelled || !fieldsRes.ok) {
           setLoading(false);
@@ -149,7 +149,7 @@ export function InlineRecordForm({
 
     try {
       const response = await api.request(
-        `/api/objects/${relatedObjectApiName}/records`,
+        `/api/v1/objects/${relatedObjectApiName}/records`,
         {
           method: 'POST',
           headers: {

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -235,7 +235,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
         try {
           pipelines = await api.get<
             Array<PipelineDefinition & { objectId?: string; object_id?: string }>
-          >('/api/admin/pipelines');
+          >('/api/v1/admin/pipelines');
         } catch {
           if (!cancelled) {
             setError('Failed to load pipeline configuration.');
@@ -258,9 +258,9 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
 
         // 2. Fetch pipeline detail AND records in parallel
         const [detailResult, recordsResult] = await Promise.allSettled([
-          api.get<PipelineDefinition>(`/api/admin/pipelines/${match.id}`),
+          api.get<PipelineDefinition>(`/api/v1/admin/pipelines/${match.id}`),
           api.get<RecordsResponse>(
-            `/api/objects/${apiName}/records?limit=100`,
+            `/api/v1/objects/${apiName}/records?limit=100`,
           ),
         ]);
 
@@ -317,12 +317,12 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     const [summaryResult, velocityResult, overdueResult] =
       await Promise.allSettled([
         api.get<{ totals: PipelineSummaryData['totals'] }>(
-          `/api/pipelines/${pipeline.id}/summary`,
+          `/api/v1/pipelines/${pipeline.id}/summary`,
         ),
         api.get<{ avgDaysToClose: number }>(
-          `/api/pipelines/${pipeline.id}/velocity?period=30d`,
+          `/api/v1/pipelines/${pipeline.id}/velocity?period=30d`,
         ),
-        api.get<OverdueRecord[]>(`/api/pipelines/${pipeline.id}/overdue`),
+        api.get<OverdueRecord[]>(`/api/v1/pipelines/${pipeline.id}/overdue`),
       ]);
 
     if (
@@ -375,7 +375,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
 
     try {
       const response = await api.request(
-        `/api/objects/${apiName}/records/${recordId}/move-stage`,
+        `/api/v1/objects/${apiName}/records/${recordId}/move-stage`,
         {
           method: 'POST',
           headers: {
@@ -491,7 +491,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     try {
       // First update the record fields
       const updateResponse = await api.request(
-        `/api/objects/${apiName}/records/${gateModal.recordId}`,
+        `/api/v1/objects/${apiName}/records/${gateModal.recordId}`,
         {
           method: 'PUT',
           headers: {

--- a/apps/web/src/components/LayoutBuilderTab.tsx
+++ b/apps/web/src/components/LayoutBuilderTab.tsx
@@ -199,7 +199,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
     setLayoutsError(null);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/layouts`);
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/layouts`);
 
       if (response.ok) {
         const data = (await response.json()) as LayoutDefinition[];
@@ -234,7 +234,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
 
     try {
       const response = await api.request(
-        `/api/admin/objects/${objectId}/layouts/${selectedLayoutId}`,
+        `/api/v1/admin/objects/${objectId}/layouts/${selectedLayoutId}`,
       );
 
       if (response.ok) {
@@ -293,7 +293,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
     setCreating(true);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/layouts`, {
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/layouts`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -331,7 +331,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
 
     try {
       const response = await api.request(
-        `/api/admin/objects/${objectId}/layouts/${selectedLayoutId}`,
+        `/api/v1/admin/objects/${objectId}/layouts/${selectedLayoutId}`,
         {
           method: 'DELETE',
         },
@@ -360,7 +360,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
 
     try {
       const response = await api.request(
-        `/api/admin/objects/${objectId}/layouts/${selectedLayoutId}/fields`,
+        `/api/v1/admin/objects/${objectId}/layouts/${selectedLayoutId}/fields`,
         {
           method: 'PUT',
           headers: {

--- a/apps/web/src/components/ObjectTabs.tsx
+++ b/apps/web/src/components/ObjectTabs.tsx
@@ -27,7 +27,7 @@ export function ObjectTabs() {
 
     const loadObjects = async () => {
       try {
-        const response = await api.request('/api/admin/objects');
+        const response = await api.request('/api/v1/admin/objects');
 
         if (cancelled || !response.ok) return;
 
@@ -67,7 +67,7 @@ export function ObjectTabs() {
     async (orderedItems: ObjectDefinitionNavItem[]) => {
       if (!sessionToken) return;
       try {
-        await api.request('/api/admin/objects/reorder', {
+        await api.request('/api/v1/admin/objects/reorder', {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',

--- a/apps/web/src/components/RelationshipSearchDropdown.tsx
+++ b/apps/web/src/components/RelationshipSearchDropdown.tsx
@@ -70,7 +70,7 @@ export function RelationshipSearchDropdown({
         const params = new URLSearchParams({ limit: '10' });
         if (search.trim()) params.set('search', search.trim());
         const response = await api.request(
-          `/api/objects/${objectApiName}/records?${params.toString()}`,
+          `/api/v1/objects/${objectApiName}/records?${params.toString()}`,
         );
         if (response.ok) {
           const data = (await response.json()) as { data: RecordOption[] };

--- a/apps/web/src/components/SalesTargetsRenderer.tsx
+++ b/apps/web/src/components/SalesTargetsRenderer.tsx
@@ -224,7 +224,7 @@ export function SalesTargetsRenderer({ component }: ComponentRendererProps) {
       if (periodEnd) params.set('period_end', periodEnd);
 
       const qs = params.toString();
-      const url = `/api/targets/summary${qs ? `?${qs}` : ''}`;
+      const url = `/api/v1/targets/summary${qs ? `?${qs}` : ''}`;
 
       const response = await api.request(url);
 

--- a/apps/web/src/components/StageFieldRenderer.tsx
+++ b/apps/web/src/components/StageFieldRenderer.tsx
@@ -130,7 +130,7 @@ export function StageFieldRenderer({
       setLoadingStages(true);
 
       try {
-        const response = await api.request('/api/admin/pipelines');
+        const response = await api.request('/api/v1/admin/pipelines');
 
         if (cancelled || !response.ok) {
           if (!cancelled) setLoadingStages(false);
@@ -151,7 +151,7 @@ export function StageFieldRenderer({
 
         // Fetch pipeline detail for stages
         const detailResponse = await api.request(
-          `/api/admin/pipelines/${match.id}`,
+          `/api/v1/admin/pipelines/${match.id}`,
         );
 
         if (cancelled) return;
@@ -187,7 +187,7 @@ export function StageFieldRenderer({
 
       try {
         const response = await api.request(
-          `/api/objects/${objectApiName}/records/${recordId}/move-stage`,
+          `/api/v1/objects/${objectApiName}/records/${recordId}/move-stage`,
           {
             method: 'POST',
             headers: {
@@ -236,7 +236,7 @@ export function StageFieldRenderer({
       try {
         // First update the record with the filled field values
         const updateResponse = await api.request(
-          `/api/objects/${objectApiName}/records/${recordId}`,
+          `/api/v1/objects/${objectApiName}/records/${recordId}`,
           {
             method: 'PUT',
             headers: {
@@ -252,7 +252,7 @@ export function StageFieldRenderer({
 
         // Now retry the stage move
         const moveResponse = await api.request(
-          `/api/objects/${objectApiName}/records/${recordId}/move-stage`,
+          `/api/v1/objects/${objectApiName}/records/${recordId}/move-stage`,
           {
             method: 'POST',
             headers: {

--- a/apps/web/src/features/field-builder/hooks/useFieldDefinitions.ts
+++ b/apps/web/src/features/field-builder/hooks/useFieldDefinitions.ts
@@ -40,7 +40,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
     setError(null);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}`);
+      const response = await api.request(`/api/v1/admin/objects/${objectId}`);
 
       if (response.ok) {
         const data = (await response.json()) as ObjectDefinitionDetail;
@@ -69,7 +69,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
     setRelationshipsError(null);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/relationships`);
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/relationships`);
 
       if (response.ok) {
         const data = (await response.json()) as RelationshipDefinition[];
@@ -88,7 +88,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
     if (!sessionToken) return;
 
     try {
-      const response = await api.request('/api/admin/objects');
+      const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
         const data = (await response.json()) as ObjectDefinitionListItem[];
@@ -108,7 +108,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
     setPageLayoutsError(null);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/page-layouts`);
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/page-layouts`);
 
       if (response.ok) {
         const data = (await response.json()) as PageLayoutListItem[];

--- a/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
+++ b/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
@@ -187,7 +187,7 @@ export function useFieldMutations({
     try {
       if (editingField) {
         const response = await api.request(
-          `/api/admin/objects/${objectId}/fields/${editingField.id}`,
+          `/api/v1/admin/objects/${objectId}/fields/${editingField.id}`,
           {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -205,7 +205,7 @@ export function useFieldMutations({
       } else {
         payload.apiName = trimmedApiName;
 
-        const response = await api.request(`/api/admin/objects/${objectId}/fields`, {
+        const response = await api.request(`/api/v1/admin/objects/${objectId}/fields`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
@@ -246,7 +246,7 @@ export function useFieldMutations({
 
     try {
       const response = await api.request(
-        `/api/admin/objects/${objectId}/fields/${deleteTarget.id}`,
+        `/api/v1/admin/objects/${objectId}/fields/${deleteTarget.id}`,
         { method: 'DELETE' },
       );
 
@@ -278,7 +278,7 @@ export function useFieldMutations({
 
     setReordering(true);
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/fields/reorder`, {
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/fields/reorder`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ fieldIds: newFields.map((f) => f.id) }),

--- a/apps/web/src/features/field-builder/hooks/useRelationshipMutations.ts
+++ b/apps/web/src/features/field-builder/hooks/useRelationshipMutations.ts
@@ -106,7 +106,7 @@ export function useRelationshipMutations({
     };
 
     try {
-      const response = await api.request('/api/admin/relationships', {
+      const response = await api.request('/api/v1/admin/relationships', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -145,7 +145,7 @@ export function useRelationshipMutations({
     setDeleteRelError(null);
 
     try {
-      const response = await api.request(`/api/admin/relationships/${deleteRelTarget.id}`, {
+      const response = await api.request(`/api/v1/admin/relationships/${deleteRelTarget.id}`, {
         method: 'DELETE',
       });
 
@@ -171,7 +171,7 @@ export function useRelationshipMutations({
     setCreatingLayout(true);
 
     try {
-      const response = await api.request(`/api/admin/objects/${objectId}/page-layouts`, {
+      const response = await api.request(`/api/v1/admin/objects/${objectId}/page-layouts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: `${objectDef.label} - Default` }),

--- a/apps/web/src/features/page-builder/hooks/usePageLayout.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayout.ts
@@ -59,7 +59,7 @@ export function usePageLayout(objectId: string | undefined) {
 
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${layoutId}`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${layoutId}`,
       );
 
       if (res.ok) {
@@ -88,10 +88,10 @@ export function usePageLayout(objectId: string | undefined) {
 
     try {
       const [objRes, relRes, regRes, layoutsRes] = await Promise.all([
-        api.request(`/api/admin/objects/${objectId}`),
-        api.request(`/api/admin/objects/${objectId}/relationships`),
-        api.request('/api/admin/component-registry'),
-        api.request(`/api/admin/objects/${objectId}/page-layouts`),
+        api.request(`/api/v1/admin/objects/${objectId}`),
+        api.request(`/api/v1/admin/objects/${objectId}/relationships`),
+        api.request('/api/v1/admin/component-registry'),
+        api.request(`/api/v1/admin/objects/${objectId}/page-layouts`),
       ]);
 
       if (!objRes.ok) {
@@ -120,7 +120,7 @@ export function usePageLayout(objectId: string | undefined) {
 
         const relatedObjResults = await Promise.all(
           uniqueTargetIds.map((targetId) =>
-            api.request(`/api/admin/objects/${targetId}`)
+            api.request(`/api/v1/admin/objects/${targetId}`)
               .then(async (res) => {
                 if (!res.ok) return null;
                 return (await res.json()) as RelatedObjectFields;

--- a/apps/web/src/features/page-builder/hooks/usePageLayoutActions.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayoutActions.ts
@@ -56,7 +56,7 @@ export function usePageLayoutActions({
     try {
       if (selectedLayoutId) {
         const res = await api.request(
-          `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}`,
+          `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}`,
           {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -71,7 +71,7 @@ export function usePageLayoutActions({
         }
       } else {
         const res = await api.request(
-          `/api/admin/objects/${objectId}/page-layouts`,
+          `/api/v1/admin/objects/${objectId}/page-layouts`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -109,7 +109,7 @@ export function usePageLayoutActions({
     setSaveError(null);
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/publish`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/publish`,
         { method: 'POST' },
       );
       if (!res.ok) {
@@ -135,7 +135,7 @@ export function usePageLayoutActions({
     } else if (role !== null) {
       try {
         const res = await api.request(
-          `/api/admin/objects/${objectId}/page-layouts`,
+          `/api/v1/admin/objects/${objectId}/page-layouts`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -173,7 +173,7 @@ export function usePageLayoutActions({
 
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/copy`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/copy`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -205,7 +205,7 @@ export function usePageLayoutActions({
 
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}`,
         { method: 'DELETE' },
       );
 
@@ -230,7 +230,7 @@ export function usePageLayoutActions({
 
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/versions`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/versions`,
       );
 
       if (res.ok) {
@@ -250,7 +250,7 @@ export function usePageLayoutActions({
     setReverting(true);
     try {
       const res = await api.request(
-        `/api/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/revert`,
+        `/api/v1/admin/objects/${objectId}/page-layouts/${selectedLayoutId}/revert`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/features/record-detail/hooks/useLeadConversion.ts
+++ b/apps/web/src/features/record-detail/hooks/useLeadConversion.ts
@@ -44,7 +44,7 @@ export function useLeadConversion(
 
     try {
       const response = await api.request(
-        `/api/objects/lead/records/${record.id}/convert`,
+        `/api/v1/objects/lead/records/${record.id}/convert`,
         {
           method: 'POST',
           headers: {

--- a/apps/web/src/features/record-detail/hooks/useRecord.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecord.ts
@@ -50,14 +50,14 @@ export function useRecord(
 
     try {
       const response = await api.request(
-        `/api/objects/${apiName}/records/${id}`,
+        `/api/v1/objects/${apiName}/records/${id}`,
       );
 
       if (response.ok) {
         const data = (await response.json()) as RecordDetail;
         setRecord(data);
 
-        const objResponse = await api.request('/api/admin/objects');
+        const objResponse = await api.request('/api/v1/admin/objects');
         if (objResponse.ok) {
           const allObjects = (await objResponse.json()) as ObjectDefinition[];
           const obj = allObjects.find((o) => o.apiName === apiName);
@@ -87,7 +87,7 @@ export function useRecord(
 
     const loadLayout = async () => {
       try {
-        const objResponse = await api.request('/api/admin/objects');
+        const objResponse = await api.request('/api/v1/admin/objects');
         if (cancelled || !objResponse.ok) return;
 
         const allObjects = (await objResponse.json()) as Array<{
@@ -98,7 +98,7 @@ export function useRecord(
         if (!obj || cancelled) return;
 
         const layoutsResponse = await api.request(
-          `/api/admin/objects/${obj.id}/layouts`,
+          `/api/v1/admin/objects/${obj.id}/layouts`,
         );
         if (cancelled || !layoutsResponse.ok) return;
 
@@ -110,7 +110,7 @@ export function useRecord(
         if (!formLayout || cancelled) return;
 
         const layoutDetailResponse = await api.request(
-          `/api/admin/objects/${obj.id}/layouts/${formLayout.id}`,
+          `/api/v1/admin/objects/${obj.id}/layouts/${formLayout.id}`,
         );
         if (cancelled || !layoutDetailResponse.ok) return;
 

--- a/apps/web/src/features/record-detail/hooks/useRecordDelete.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecordDelete.ts
@@ -32,7 +32,7 @@ export function useRecordDelete(
 
     try {
       const response = await api.request(
-        `/api/objects/${apiName}/records/${record.id}`,
+        `/api/v1/objects/${apiName}/records/${record.id}`,
         {
           method: 'DELETE',
         },

--- a/apps/web/src/features/record-detail/hooks/useRecordEdit.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecordEdit.ts
@@ -100,7 +100,7 @@ export function useRecordEdit(
 
     try {
       const response = await api.request(
-        `/api/objects/${apiName}/records/${record.id}`,
+        `/api/v1/objects/${apiName}/records/${record.id}`,
         {
           method: 'PUT',
           headers: {

--- a/apps/web/src/lib/__tests__/apiClient.test.ts
+++ b/apps/web/src/lib/__tests__/apiClient.test.ts
@@ -52,7 +52,7 @@ describe('useApiClient', () => {
   it('sends requests with credentials: include', async () => {
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts');
+    await result.current.request('/api/v1/accounts');
 
     const [, init] = vi.mocked(fetch).mock.calls[0]!;
     expect(init?.credentials).toBe('include');
@@ -61,7 +61,7 @@ describe('useApiClient', () => {
   it('does not set an Authorization header (uses cookies instead)', async () => {
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts');
+    await result.current.request('/api/v1/accounts');
 
     const [, init] = vi.mocked(fetch).mock.calls[0]!;
     const headers = new Headers(init?.headers);
@@ -76,7 +76,7 @@ describe('useApiClient', () => {
 
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts', {
+    await result.current.request('/api/v1/accounts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Acme' }),
@@ -99,7 +99,7 @@ describe('useApiClient', () => {
 
     for (const method of ['PUT', 'PATCH', 'DELETE']) {
       vi.mocked(fetch).mockClear();
-      await result.current.request('/api/test', { method });
+      await result.current.request('/api/v1/test', { method });
 
       const [, init] = vi.mocked(fetch).mock.calls[0]!;
       const headers = new Headers(init?.headers);
@@ -115,7 +115,7 @@ describe('useApiClient', () => {
 
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts');
+    await result.current.request('/api/v1/accounts');
 
     const [, init] = vi.mocked(fetch).mock.calls[0]!;
     const headers = new Headers(init?.headers);
@@ -130,7 +130,7 @@ describe('useApiClient', () => {
 
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts', {
+    await result.current.request('/api/v1/accounts', {
       method: 'POST',
       headers: { 'X-CSRF-Token': 'caller-override' },
     });
@@ -158,7 +158,7 @@ describe('useApiClient', () => {
 
     const { result } = renderHook(() => useApiClient());
 
-    await result.current.request('/api/accounts', {
+    await result.current.request('/api/v1/accounts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Custom': 'value' },
       body: JSON.stringify({ name: 'Acme' }),
@@ -192,7 +192,7 @@ describe('useApiClient typed methods', () => {
 
     const { result } = renderHook(() => useApiClient());
     const data = await result.current.get<{ id: string; name: string }>(
-      '/api/accounts/1',
+      '/api/v1/accounts/1',
     );
 
     expect(data).toEqual({ id: '1', name: 'Acme' });
@@ -209,7 +209,7 @@ describe('useApiClient typed methods', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useApiClient());
-    const data = await result.current.post<{ id: string }>('/api/accounts', {
+    const data = await result.current.post<{ id: string }>('/api/v1/accounts', {
       body: { name: 'Acme' },
     });
 
@@ -226,7 +226,7 @@ describe('useApiClient typed methods', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(emptyResponse(204)));
 
     const { result } = renderHook(() => useApiClient());
-    const data = await result.current.del('/api/accounts/1');
+    const data = await result.current.del('/api/v1/accounts/1');
 
     expect(data).toBeUndefined();
   });
@@ -245,7 +245,7 @@ describe('useApiClient typed methods', () => {
     const { result } = renderHook(() => useApiClient());
 
     await expect(
-      result.current.post('/api/accounts', { body: {} }),
+      result.current.post('/api/v1/accounts', { body: {} }),
     ).rejects.toMatchObject({
       name: 'ApiError',
       status: 400,
@@ -272,7 +272,7 @@ describe('useApiClient typed methods', () => {
     const { result } = renderHook(() => useApiClient());
     let caught: ApiError | undefined;
     try {
-      await result.current.post('/api/accounts', { body: {} });
+      await result.current.post('/api/v1/accounts', { body: {} });
     } catch (err) {
       caught = err as ApiError;
     }
@@ -292,7 +292,7 @@ describe('useApiClient typed methods', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useApiClient());
-    const data = await result.current.get<{ ok: boolean }>('/api/accounts');
+    const data = await result.current.get<{ ok: boolean }>('/api/v1/accounts');
 
     expect(data).toEqual({ ok: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -306,7 +306,7 @@ describe('useApiClient typed methods', () => {
 
     const { result } = renderHook(() => useApiClient());
     await expect(
-      result.current.post('/api/accounts', { body: { name: 'x' } }),
+      result.current.post('/api/v1/accounts', { body: { name: 'x' } }),
     ).rejects.toBeInstanceOf(ApiError);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -319,7 +319,7 @@ describe('useApiClient typed methods', () => {
     const { result } = renderHook(() => useApiClient());
     let caught: ApiError | undefined;
     try {
-      await result.current.get('/api/accounts');
+      await result.current.get('/api/v1/accounts');
     } catch (err) {
       caught = err as ApiError;
     }
@@ -338,7 +338,7 @@ describe('useApiClient typed methods', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useApiClient());
-    await expect(result.current.get('/api/accounts')).rejects.toMatchObject({
+    await expect(result.current.get('/api/v1/accounts')).rejects.toMatchObject({
       name: 'ApiError',
       status: 500,
     });
@@ -441,10 +441,10 @@ describe('clearServerSession', () => {
     vi.restoreAllMocks();
   });
 
-  it('calls DELETE /api/auth/session with credentials: include', async () => {
+  it('calls DELETE /api/v1/auth/session with credentials: include', async () => {
     await clearServerSession();
 
-    expect(fetch).toHaveBeenCalledWith('/api/auth/session', {
+    expect(fetch).toHaveBeenCalledWith('/api/v1/auth/session', {
       method: 'DELETE',
       credentials: 'include',
     });

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -460,12 +460,12 @@ export function useApiClient(): ApiClient {
 
 /**
  * Syncs the Descope session token to a server-side HttpOnly cookie by
- * calling POST /api/auth/session.  Called by `<SessionSync />` on login
+ * calling POST /api/v1/auth/session.  Called by `<SessionSync />` on login
  * and whenever the Descope SDK refreshes the token.
  */
 export async function syncSessionCookie(sessionToken: string): Promise<void> {
   try {
-    await fetch('/api/auth/session', {
+    await fetch('/api/v1/auth/session', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
@@ -478,12 +478,12 @@ export async function syncSessionCookie(sessionToken: string): Promise<void> {
 }
 
 /**
- * Clears the server-side session cookie by calling DELETE /api/auth/session.
+ * Clears the server-side session cookie by calling DELETE /api/v1/auth/session.
  * Should be called during the logout flow.
  */
 export async function clearServerSession(): Promise<void> {
   try {
-    await fetch('/api/auth/session', {
+    await fetch('/api/v1/auth/session', {
       method: 'DELETE',
       credentials: 'include',
     });

--- a/apps/web/src/pages/AccountDetailPage.tsx
+++ b/apps/web/src/pages/AccountDetailPage.tsx
@@ -130,7 +130,7 @@ export function AccountDetailPage() {
       setLoadError(null);
 
       try {
-        const response = await api.request(`/api/accounts/${id}`);
+        const response = await api.request(`/api/v1/accounts/${id}`);
 
         if (cancelled) return;
 
@@ -220,7 +220,7 @@ export function AccountDetailPage() {
     setSaveSuccess(false);
 
     try {
-      const response = await api.request(`/api/accounts/${account.id}`, {
+      const response = await api.request(`/api/v1/accounts/${account.id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -277,7 +277,7 @@ export function AccountDetailPage() {
     setDeleteError(null);
 
     try {
-      const response = await api.request(`/api/accounts/${account.id}`, {
+      const response = await api.request(`/api/v1/accounts/${account.id}`, {
         method: 'DELETE',
       });
 

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -89,7 +89,7 @@ export function AccountsPage() {
       }
 
       try {
-        const response = await api.request(`/api/accounts?${params.toString()}`);
+        const response = await api.request(`/api/v1/accounts?${params.toString()}`);
 
         if (cancelled) return;
 

--- a/apps/web/src/pages/AdminTargetsPage.tsx
+++ b/apps/web/src/pages/AdminTargetsPage.tsx
@@ -261,7 +261,7 @@ export function AdminTargetsPage() {
         period_end: selectedPeriod.periodEnd,
       });
 
-      const response = await api.request(`/api/admin/targets?${params.toString()}`);
+      const response = await api.request(`/api/v1/admin/targets?${params.toString()}`);
 
       if (!response.ok) {
         const data = (await response.json().catch(() => ({}))) as ApiError;
@@ -431,7 +431,7 @@ export function AdminTargetsPage() {
 
         // If value is 0 but we have an existing id, delete it
         if (value === 0 && draft.id) {
-          const deleteRes = await api.request(`/api/admin/targets/${draft.id}`, {
+          const deleteRes = await api.request(`/api/v1/admin/targets/${draft.id}`, {
             method: 'DELETE',
             headers,
           });
@@ -452,7 +452,7 @@ export function AdminTargetsPage() {
           currency: DEFAULT_CURRENCY,
         };
 
-        const res = await api.request('/api/admin/targets', {
+        const res = await api.request('/api/v1/admin/targets', {
           method: 'POST',
           headers,
           body: JSON.stringify(body),

--- a/apps/web/src/pages/AdminTenantSettingsPage.tsx
+++ b/apps/web/src/pages/AdminTenantSettingsPage.tsx
@@ -112,8 +112,8 @@ export function AdminTenantSettingsPage() {
       setLoadError(null);
       try {
         const [settingsRes, pipelinesRes] = await Promise.all([
-          api.request('/api/admin/tenant-settings'),
-          api.request('/api/admin/pipelines'),
+          api.request('/api/v1/admin/tenant-settings'),
+          api.request('/api/v1/admin/pipelines'),
         ]);
 
         if (!settingsRes.ok) {
@@ -169,7 +169,7 @@ export function AdminTenantSettingsPage() {
     settings.leadAutoConversion = leadAutoConversion;
 
     try {
-      const response = await api.request('/api/admin/tenant-settings', {
+      const response = await api.request('/api/v1/admin/tenant-settings', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/AdminUsersPage.tsx
+++ b/apps/web/src/pages/AdminUsersPage.tsx
@@ -46,7 +46,7 @@ export function AdminUsersPage() {
     const loadUsers = async () => {
       try {
         const result = await api.get<UsersResponse>(
-          '/api/objects/user/records?limit=100',
+          '/api/v1/objects/user/records?limit=100',
         );
         if (!cancelled) {
           setUsers(result.data);

--- a/apps/web/src/pages/CreateAccountPage.tsx
+++ b/apps/web/src/pages/CreateAccountPage.tsx
@@ -106,7 +106,7 @@ export function CreateAccountPage() {
       const industry =
         form.industry === 'Other' ? form.customIndustry.trim() : form.industry || undefined;
 
-      const response = await api.request('/api/accounts', {
+      const response = await api.request('/api/v1/accounts', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/CreateRecordPage.tsx
+++ b/apps/web/src/pages/CreateRecordPage.tsx
@@ -121,7 +121,7 @@ export function CreateRecordPage() {
 
       try {
         // Fetch all object definitions to find our object
-        const objResponse = await api.request('/api/admin/objects');
+        const objResponse = await api.request('/api/v1/admin/objects');
 
         if (cancelled) return;
 
@@ -144,7 +144,7 @@ export function CreateRecordPage() {
 
         // Fetch field definitions
         const fieldsResponse = await api.request(
-          `/api/admin/objects/${obj.id}/fields`,
+          `/api/v1/admin/objects/${obj.id}/fields`,
         );
 
         if (cancelled) return;
@@ -156,7 +156,7 @@ export function CreateRecordPage() {
 
         // Fetch layouts
         const layoutsResponse = await api.request(
-          `/api/admin/objects/${obj.id}/layouts`,
+          `/api/v1/admin/objects/${obj.id}/layouts`,
         );
 
         if (cancelled) return;
@@ -171,7 +171,7 @@ export function CreateRecordPage() {
 
           if (formLayout) {
             const layoutDetailResponse = await api.request(
-              `/api/admin/objects/${obj.id}/layouts/${formLayout.id}`,
+              `/api/v1/admin/objects/${obj.id}/layouts/${formLayout.id}`,
             );
 
             if (!cancelled && layoutDetailResponse.ok) {
@@ -259,7 +259,7 @@ export function CreateRecordPage() {
     setSubmitting(true);
 
     try {
-      const response = await api.request(`/api/objects/${apiName}/records`, {
+      const response = await api.request(`/api/v1/objects/${apiName}/records`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -102,7 +102,7 @@ export function DashboardPage() {
   useEffect(() => {
     if (!sessionToken) return;
 
-    api.request('/api/objects/opportunity/records?limit=1&page=1')
+    api.request('/api/v1/objects/opportunity/records?limit=1&page=1')
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { total?: number } | null) => {
         if (data && typeof data.total === 'number') {
@@ -111,7 +111,7 @@ export function DashboardPage() {
       })
       .catch(() => { /* best-effort */ });
 
-    api.request('/api/objects/account/records?limit=1&page=1')
+    api.request('/api/v1/objects/account/records?limit=1&page=1')
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { total?: number } | null) => {
         if (data && typeof data.total === 'number') {

--- a/apps/web/src/pages/ObjectManagerPage.tsx
+++ b/apps/web/src/pages/ObjectManagerPage.tsx
@@ -122,7 +122,7 @@ export function ObjectManagerPage() {
     setError(null);
 
     try {
-      const response = await api.request('/api/admin/objects');
+      const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
         const data = (await response.json()) as ObjectDefinitionListItem[];
@@ -208,7 +208,7 @@ export function ObjectManagerPage() {
     setCreating(true);
 
     try {
-      const response = await api.request('/api/admin/objects', {
+      const response = await api.request('/api/v1/admin/objects', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -255,7 +255,7 @@ export function ObjectManagerPage() {
     setDeleteError(null);
 
     try {
-      const response = await api.request(`/api/admin/objects/${deleteTarget.id}`, {
+      const response = await api.request(`/api/v1/admin/objects/${deleteTarget.id}`, {
         method: 'DELETE',
       });
 

--- a/apps/web/src/pages/OrganisationProvisioningPage.tsx
+++ b/apps/web/src/pages/OrganisationProvisioningPage.tsx
@@ -41,7 +41,7 @@ export function OrganisationProvisioningPage() {
     setSubmitting(true);
 
     try {
-      const response = await api.request('/api/organisations', {
+      const response = await api.request('/api/v1/organisations', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/PipelineDetailPage.tsx
+++ b/apps/web/src/pages/PipelineDetailPage.tsx
@@ -190,7 +190,7 @@ export function PipelineDetailPage() {
     setError(null);
 
     try {
-      const response = await api.request(`/api/admin/pipelines/${id}`);
+      const response = await api.request(`/api/v1/admin/pipelines/${id}`);
 
       if (response.ok) {
         const data = (await response.json()) as PipelineDetail;
@@ -217,7 +217,7 @@ export function PipelineDetailPage() {
     if (!sessionToken || !pipeline?.objectId) return;
 
     try {
-      const response = await api.request(`/api/admin/objects/${pipeline.objectId}/fields`);
+      const response = await api.request(`/api/v1/admin/objects/${pipeline.objectId}/fields`);
 
       if (response.ok) {
         const data = (await response.json()) as FieldOption[];
@@ -240,7 +240,7 @@ export function PipelineDetailPage() {
     setGatesLoading(true);
 
     try {
-      const response = await api.request(`/api/admin/stages/${stageId}/gates`);
+      const response = await api.request(`/api/v1/admin/stages/${stageId}/gates`);
 
       if (response.ok) {
         const data = (await response.json()) as StageGate[];
@@ -281,7 +281,7 @@ export function PipelineDetailPage() {
 
     try {
       const response = await api.request(
-        `/api/admin/pipelines/${pipeline.id}/stages/${selectedStageId}`,
+        `/api/v1/admin/pipelines/${pipeline.id}/stages/${selectedStageId}`,
         {
           method: 'PUT',
           headers: {
@@ -344,7 +344,7 @@ export function PipelineDetailPage() {
     setAddStageError(null);
 
     try {
-      const response = await api.request(`/api/admin/pipelines/${pipeline.id}/stages`, {
+      const response = await api.request(`/api/v1/admin/pipelines/${pipeline.id}/stages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -383,7 +383,7 @@ export function PipelineDetailPage() {
 
     try {
       const response = await api.request(
-        `/api/admin/pipelines/${pipeline.id}/stages/${deleteStageTarget.id}`,
+        `/api/v1/admin/pipelines/${pipeline.id}/stages/${deleteStageTarget.id}`,
         {
           method: 'DELETE',
         },
@@ -429,7 +429,7 @@ export function PipelineDetailPage() {
     const reorderedIds = [...openStages.map((s) => s.id), ...terminalStages.map((s) => s.id)];
 
     try {
-      await api.request(`/api/admin/pipelines/${pipeline.id}/stages/reorder`, {
+      await api.request(`/api/v1/admin/pipelines/${pipeline.id}/stages/reorder`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -469,7 +469,7 @@ export function PipelineDetailPage() {
     setGateError(null);
 
     try {
-      const response = await api.request(`/api/admin/stages/${selectedStageId}/gates`, {
+      const response = await api.request(`/api/v1/admin/stages/${selectedStageId}/gates`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -500,7 +500,7 @@ export function PipelineDetailPage() {
     if (!sessionToken || !selectedStageId) return;
 
     try {
-      await api.request(`/api/admin/stages/${selectedStageId}/gates/${gateId}`, {
+      await api.request(`/api/v1/admin/stages/${selectedStageId}/gates/${gateId}`, {
         method: 'DELETE',
       });
 

--- a/apps/web/src/pages/PipelineManagerPage.tsx
+++ b/apps/web/src/pages/PipelineManagerPage.tsx
@@ -94,7 +94,7 @@ export function PipelineManagerPage() {
     setError(null);
 
     try {
-      const response = await api.request('/api/admin/pipelines');
+      const response = await api.request('/api/v1/admin/pipelines');
 
       if (response.ok) {
         const data = (await response.json()) as PipelineListItem[];
@@ -115,7 +115,7 @@ export function PipelineManagerPage() {
     if (!sessionToken) return;
 
     try {
-      const response = await api.request('/api/admin/objects');
+      const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
         const data = (await response.json()) as ObjectOption[];
@@ -196,7 +196,7 @@ export function PipelineManagerPage() {
     setCreating(true);
 
     try {
-      const response = await api.request('/api/admin/pipelines', {
+      const response = await api.request('/api/v1/admin/pipelines', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/PlatformTenantDetailPage.tsx
+++ b/apps/web/src/pages/PlatformTenantDetailPage.tsx
@@ -125,7 +125,7 @@ export function PlatformTenantDetailPage() {
     setError(null);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}`);
+      const response = await api.request(`/api/v1/platform/tenants/${id}`);
 
       if (response.ok) {
         const data = (await response.json()) as TenantDetail;
@@ -151,7 +151,7 @@ export function PlatformTenantDetailPage() {
     setUsersLoading(true);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}/users`);
+      const response = await api.request(`/api/v1/platform/tenants/${id}/users`);
 
       if (response.ok) {
         const data = (await response.json()) as TenantUser[];
@@ -179,7 +179,7 @@ export function PlatformTenantDetailPage() {
     setSaveSuccess(false);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}`, {
+      const response = await api.request(`/api/v1/platform/tenants/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -211,7 +211,7 @@ export function PlatformTenantDetailPage() {
     setSaveError(null);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}`, {
+      const response = await api.request(`/api/v1/platform/tenants/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -243,7 +243,7 @@ export function PlatformTenantDetailPage() {
     setDeleteError(null);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}?cascade=true`, {
+      const response = await api.request(`/api/v1/platform/tenants/${id}?cascade=true`, {
         method: 'DELETE',
       });
 
@@ -301,7 +301,7 @@ export function PlatformTenantDetailPage() {
     setInviting(true);
 
     try {
-      const response = await api.request(`/api/platform/tenants/${id}/users/invite`, {
+      const response = await api.request(`/api/v1/platform/tenants/${id}/users/invite`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/PlatformTenantsPage.tsx
+++ b/apps/web/src/pages/PlatformTenantsPage.tsx
@@ -121,7 +121,7 @@ export function PlatformTenantsPage() {
     setError(null);
 
     try {
-      const response = await api.request('/api/platform/tenants');
+      const response = await api.request('/api/v1/platform/tenants');
 
       if (response.ok) {
         const data = (await response.json()) as TenantListResponse;
@@ -221,7 +221,7 @@ export function PlatformTenantsPage() {
       await new Promise((resolve) => setTimeout(resolve, 500));
       setProvisionStep('seeding');
 
-      const response = await api.request('/api/platform/tenants', {
+      const response = await api.request('/api/v1/platform/tenants', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -41,7 +41,7 @@ export function ProfilePage() {
       setLoading(true);
       setLoadError(null);
       try {
-        const response = await api.request('/api/profile');
+        const response = await api.request('/api/v1/profile');
         if (!response.ok) {
           const data = (await response.json()) as ApiError;
           if (!cancelled) setLoadError(data.error ?? 'Failed to load profile');
@@ -83,7 +83,7 @@ export function ProfilePage() {
     if (form.jobTitle.trim()) body.jobTitle = form.jobTitle.trim();
 
     try {
-      const response = await api.request('/api/profile', {
+      const response = await api.request('/api/v1/profile', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/src/pages/RecordCreatePage.tsx
+++ b/apps/web/src/pages/RecordCreatePage.tsx
@@ -258,7 +258,7 @@ export function RecordCreatePage() {
 
       try {
         // 1. Get object definitions to find the object ID
-        const objResponse = await api.request('/api/admin/objects');
+        const objResponse = await api.request('/api/v1/admin/objects');
 
         if (cancelled) return;
         if (!objResponse.ok) {
@@ -280,8 +280,8 @@ export function RecordCreatePage() {
 
         // 2. Fetch layouts + relationships in parallel
         const [layoutsResponse, relsResponse] = await Promise.all([
-          api.request(`/api/admin/objects/${obj.id}/layouts`),
-          api.request(`/api/admin/objects/${obj.id}/relationships`),
+          api.request(`/api/v1/admin/objects/${obj.id}/layouts`),
+          api.request(`/api/v1/admin/objects/${obj.id}/relationships`),
         ]);
 
         if (cancelled) return;
@@ -296,7 +296,7 @@ export function RecordCreatePage() {
 
           if (formLayout && !cancelled) {
             const layoutDetailResponse = await api.request(
-              `/api/admin/objects/${obj.id}/layouts/${formLayout.id}`,
+              `/api/v1/admin/objects/${obj.id}/layouts/${formLayout.id}`,
             );
 
             if (cancelled) return;
@@ -317,7 +317,7 @@ export function RecordCreatePage() {
         // still create a record.
         if (!layoutResolved && !cancelled) {
           const fieldsResponse = await api.request(
-            `/api/admin/objects/${obj.id}/fields`,
+            `/api/v1/admin/objects/${obj.id}/fields`,
           );
 
           if (cancelled) return;
@@ -448,7 +448,7 @@ export function RecordCreatePage() {
 
     try {
       // Create the record
-      const response = await api.request(`/api/objects/${apiName}/records`, {
+      const response = await api.request(`/api/v1/objects/${apiName}/records`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -470,7 +470,7 @@ export function RecordCreatePage() {
       // Link relationships
       const relLinks = relationshipSelections.filter((s) => s.recordId);
       for (const link of relLinks) {
-        await api.request(`/api/records/${created.id}/relationships`, {
+        await api.request(`/api/v1/records/${created.id}/relationships`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -187,7 +187,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     const loadLayout = async () => {
       try {
         // First get the object definitions to find the object ID
-        const objResponse = await api.request('/api/admin/objects');
+        const objResponse = await api.request('/api/v1/admin/objects');
 
         if (cancelled) return;
 
@@ -204,7 +204,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
         setResolvedObjectId(obj.id);
 
         // Check for pipeline existence (best-effort)
-        api.request('/api/admin/pipelines')
+        api.request('/api/v1/admin/pipelines')
           .then((resp) => {
             if (cancelled || !resp.ok) return null;
             return resp.json();
@@ -220,7 +220,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
         // Fetch layouts for this object
         const layoutsResponse = await api.request(
-          `/api/admin/objects/${obj.id}/layouts`,
+          `/api/v1/admin/objects/${obj.id}/layouts`,
         );
 
         if (cancelled || !layoutsResponse.ok) return;
@@ -234,7 +234,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
         // Fetch the layout detail with fields
         const layoutDetailResponse = await api.request(
-          `/api/admin/objects/${obj.id}/layouts/${listLayout.id}`,
+          `/api/v1/admin/objects/${obj.id}/layouts/${listLayout.id}`,
         );
 
         if (cancelled || !layoutDetailResponse.ok) return;
@@ -279,7 +279,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
       try {
         const data = await api.get<RecordsResponse>(
-          `/api/objects/${apiName}/records?${params.toString()}`,
+          `/api/v1/objects/${apiName}/records?${params.toString()}`,
         );
 
         if (!cancelled) {

--- a/apps/web/src/store/superAdmin.ts
+++ b/apps/web/src/store/superAdmin.ts
@@ -5,7 +5,7 @@ import { useApiClient } from '../lib/apiClient.js';
 /**
  * Checks whether the current authenticated user is a platform super-admin.
  *
- * Calls GET /api/me and reads the `isSuperAdmin` flag from the response.
+ * Calls GET /api/v1/me and reads the `isSuperAdmin` flag from the response.
  * Returns `{ isSuperAdmin, loading }`.
  */
 export function useSuperAdmin(): { isSuperAdmin: boolean; loading: boolean } {
@@ -25,7 +25,7 @@ export function useSuperAdmin(): { isSuperAdmin: boolean; loading: boolean } {
 
     const check = async () => {
       try {
-        const response = await api.request('/api/me');
+        const response = await api.request('/api/v1/me');
 
         if (cancelled) return;
 

--- a/apps/web/src/store/tenantSettings.tsx
+++ b/apps/web/src/store/tenantSettings.tsx
@@ -43,7 +43,7 @@ export function TenantSettingsProvider({ children }: TenantSettingsProviderProps
 
     const fetchSettings = async () => {
       try {
-        const response = await api.request('/api/admin/tenant-settings');
+        const response = await api.request('/api/v1/admin/tenant-settings');
 
         if (!response.ok || cancelled) return;
 

--- a/apps/web/src/usePageLayout.ts
+++ b/apps/web/src/usePageLayout.ts
@@ -27,7 +27,7 @@ export function usePageLayout(objectApiName: string | undefined) {
 
       try {
         const response = await api.request(
-          `/api/objects/${encodeURIComponent(objectApiName)}/page-layout`,
+          `/api/v1/objects/${encodeURIComponent(objectApiName)}/page-layout`,
         );
 
         if (cancelled) return;

--- a/docs/architecture/adr-005-api-versioning.md
+++ b/docs/architecture/adr-005-api-versioning.md
@@ -1,0 +1,155 @@
+# ADR-005: API Versioning and Deprecation Policy
+
+## Status
+
+Accepted
+
+## Context
+
+Before CPCRM has any external API consumers, every HTTP route is mounted under
+the bare `/api` prefix. That shape has served well for internal use — the
+single-page web app is the only client today — but it leaves no room to ship
+breaking changes without coordinated releases across the monorepo. As soon as
+a third party (integration partner, mobile client, automation script, or
+downstream service) takes a dependency on an endpoint, the shape of every
+request and response becomes a public contract we cannot rewrite on a whim.
+
+Introducing versioning **now**, while we still control 100 % of the callers, is
+an order of magnitude cheaper than retrofitting it later. Doing it before
+external consumers exist means:
+
+1. We can pick a clean URL scheme without having to invent compatibility shims.
+2. We can document a firm deprecation timeline that external integrators can
+   plan around.
+3. Future breaking changes (new request shape, removed field, renamed route)
+   can land on `/api/v2` without coordinating a hard cutover.
+
+---
+
+## Decision
+
+### 1. Canonical Versioned Prefix: `/api/v1`
+
+Every current and future HTTP endpoint is mounted under a version-prefixed
+path. The first version is `v1`:
+
+```
+/api/v1/health
+/api/v1/auth/session
+/api/v1/accounts
+/api/v1/objects/:apiName/records
+/api/v1/admin/pipelines
+...
+```
+
+All routes are registered on a single Express `Router` in
+`apps/api/src/index.ts` and that router is mounted at `/api/v1`. Mounting via a
+shared router (rather than duplicating `app.use('/api/v1/...', routerA);
+app.use('/api/v1/...', routerB);` by hand) guarantees that any new route added
+to the registry is automatically available under the versioned prefix.
+
+### 2. Legacy `/api` Alias With `Deprecation` Headers
+
+The same `apiRouter` is also mounted at the bare `/api` prefix so that any
+client that has not yet migrated keeps working. Every response served from
+the legacy mount carries two RFC 8594 headers:
+
+| Header | Value | Meaning |
+|--------|-------|---------|
+| `Deprecation` | `true` | This endpoint (under the bare `/api` prefix) is deprecated. |
+| `Link` | `</api/v1/…>; rel="successor-version"` | Points the client at the canonical versioned path. |
+
+The legacy alias exists **only** to prevent a flag-day migration. It is not a
+supported long-term surface: clients that continue using `/api/...` after the
+deprecation window lapses may begin receiving 410 Gone responses.
+
+The versioned mount is registered first in the Express middleware chain so
+that requests to `/api/v1/...` never fall through to the legacy alias and the
+`Deprecation` header is never emitted on versioned responses.
+
+### 3. Deprecation Policy for Breaking Changes
+
+A breaking change is any change that could cause a previously working client
+to fail:
+
+- Removing a route, query parameter, request-body field, or response field.
+- Renaming a route, field, or enum value.
+- Changing a field's type, nullability, or semantic meaning.
+- Tightening validation (e.g. making a previously optional field required).
+- Removing a permission a caller previously relied on.
+
+Non-breaking changes (adding optional fields, adding new endpoints, adding
+new enum values in output-only fields, relaxing validation) may ship at any
+time under the current version.
+
+When a breaking change is required, the following policy applies:
+
+1. **Minimum six months' notice.** A breaking change must be announced at
+   least six months before the old behaviour is removed. The clock starts on
+   the date the deprecation notice is published in the OpenAPI spec and the
+   release notes, *not* the date the replacement endpoint first ships.
+2. **Mark the old surface deprecated.** The deprecated endpoint, field, or
+   parameter is marked `deprecated: true` in the OpenAPI document and the
+   response begins emitting the `Deprecation: true` header (in addition to
+   the `Link` header pointing at the successor, if one exists).
+3. **Ship the replacement on a new version prefix.** Breaking changes land
+   on `/api/v2`, `/api/v3`, etc. The previous version continues to serve the
+   unchanged shape until its sunset date.
+4. **Publish a sunset date.** Deprecated endpoints add a `Sunset` header
+   (RFC 8594) carrying the earliest date the old surface may be removed.
+   That date must be at least six months after the deprecation notice.
+5. **Remove only after the window elapses.** Once the sunset date has passed
+   *and* telemetry confirms no active callers remain, the old surface may be
+   removed in a subsequent release.
+
+The bare `/api` alias itself is subject to the same policy: it is considered
+deprecated from the moment `/api/v1` ships, and will not be removed before
+the policy window has elapsed for every currently-deployed client.
+
+### 4. Client Guidance
+
+- **Internal clients** (the web app, any future mobile app, server-side
+  workers) must target `/api/v1` directly. The web app's shared `apiClient`
+  only emits versioned URLs; there is no fallback to the legacy prefix.
+- **External integrators** should target `/api/v1`. Treat any response that
+  carries a `Deprecation: true` header as a signal to inspect the `Link`
+  header and migrate to the successor version before the next release.
+- **Observability.** Server logs include the matched route path, which makes
+  it possible to track legacy-alias usage over time via the existing
+  request-id log fields. Once the volume of bare `/api` traffic drops to
+  zero for a full release cycle, the alias can be scheduled for removal.
+
+---
+
+## Consequences
+
+### Positive
+
+- Breaking changes can ship on a new prefix without coordinating a flag-day
+  cutover with every consumer.
+- External integrators get a firm, written commitment to a minimum six-month
+  deprecation window, which is table stakes for enterprise adoption.
+- The OpenAPI spec and the generated Swagger UI now advertise a stable,
+  versioned URL scheme that matches the shipped reality.
+- The legacy `/api` alias keeps the migration risk-free: any caller that was
+  missed during the internal cutover continues to work, and a deprecation
+  header makes the missed caller easy to notice.
+
+### Negative
+
+- Every internal caller (the web app, tests, OpenAPI tooling) had to migrate
+  to the new prefix. This was a mechanical find-and-replace but it touched
+  ~50 files.
+- Running two mount points for the same router costs a small amount of
+  additional middleware per request on the legacy path (the
+  `legacyApiDeprecationHeaders` middleware). This is negligible compared to
+  the cost of the rest of the request pipeline.
+- The deprecation policy imposes a hard minimum timeline on breaking changes.
+  Teams must plan rollouts against the six-month window rather than shipping
+  breaking changes on demand.
+
+### Neutral
+
+- Shipping `/api/v2` in future will not require any refactoring of
+  `index.ts`: a new router can be registered alongside `apiRouter` and
+  mounted at the new prefix without touching the existing mounts.

--- a/docs/architecture/adr-005-api-versioning.md
+++ b/docs/architecture/adr-005-api-versioning.md
@@ -52,20 +52,32 @@ to the registry is automatically available under the versioned prefix.
 
 The same `apiRouter` is also mounted at the bare `/api` prefix so that any
 client that has not yet migrated keeps working. Every response served from
-the legacy mount carries two RFC 8594 headers:
+the legacy mount carries two standardised headers:
 
-| Header | Value | Meaning |
-|--------|-------|---------|
-| `Deprecation` | `true` | This endpoint (under the bare `/api` prefix) is deprecated. |
-| `Link` | `</api/v1/…>; rel="successor-version"` | Points the client at the canonical versioned path. |
+| Header | Value | Standard | Meaning |
+|--------|-------|----------|---------|
+| `Deprecation` | `true` | [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) | This endpoint (under the bare `/api` prefix) is deprecated. |
+| `Link` | `</api/v1/…>; rel="successor-version"` | [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) (header) + [RFC 5829](https://www.rfc-editor.org/rfc/rfc5829) (`successor-version` relation type) | Points the client at the canonical versioned path. |
 
 The legacy alias exists **only** to prevent a flag-day migration. It is not a
 supported long-term surface: clients that continue using `/api/...` after the
 deprecation window lapses may begin receiving 410 Gone responses.
 
-The versioned mount is registered first in the Express middleware chain so
-that requests to `/api/v1/...` never fall through to the legacy alias and the
-`Deprecation` header is never emitted on versioned responses.
+The versioned mount is registered first in the Express middleware chain, and
+the shared router ends with a terminal 404 handler that throws the canonical
+`NOT_FOUND` error. Together these guarantee two things:
+
+1. A valid `/api/v1/...` request is always answered by the versioned mount —
+   it never falls through to the legacy alias, so `Deprecation` headers are
+   never emitted on versioned responses.
+2. An unmatched `/api/v1/...` request (typo, wrong method) returns the
+   canonical JSON error payload rather than the SPA `index.html` that the
+   production static-file fallback would otherwise serve for unknown paths.
+
+The legacy-alias middleware additionally short-circuits any request whose
+`originalUrl` already begins with `/api/v1` as a defence-in-depth check, so
+even a future misconfiguration cannot mistakenly stamp a versioned response
+with deprecation headers or a malformed `Link: </api/v1/v1/…>` value.
 
 ### 3. Deprecation Policy for Breaking Changes
 


### PR DESCRIPTION
## Summary

- Mount every API route under a shared Express router at `/api/v1`, and keep `/api` as a temporary alias that emits an RFC 8594 `Deprecation: true` header plus a `Link: </api/v1/...>; rel="successor-version"` header on every legacy response. The versioned mount is registered first so `/api/v1` traffic never falls through to the legacy alias.
- Update every frontend caller, hook, component, and test to target `/api/v1/...`, including escaped regex URL matchers in test files and the `syncSessionCookie` / `clearServerSession` helpers in `apiClient.ts`.
- Regenerate `openapi.json` with `/api/v1` as the primary server URL and `/api` as a deprecated-alias server entry, and add `docs/architecture/adr-005-api-versioning.md` documenting the versioning scheme plus a firm six-month minimum deprecation-window policy for future breaking changes.

Closes #375

## Test plan

- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run test` in `apps/api` — 1237 passed (56 files)
- [x] `npm run test` in `apps/web` — 634 passed (46 files)
- [x] `npm run build` in `apps/api` — regenerates `openapi.json` with the new server list
- [ ] Smoke: `curl -i /api/v1/health` returns 200 with no `Deprecation` header
- [ ] Smoke: `curl -i /api/health` returns 200 with `Deprecation: true` and a `Link: </api/v1/health>; rel="successor-version"` header

## Acceptance criteria

- [x] All routes reachable at `/api/v1/...` (shared router mounted at `/api/v1`)
- [x] Legacy `/api/...` still works and emits `Deprecation` header (same router mounted at `/api` with deprecation middleware)
- [x] Frontend uses v1 (all call sites, session helpers, and tests updated)
- [x] Versioning policy documented (`docs/architecture/adr-005-api-versioning.md`)