### PR TITLE
Enforce pagination defaults and max limits across list endpoints

### DIFF
--- a/apps/api/src/lib/__tests__/pagination.test.ts
+++ b/apps/api/src/lib/__tests__/pagination.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  parsePaginationQuery,
+  paginateInMemory,
+  paginatedResponse,
+} from '../pagination.js';
+import { AppError, isAppError } from '../appError.js';
+
+describe('parsePaginationQuery', () => {
+  it('returns defaults when no query params are supplied', () => {
+    expect(parsePaginationQuery({})).toEqual({
+      limit: DEFAULT_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('coerces string values from Express query parsing', () => {
+    expect(parsePaginationQuery({ limit: '25', offset: '100' })).toEqual({
+      limit: 25,
+      offset: 100,
+    });
+  });
+
+  it('accepts numeric values directly', () => {
+    expect(parsePaginationQuery({ limit: 10, offset: 20 })).toEqual({
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  it('treats empty strings as missing (default applied)', () => {
+    expect(parsePaginationQuery({ limit: '', offset: '' })).toEqual({
+      limit: DEFAULT_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('accepts limit at exactly MAX_LIMIT', () => {
+    expect(parsePaginationQuery({ limit: String(MAX_LIMIT) })).toEqual({
+      limit: MAX_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('accepts limit at exactly 1', () => {
+    expect(parsePaginationQuery({ limit: '1' })).toEqual({
+      limit: 1,
+      offset: 0,
+    });
+  });
+
+  it('accepts offset at exactly 0', () => {
+    expect(parsePaginationQuery({ offset: '0' })).toEqual({
+      limit: DEFAULT_LIMIT,
+      offset: 0,
+    });
+  });
+
+  it('rejects limit > MAX_LIMIT with validation error', () => {
+    try {
+      parsePaginationQuery({ limit: String(MAX_LIMIT + 1) });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAppError(err)).toBe(true);
+      const appErr = err as AppError;
+      expect(appErr.statusCode).toBe(400);
+      expect(appErr.code).toBe('VALIDATION_ERROR');
+      expect(appErr.details).toBeDefined();
+      const details = appErr.details as { fieldErrors: Record<string, string> };
+      expect(details.fieldErrors.limit).toMatch(/limit must be <=/);
+    }
+  });
+
+  it('rejects limit = 0 as below minimum', () => {
+    expect(() => parsePaginationQuery({ limit: '0' })).toThrow(AppError);
+  });
+
+  it('rejects negative limit', () => {
+    expect(() => parsePaginationQuery({ limit: '-1' })).toThrow(AppError);
+  });
+
+  it('rejects negative offset', () => {
+    expect(() => parsePaginationQuery({ offset: '-1' })).toThrow(AppError);
+  });
+
+  it('rejects non-numeric limit', () => {
+    expect(() => parsePaginationQuery({ limit: 'abc' })).toThrow(AppError);
+  });
+
+  it('rejects non-numeric offset', () => {
+    expect(() => parsePaginationQuery({ offset: 'abc' })).toThrow(AppError);
+  });
+
+  it('rejects non-integer (fractional) limit', () => {
+    expect(() => parsePaginationQuery({ limit: '5.5' })).toThrow(AppError);
+  });
+
+  it('rejects non-integer (fractional) offset', () => {
+    expect(() => parsePaginationQuery({ offset: '2.5' })).toThrow(AppError);
+  });
+
+  it('collects field errors for both limit and offset when both invalid', () => {
+    try {
+      parsePaginationQuery({ limit: '-5', offset: 'bogus' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(isAppError(err)).toBe(true);
+      const details = (err as AppError).details as {
+        fieldErrors: Record<string, string>;
+      };
+      expect(details.fieldErrors.limit).toBeDefined();
+      expect(details.fieldErrors.offset).toBeDefined();
+    }
+  });
+});
+
+describe('paginatedResponse', () => {
+  it('wraps data with correct pagination metadata (first page)', () => {
+    expect(paginatedResponse(['a', 'b'], 10, { limit: 2, offset: 0 })).toEqual({
+      data: ['a', 'b'],
+      pagination: { total: 10, limit: 2, offset: 0, hasMore: true },
+    });
+  });
+
+  it('reports hasMore=false on the last full page', () => {
+    expect(paginatedResponse(['i', 'j'], 10, { limit: 2, offset: 8 })).toEqual({
+      data: ['i', 'j'],
+      pagination: { total: 10, limit: 2, offset: 8, hasMore: false },
+    });
+  });
+
+  it('reports hasMore=false for a partial tail page', () => {
+    expect(paginatedResponse(['last'], 5, { limit: 2, offset: 4 })).toEqual({
+      data: ['last'],
+      pagination: { total: 5, limit: 2, offset: 4, hasMore: false },
+    });
+  });
+
+  it('handles an empty page past the end of the data set', () => {
+    expect(paginatedResponse([], 3, { limit: 10, offset: 100 })).toEqual({
+      data: [],
+      pagination: { total: 3, limit: 10, offset: 100, hasMore: false },
+    });
+  });
+
+  it('handles an empty data set', () => {
+    expect(paginatedResponse([], 0, { limit: 50, offset: 0 })).toEqual({
+      data: [],
+      pagination: { total: 0, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+});
+
+describe('paginateInMemory', () => {
+  const items = ['a', 'b', 'c', 'd', 'e'];
+
+  it('returns the full list when limit exceeds size', () => {
+    expect(paginateInMemory(items, { limit: 50, offset: 0 })).toEqual({
+      data: ['a', 'b', 'c', 'd', 'e'],
+      pagination: { total: 5, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('slices the first page correctly', () => {
+    expect(paginateInMemory(items, { limit: 2, offset: 0 })).toEqual({
+      data: ['a', 'b'],
+      pagination: { total: 5, limit: 2, offset: 0, hasMore: true },
+    });
+  });
+
+  it('slices the middle page correctly', () => {
+    expect(paginateInMemory(items, { limit: 2, offset: 2 })).toEqual({
+      data: ['c', 'd'],
+      pagination: { total: 5, limit: 2, offset: 2, hasMore: true },
+    });
+  });
+
+  it('slices the partial tail page correctly', () => {
+    expect(paginateInMemory(items, { limit: 2, offset: 4 })).toEqual({
+      data: ['e'],
+      pagination: { total: 5, limit: 2, offset: 4, hasMore: false },
+    });
+  });
+
+  it('returns an empty page when offset is past the end', () => {
+    expect(paginateInMemory(items, { limit: 10, offset: 100 })).toEqual({
+      data: [],
+      pagination: { total: 5, limit: 10, offset: 100, hasMore: false },
+    });
+  });
+
+  it('handles an empty input', () => {
+    expect(paginateInMemory([], { limit: 10, offset: 0 })).toEqual({
+      data: [],
+      pagination: { total: 0, limit: 10, offset: 0, hasMore: false },
+    });
+  });
+});

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -1,0 +1,187 @@
+/**
+ * Pagination helpers used by all list endpoints.
+ *
+ * The CRM exposes a single canonical pagination envelope:
+ *
+ * ```json
+ * {
+ *   "data": [ ... ],
+ *   "pagination": {
+ *     "total": 123,
+ *     "limit": 50,
+ *     "offset": 0,
+ *     "hasMore": true
+ *   }
+ * }
+ * ```
+ *
+ * Query parameters `limit` and `offset` are both optional. If omitted,
+ * `limit` defaults to {@link DEFAULT_LIMIT} and `offset` defaults to 0.
+ * `limit` is bounded by {@link MAX_LIMIT}; any request with a larger value is
+ * rejected with HTTP 400 so an unbounded result set cannot be requested.
+ *
+ * Validation is enforced via {@link parsePaginationQuery}, which throws an
+ * `AppError` so the global error middleware produces the canonical error
+ * response shape.
+ */
+import { z } from 'zod';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { AppError } from './appError.js';
+
+// Ensure `.openapi(...)` is available on Zod schemas even when this module is
+// imported before any route `*.schema.ts` file that also calls
+// `extendZodWithOpenApi`. The helper is idempotent.
+extendZodWithOpenApi(z);
+
+/** Default page size when `limit` is not supplied. */
+export const DEFAULT_LIMIT = 50;
+
+/** Maximum permitted value for the `limit` query parameter. */
+export const MAX_LIMIT = 200;
+
+/** Validated pagination parameters returned by {@link parsePaginationQuery}. */
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+}
+
+/** Canonical pagination metadata returned by every list endpoint. */
+export interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+/** Canonical response envelope returned by every list endpoint. */
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: PaginationMeta;
+}
+
+/**
+ * Zod schema for pagination query parameters.
+ *
+ * Query values arrive as strings; this schema coerces and validates them.
+ * Invalid values (non-numeric, negative, `limit > MAX_LIMIT`) are rejected.
+ */
+export const PaginationQuerySchema = z.object({
+  limit: z
+    .union([z.string(), z.number()])
+    .optional()
+    .transform((v) => (v === undefined || v === '' ? undefined : Number(v)))
+    .refine((v) => v === undefined || (Number.isFinite(v) && Number.isInteger(v)), {
+      message: 'limit must be an integer',
+    })
+    .refine((v) => v === undefined || v >= 1, {
+      message: 'limit must be >= 1',
+    })
+    .refine((v) => v === undefined || v <= MAX_LIMIT, {
+      message: `limit must be <= ${MAX_LIMIT}`,
+    }),
+  offset: z
+    .union([z.string(), z.number()])
+    .optional()
+    .transform((v) => (v === undefined || v === '' ? undefined : Number(v)))
+    .refine((v) => v === undefined || (Number.isFinite(v) && Number.isInteger(v)), {
+      message: 'offset must be an integer',
+    })
+    .refine((v) => v === undefined || v >= 0, {
+      message: 'offset must be >= 0',
+    }),
+});
+
+/** Zod schema used by OpenAPI registrations for the pagination envelope. */
+export const PaginationMetaSchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    limit: z.number().int().positive(),
+    offset: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
+  })
+  .openapi('PaginationMeta');
+
+/**
+ * Produces a Zod schema describing the canonical paginated envelope for a
+ * given item schema. Usable directly in `registry.registerPath()`.
+ */
+export function paginatedResponseSchema<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z.object({
+    data: z.array(itemSchema),
+    pagination: PaginationMetaSchema,
+  });
+}
+
+/** OpenAPI `query` object covering the shared `limit` / `offset` params. */
+export const PaginationOpenApiQuery = z.object({
+  limit: z.string().optional().openapi({
+    description: `Maximum number of items to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+    example: String(DEFAULT_LIMIT),
+  }),
+  offset: z.string().optional().openapi({
+    description: 'Number of items to skip before returning results (default 0).',
+    example: '0',
+  }),
+});
+
+/**
+ * Parses and validates pagination query parameters.
+ *
+ * @throws {AppError} 400 VALIDATION_ERROR when `limit` or `offset` are malformed
+ *   or out of range.
+ */
+export function parsePaginationQuery(query: unknown): PaginationParams {
+  const result = PaginationQuerySchema.safeParse(query);
+
+  if (!result.success) {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of result.error.issues) {
+      const field = issue.path[0];
+      if (typeof field === 'string' && !(field in fieldErrors)) {
+        fieldErrors[field] = issue.message;
+      }
+    }
+    throw AppError.validation('Invalid pagination parameters', { fieldErrors });
+  }
+
+  const limit = result.data.limit ?? DEFAULT_LIMIT;
+  const offset = result.data.offset ?? 0;
+
+  return { limit, offset };
+}
+
+/**
+ * Wraps a list of items and a total count in the canonical paginated response.
+ */
+export function paginatedResponse<T>(
+  data: T[],
+  total: number,
+  { limit, offset }: PaginationParams,
+): PaginatedResponse<T> {
+  return {
+    data,
+    pagination: {
+      total,
+      limit,
+      offset,
+      hasMore: offset + data.length < total,
+    },
+  };
+}
+
+/**
+ * Paginates an already-materialised array in memory and wraps it in the
+ * canonical paginated response. Intended for small, bounded result sets
+ * (e.g. admin metadata) where loading the full list is cheap.
+ *
+ * For larger datasets, pagination should be pushed into the database query
+ * via {@link paginatedResponse} with a separate `COUNT(*)`.
+ */
+export function paginateInMemory<T>(
+  items: readonly T[],
+  pagination: PaginationParams,
+): PaginatedResponse<T> {
+  const { limit, offset } = pagination;
+  const page = items.slice(offset, offset + limit);
+  return paginatedResponse(page as T[], items.length, pagination);
+}

--- a/apps/api/src/routes/__tests__/accounts.test.ts
+++ b/apps/api/src/routes/__tests__/accounts.test.ts
@@ -176,26 +176,24 @@ describe('GET /accounts', () => {
     mockListAccounts.mockReset();
   });
 
-  it('returns 200 with paginated accounts', async () => {
+  it('returns 200 with paginated accounts wrapped in the canonical envelope', async () => {
     const now = new Date();
-    const result = {
-      data: [
-        {
-          id: 'acc-1',
-          tenantId: 'tenant-abc',
-          name: 'Acme Corp',
-          ownerId: 'user-123',
-          createdAt: now,
-          updatedAt: now,
-          createdBy: 'user-123',
-        },
-      ],
-      total: 1,
-      page: 1,
-      limit: 20,
+    const account = {
+      id: 'acc-1',
+      tenantId: 'tenant-abc',
+      name: 'Acme Corp',
+      ownerId: 'user-123',
+      createdAt: now,
+      updatedAt: now,
+      createdBy: 'user-123',
     };
 
-    mockListAccounts.mockResolvedValue(result);
+    mockListAccounts.mockResolvedValue({
+      data: [account],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    });
 
     const req = mockReq({}, undefined, {}, {});
     const res = mockRes();
@@ -206,17 +204,20 @@ describe('GET /accounts', () => {
       tenantId: 'tenant-abc',
       ownerId: 'user-123',
       search: undefined,
-      page: 1,
-      limit: 20,
+      limit: 50,
+      offset: 0,
     });
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(result);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [account],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
   });
 
   it('passes search and pagination parameters to the service', async () => {
-    mockListAccounts.mockResolvedValue({ data: [], total: 0, page: 2, limit: 10 });
+    mockListAccounts.mockResolvedValue({ data: [], total: 0, limit: 10, offset: 20 });
 
-    const req = mockReq({}, undefined, {}, { search: 'acme', page: '2', limit: '10' });
+    const req = mockReq({}, undefined, {}, { search: 'acme', limit: '10', offset: '20' });
     const res = mockRes();
 
     await handleListAccounts(req, res);
@@ -225,21 +226,61 @@ describe('GET /accounts', () => {
       tenantId: 'tenant-abc',
       ownerId: 'user-123',
       search: 'acme',
-      page: 2,
       limit: 10,
+      offset: 20,
     });
   });
 
-  it('clamps limit to maximum of 100', async () => {
-    mockListAccounts.mockResolvedValue({ data: [], total: 0, page: 1, limit: 100 });
-
+  it('rejects limit greater than the max with HTTP 400', async () => {
     const req = mockReq({}, undefined, {}, { limit: '500' });
     const res = mockRes();
 
     await handleListAccounts(req, res);
 
-    expect(mockListAccounts).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 100 }),
+    expect(mockListAccounts).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'VALIDATION_ERROR' }),
+    );
+  });
+
+  it('rejects negative offset with HTTP 400', async () => {
+    const req = mockReq({}, undefined, {}, { offset: '-1' });
+    const res = mockRes();
+
+    await handleListAccounts(req, res);
+
+    expect(mockListAccounts).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects non-numeric limit with HTTP 400', async () => {
+    const req = mockReq({}, undefined, {}, { limit: 'banana' });
+    const res = mockRes();
+
+    await handleListAccounts(req, res);
+
+    expect(mockListAccounts).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('reports hasMore=true when more results are available', async () => {
+    mockListAccounts.mockResolvedValue({
+      data: Array.from({ length: 50 }, (_, i) => ({ id: `acc-${i}` })),
+      total: 120,
+      limit: 50,
+      offset: 0,
+    });
+
+    const req = mockReq({}, undefined, {}, {});
+    const res = mockRes();
+
+    await handleListAccounts(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pagination: { total: 120, limit: 50, offset: 0, hasMore: true },
+      }),
     );
   });
 

--- a/apps/api/src/routes/__tests__/adminFields.test.ts
+++ b/apps/api/src/routes/__tests__/adminFields.test.ts
@@ -48,9 +48,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = { objectId: 'obj-1' },
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/objects/obj-1/fields',
     user,
     params,
@@ -198,7 +200,7 @@ describe('GET /admin/objects/:objectId/fields', () => {
     mockListFieldDefinitions.mockReset();
   });
 
-  it('returns 200 with all fields', async () => {
+  it('returns 200 with all fields wrapped in canonical pagination envelope', async () => {
     const fields = [
       { id: 'f1', apiName: 'name', label: 'Name', fieldType: 'text', sortOrder: 1 },
     ];
@@ -211,7 +213,20 @@ describe('GET /admin/objects/:objectId/fields', () => {
 
     expect(mockListFieldDefinitions).toHaveBeenCalledWith('tenant-abc', 'obj-1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(fields);
+    expect(res.json).toHaveBeenCalledWith({
+      data: fields,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, { objectId: 'obj-1' }, { limit: '500' });
+    const res = mockRes();
+
+    await handleListFields(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListFieldDefinitions).not.toHaveBeenCalled();
   });
 
   it('returns 404 when parent object not found', async () => {

--- a/apps/api/src/routes/__tests__/adminLayouts.test.ts
+++ b/apps/api/src/routes/__tests__/adminLayouts.test.ts
@@ -51,9 +51,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = { objectId: 'obj-1' },
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/objects/obj-1/layouts',
     user,
     params,
@@ -192,7 +194,7 @@ describe('GET /admin/objects/:objectId/layouts', () => {
     mockListLayoutDefinitions.mockReset();
   });
 
-  it('returns 200 with all layouts', async () => {
+  it('returns 200 with all layouts wrapped in canonical pagination envelope', async () => {
     const layouts = [
       { id: 'l1', name: 'Default Form', layoutType: 'form', isDefault: true },
     ];
@@ -205,7 +207,20 @@ describe('GET /admin/objects/:objectId/layouts', () => {
 
     expect(mockListLayoutDefinitions).toHaveBeenCalledWith('tenant-abc', 'obj-1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(layouts);
+    expect(res.json).toHaveBeenCalledWith({
+      data: layouts,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, { objectId: 'obj-1' }, { limit: '500' });
+    const res = mockRes();
+
+    await handleListLayouts(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListLayoutDefinitions).not.toHaveBeenCalled();
   });
 
   it('returns 404 when parent object not found', async () => {

--- a/apps/api/src/routes/__tests__/adminObjects.test.ts
+++ b/apps/api/src/routes/__tests__/adminObjects.test.ts
@@ -75,12 +75,14 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = {},
+  query: Record<string, string> = {},
 ) {
   return {
     body,
     path: '/admin/objects',
     user,
     params,
+    query,
   } as unknown as AuthenticatedRequest;
 }
 
@@ -220,7 +222,7 @@ describe('GET /admin/objects', () => {
     mockListObjectDefinitions.mockReset();
   });
 
-  it('returns 200 with all objects', async () => {
+  it('returns 200 with objects wrapped in the canonical pagination envelope', async () => {
     const now = new Date();
     const objects = [
       {
@@ -245,7 +247,20 @@ describe('GET /admin/objects', () => {
     await handleListObjects(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(objects);
+    expect(res.json).toHaveBeenCalledWith({
+      data: objects,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than the max with HTTP 400', async () => {
+    const req = mockReq({}, undefined, {}, { limit: '500' });
+    const res = mockRes();
+
+    await handleListObjects(req, res);
+
+    expect(mockListObjectDefinitions).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('returns 500 when the service throws an unexpected error', async () => {

--- a/apps/api/src/routes/__tests__/adminPageLayouts.test.ts
+++ b/apps/api/src/routes/__tests__/adminPageLayouts.test.ts
@@ -69,9 +69,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = { objectId: 'obj-1' },
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/objects/obj-1/page-layouts',
     user,
     params,
@@ -213,7 +215,7 @@ describe('GET /admin/objects/:objectId/page-layouts', () => {
     mockListPageLayouts.mockReset();
   });
 
-  it('returns 200 with all page layouts', async () => {
+  it('returns 200 with all page layouts wrapped in canonical pagination envelope', async () => {
     const layouts = [
       { id: 'pl1', name: 'Default Page', status: 'published' },
     ];
@@ -226,7 +228,20 @@ describe('GET /admin/objects/:objectId/page-layouts', () => {
 
     expect(mockListPageLayouts).toHaveBeenCalledWith('tenant-abc', 'obj-1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(layouts);
+    expect(res.json).toHaveBeenCalledWith({
+      data: layouts,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, { objectId: 'obj-1' }, { limit: '500' });
+    const res = mockRes();
+
+    await handleListPageLayouts(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListPageLayouts).not.toHaveBeenCalled();
   });
 
   it('returns 404 when parent object not found', async () => {
@@ -468,7 +483,7 @@ describe('GET /admin/objects/:objectId/page-layouts/:id/versions', () => {
     mockListPageLayoutVersions.mockReset();
   });
 
-  it('returns 200 with version history', async () => {
+  it('returns 200 with version history wrapped in canonical pagination envelope', async () => {
     const versions = [
       { id: 'v2', layoutId: 'pl1', version: 2 },
       { id: 'v1', layoutId: 'pl1', version: 1 },
@@ -486,7 +501,25 @@ describe('GET /admin/objects/:objectId/page-layouts/:id/versions', () => {
 
     expect(mockListPageLayoutVersions).toHaveBeenCalledWith('tenant-abc', 'obj-1', 'pl1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(versions);
+    expect(res.json).toHaveBeenCalledWith({
+      data: versions,
+      pagination: { total: 2, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq(
+      {},
+      { userId: 'user-123', tenantId: 'tenant-abc' },
+      { objectId: 'obj-1', id: 'pl1' },
+      { limit: '500' },
+    );
+    const res = mockRes();
+
+    await handleListPageLayoutVersions(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListPageLayoutVersions).not.toHaveBeenCalled();
   });
 
   it('returns 404 when layout not found', async () => {

--- a/apps/api/src/routes/__tests__/adminPipelines.test.ts
+++ b/apps/api/src/routes/__tests__/adminPipelines.test.ts
@@ -60,9 +60,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = {},
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/pipelines',
     user,
     params,
@@ -206,7 +208,7 @@ describe('GET /admin/pipelines', () => {
     mockListPipelines.mockReset();
   });
 
-  it('returns 200 with all pipelines', async () => {
+  it('returns 200 with all pipelines wrapped in canonical pagination envelope', async () => {
     const pipelines = [
       { id: 'p1', name: 'Sales Pipeline', apiName: 'sales_pipeline', isSystem: true },
     ];
@@ -218,7 +220,20 @@ describe('GET /admin/pipelines', () => {
     await handleListPipelines(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(pipelines);
+    expect(res.json).toHaveBeenCalledWith({
+      data: pipelines,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, {}, { limit: '500' });
+    const res = mockRes();
+
+    await handleListPipelines(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListPipelines).not.toHaveBeenCalled();
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/apps/api/src/routes/__tests__/adminRelationships.test.ts
+++ b/apps/api/src/routes/__tests__/adminRelationships.test.ts
@@ -42,9 +42,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = {},
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/relationships',
     user,
     params,
@@ -243,7 +245,20 @@ describe('GET /admin/objects/:objectId/relationships', () => {
 
     expect(mockListRelationshipDefinitions).toHaveBeenCalledWith('tenant-abc', 'obj-1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(relationships);
+    expect(res.json).toHaveBeenCalledWith({
+      data: relationships,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, { objectId: 'obj-1' }, { limit: '500' });
+    const res = mockRes();
+
+    await handleListRelationships(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListRelationshipDefinitions).not.toHaveBeenCalled();
   });
 
   it('returns 404 when object not found', async () => {

--- a/apps/api/src/routes/__tests__/adminStageGates.test.ts
+++ b/apps/api/src/routes/__tests__/adminStageGates.test.ts
@@ -45,9 +45,11 @@ function mockReq(
   body: unknown,
   user = { userId: 'user-123', tenantId: 'tenant-abc' },
   params: Record<string, string> = { stageId: 'stage-1' },
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/admin/stages/stage-1/gates',
     user,
     params,
@@ -79,7 +81,7 @@ describe('GET /admin/stages/:stageId/gates', () => {
     mockListStageGates.mockReset();
   });
 
-  it('returns 200 with all gates for a stage', async () => {
+  it('returns 200 with all gates wrapped in canonical pagination envelope', async () => {
     mockListStageGates.mockResolvedValue([sampleGate]);
 
     const req = mockReq({});
@@ -89,7 +91,20 @@ describe('GET /admin/stages/:stageId/gates', () => {
 
     expect(mockListStageGates).toHaveBeenCalledWith('tenant-abc', 'stage-1');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith([sampleGate]);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [sampleGate],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, undefined, { stageId: 'stage-1' }, { limit: '500' });
+    const res = mockRes();
+
+    await handleListGates(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListStageGates).not.toHaveBeenCalled();
   });
 
   it('returns 404 when stage not found', async () => {

--- a/apps/api/src/routes/__tests__/adminTargets.test.ts
+++ b/apps/api/src/routes/__tests__/adminTargets.test.ts
@@ -182,7 +182,7 @@ describe('GET /admin/targets', () => {
     vi.clearAllMocks();
   });
 
-  it('returns 200 with targets list', async () => {
+  it('returns 200 with targets wrapped in canonical pagination envelope', async () => {
     const targets = [
       { id: 'target-1', target_type: 'business', target_value: 500000 },
       { id: 'target-2', target_type: 'team', target_value: 300000 },
@@ -196,8 +196,21 @@ describe('GET /admin/targets', () => {
     await handleListTargets(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(targets);
+    expect(res.json).toHaveBeenCalledWith({
+      data: targets,
+      pagination: { total: 2, limit: 50, offset: 0, hasMore: false },
+    });
     expect(mockListTargets).toHaveBeenCalledWith('tenant-abc', undefined, undefined);
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, {}, { limit: '500' });
+    const res = mockRes();
+
+    await handleListTargets(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListTargets).not.toHaveBeenCalled();
   });
 
   it('passes period filters to service', async () => {

--- a/apps/api/src/routes/__tests__/adminUsers.test.ts
+++ b/apps/api/src/routes/__tests__/adminUsers.test.ts
@@ -58,9 +58,11 @@ beforeEach(() => {
 function mockReq(
   body: unknown,
   params: Record<string, string> = {},
+  query: Record<string, string> = {},
 ) {
   return {
     body,
+    query,
     path: '/api/admin/users',
     user: {
       userId: 'admin-user-1',
@@ -219,7 +221,20 @@ describe('GET /api/admin/users', () => {
 
     expect(mockListTenantUsers).toHaveBeenCalledWith('acme-corp');
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(users);
+    expect(res.json).toHaveBeenCalledWith({
+      data: users,
+      pagination: { total: 2, limit: 50, offset: 0, hasMore: false },
+    });
+  });
+
+  it('rejects limit greater than MAX_LIMIT with 400', async () => {
+    const req = mockReq({}, {}, { limit: '500' });
+    const res = mockRes();
+
+    await handleListUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockListTenantUsers).not.toHaveBeenCalled();
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/apps/api/src/routes/__tests__/platformTenants.test.ts
+++ b/apps/api/src/routes/__tests__/platformTenants.test.ts
@@ -216,7 +216,7 @@ describe('GET /api/platform/tenants', () => {
     mockListTenants.mockReset();
   });
 
-  it('returns 200 with tenant list', async () => {
+  it('returns 200 with tenant list wrapped in the canonical envelope', async () => {
     mockListTenants.mockResolvedValue({ tenants: [SAMPLE_TENANT], total: 1 });
 
     const req = mockReq({}, {}, { limit: '50', offset: '0' });
@@ -225,22 +225,30 @@ describe('GET /api/platform/tenants', () => {
     await handleListTenants(req, res);
 
     expect(res.json).toHaveBeenCalledWith({
-      tenants: [SAMPLE_TENANT],
-      total: 1,
-      limit: 50,
-      offset: 0,
+      data: [SAMPLE_TENANT],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
     });
   });
 
-  it('clamps limit to 100', async () => {
-    mockListTenants.mockResolvedValue({ tenants: [], total: 0 });
-
+  it('rejects limit greater than the max with HTTP 400', async () => {
     const req = mockReq({}, {}, { limit: '500', offset: '0' });
     const res = mockRes();
 
     await handleListTenants(req, res);
 
-    expect(mockListTenants).toHaveBeenCalledWith(100, 0);
+    expect(mockListTenants).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('uses default limit and offset when not provided', async () => {
+    mockListTenants.mockResolvedValue({ tenants: [], total: 0 });
+
+    const req = mockReq({}, {}, {});
+    const res = mockRes();
+
+    await handleListTenants(req, res);
+
+    expect(mockListTenants).toHaveBeenCalledWith(50, 0);
   });
 
   it('returns 500 on unexpected error', async () => {
@@ -411,7 +419,7 @@ describe('GET /api/platform/tenants/:id/users', () => {
     mockListTenantUsers.mockReset();
   });
 
-  it('returns 200 with user list', async () => {
+  it('returns 200 with paginated user list wrapped in the canonical envelope', async () => {
     const users = [
       { userId: 'U1', loginId: 'admin@acme.com', email: 'admin@acme.com', name: 'John', roles: ['admin'], status: 'enabled', lastLogin: null },
     ];
@@ -423,7 +431,10 @@ describe('GET /api/platform/tenants/:id/users', () => {
     await handleListTenantUsers(req, res);
 
     expect(mockListTenantUsers).toHaveBeenCalledWith('acme-corp');
-    expect(res.json).toHaveBeenCalledWith(users);
+    expect(res.json).toHaveBeenCalledWith({
+      data: users,
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
   });
 
   it('returns 500 on unexpected error', async () => {

--- a/apps/api/src/routes/__tests__/recordRelationships.test.ts
+++ b/apps/api/src/routes/__tests__/recordRelationships.test.ts
@@ -222,17 +222,21 @@ describe('GET /records/:id/related/:objectApiName', () => {
     mockGetRelatedRecords.mockReset();
   });
 
-  it('returns 200 with paginated related records', async () => {
-    const result = {
-      data: [
-        { id: 'rec-2', name: 'Acme Corp', fieldValues: { name: 'Acme Corp' }, createdAt: new Date(), updatedAt: new Date() },
-      ],
-      total: 1,
-      page: 1,
-      limit: 20,
+  it('returns 200 with paginated related records wrapped in the canonical envelope', async () => {
+    const item = {
+      id: 'rec-2',
+      name: 'Acme Corp',
+      fieldValues: { name: 'Acme Corp' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
     };
 
-    mockGetRelatedRecords.mockResolvedValue(result);
+    mockGetRelatedRecords.mockResolvedValue({
+      data: [item],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    });
 
     const req = mockReq(
       {},
@@ -244,30 +248,31 @@ describe('GET /records/:id/related/:objectApiName', () => {
 
     await handleGetRelatedRecords(req, res);
 
-    expect(mockGetRelatedRecords).toHaveBeenCalledWith('tenant-abc', 'rec-uuid', 'account', 'user-123', 1, 20);
+    expect(mockGetRelatedRecords).toHaveBeenCalledWith('tenant-abc', 'rec-uuid', 'account', 'user-123', 50, 0);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(result);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [item],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    });
   });
 
   it('passes pagination params to service', async () => {
-    mockGetRelatedRecords.mockResolvedValue({ data: [], total: 0, page: 2, limit: 10 });
+    mockGetRelatedRecords.mockResolvedValue({ data: [], total: 0, limit: 10, offset: 20 });
 
     const req = mockReq(
       {},
       undefined,
       { id: 'rec-uuid', objectApiName: 'account' },
-      { page: '2', limit: '10' },
+      { limit: '10', offset: '20' },
     );
     const res = mockRes();
 
     await handleGetRelatedRecords(req, res);
 
-    expect(mockGetRelatedRecords).toHaveBeenCalledWith('tenant-abc', 'rec-uuid', 'account', 'user-123', 2, 10);
+    expect(mockGetRelatedRecords).toHaveBeenCalledWith('tenant-abc', 'rec-uuid', 'account', 'user-123', 10, 20);
   });
 
-  it('clamps limit to maximum of 100', async () => {
-    mockGetRelatedRecords.mockResolvedValue({ data: [], total: 0, page: 1, limit: 100 });
-
+  it('rejects limit greater than the max with HTTP 400', async () => {
     const req = mockReq(
       {},
       undefined,
@@ -278,9 +283,8 @@ describe('GET /records/:id/related/:objectApiName', () => {
 
     await handleGetRelatedRecords(req, res);
 
-    expect(mockGetRelatedRecords).toHaveBeenCalledWith(
-      'tenant-abc', 'rec-uuid', 'account', 'user-123', 1, 100,
-    );
+    expect(mockGetRelatedRecords).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('returns 404 when record not found', async () => {

--- a/apps/api/src/routes/__tests__/records.test.ts
+++ b/apps/api/src/routes/__tests__/records.test.ts
@@ -352,13 +352,20 @@ describe('GET /objects/:apiName/records', () => {
     mockListRecords.mockReset();
   });
 
-  it('returns 200 with paginated records', async () => {
+  it('returns 200 with paginated records wrapped in the canonical envelope', async () => {
+    const objectDef = {
+      id: 'obj-id',
+      apiName: 'account',
+      label: 'Account',
+      pluralLabel: 'Accounts',
+      isSystem: true,
+    };
     const result = {
       data: [],
       total: 0,
-      page: 1,
-      limit: 20,
-      object: { id: 'obj-id', apiName: 'account', label: 'Account', pluralLabel: 'Accounts', isSystem: true },
+      limit: 50,
+      offset: 0,
+      object: objectDef,
     };
 
     mockListRecords.mockResolvedValue(result);
@@ -373,23 +380,27 @@ describe('GET /objects/:apiName/records', () => {
       apiName: 'account',
       ownerId: 'user-123',
       search: undefined,
-      page: 1,
-      limit: 20,
+      limit: 50,
+      offset: 0,
       sortBy: undefined,
       sortDir: undefined,
     });
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(result);
+    expect(res.json).toHaveBeenCalledWith({
+      data: [],
+      pagination: { total: 0, limit: 50, offset: 0, hasMore: false },
+      object: objectDef,
+    });
   });
 
   it('passes search and pagination params to service', async () => {
-    mockListRecords.mockResolvedValue({ data: [], total: 0, page: 2, limit: 10, object: {} });
+    mockListRecords.mockResolvedValue({ data: [], total: 0, limit: 10, offset: 20, object: {} });
 
     const req = mockReq(
       {},
       undefined,
       { apiName: 'account' },
-      { search: 'acme', page: '2', limit: '10', sort_by: 'name', sort_dir: 'asc' },
+      { search: 'acme', limit: '10', offset: '20', sort_by: 'name', sort_dir: 'asc' },
     );
     const res = mockRes();
 
@@ -400,24 +411,34 @@ describe('GET /objects/:apiName/records', () => {
       apiName: 'account',
       ownerId: 'user-123',
       search: 'acme',
-      page: 2,
       limit: 10,
+      offset: 20,
       sortBy: 'name',
       sortDir: 'asc',
     });
   });
 
-  it('clamps limit to maximum of 100', async () => {
-    mockListRecords.mockResolvedValue({ data: [], total: 0, page: 1, limit: 100, object: {} });
-
+  it('rejects limit greater than the max with HTTP 400', async () => {
     const req = mockReq({}, undefined, { apiName: 'account' }, { limit: '500' });
     const res = mockRes();
 
     await handleListRecords(req, res);
 
-    expect(mockListRecords).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 100 }),
+    expect(mockListRecords).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'VALIDATION_ERROR' }),
     );
+  });
+
+  it('rejects negative offset with HTTP 400', async () => {
+    const req = mockReq({}, undefined, { apiName: 'account' }, { offset: '-5' });
+    const res = mockRes();
+
+    await handleListRecords(req, res);
+
+    expect(mockListRecords).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('returns 404 when object type not found', async () => {

--- a/apps/api/src/routes/accounts.schema.ts
+++ b/apps/api/src/routes/accounts.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { registry } from '../lib/openapi.js';
 import { commonResponses } from '../lib/openapi.js';
+import { paginatedResponseSchema, PaginationOpenApiQuery } from '../lib/pagination.js';
 
 // Request schemas
 export const CreateAccountRequestSchema = z.object({
@@ -98,24 +99,18 @@ registry.registerPath({
   request: {
     query: z.object({
       search: z.string().optional(),
-      page: z.string().optional(),
-      limit: z.string().optional(),
-    }),
+    }).merge(PaginationOpenApiQuery),
   },
   responses: {
     200: {
       description: 'Paginated list of accounts',
       content: {
         'application/json': {
-          schema: z.object({
-            data: z.array(AccountSchema),
-            total: z.number(),
-            page: z.number(),
-            limit: z.number(),
-          }),
+          schema: paginatedResponseSchema(AccountSchema),
         },
       },
     },
+    400: commonResponses[400],
     401: commonResponses[401],
     403: commonResponses[403],
     500: commonResponses[500],

--- a/apps/api/src/routes/accounts.ts
+++ b/apps/api/src/routes/accounts.ts
@@ -12,6 +12,13 @@ import {
 } from '../services/accountService.js';
 import type { UpdateAccountParams } from '../services/accountService.js';
 import { logger } from '../lib/logger.js';
+import {
+  parsePaginationQuery,
+  paginatedResponse,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+} from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const accountsRouter = Router();
 
@@ -107,11 +114,12 @@ export async function handleCreateAccount(
  *
  * Query parameters:
  *   search?: string — searches name and email (case-insensitive)
- *   page?: number — page number, defaults to 1
- *   limit?: number — results per page, defaults to 20 (max 100)
+ *   limit?:  number — results per page, defaults to {@link DEFAULT_LIMIT} (max {@link MAX_LIMIT})
+ *   offset?: number — results to skip, defaults to 0
  *
  * Responses:
- *   200  – { data: Account[], total: number, page: number, limit: number }
+ *   200  – { data: Account[], pagination: { total, limit, offset, hasMore } }
+ *   400  – invalid pagination parameters (limit > max, negative values, etc.)
  *   401  – missing or invalid Bearer token
  *   403  – authenticated but no active tenant context
  *   500  – unexpected server error
@@ -122,20 +130,31 @@ export async function handleListAccounts(
 ): Promise<void> {
   const { userId: requestingUserId, tenantId } = req.user!;
 
-  const query = req.query as { search?: string; page?: string; limit?: string };
-  const page = Math.max(1, parseInt(query.page ?? '1', 10) || 1);
-  const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20', 10) || 20));
+  const query = req.query as { search?: string; limit?: string; offset?: string };
+
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
 
   try {
     const result = await listAccounts({
       tenantId: tenantId!,
       ownerId: requestingUserId,
       search: query.search,
-      page,
-      limit,
+      limit: pagination.limit,
+      offset: pagination.offset,
     });
 
-    res.status(200).json(result);
+    res.status(200).json(paginatedResponse(result.data, result.total, pagination));
   } catch (err: unknown) {
     logger.error({ err, tenantId, requestingUserId }, 'Unexpected error listing accounts');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/adminFields.ts
+++ b/apps/api/src/routes/adminFields.ts
@@ -12,6 +12,8 @@ import {
 } from '../services/fieldDefinitionService.js';
 import type { UpdateFieldDefinitionParams } from '../services/fieldDefinitionService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminFieldsRouter = Router({ mergeParams: true });
 
@@ -101,10 +103,15 @@ export async function handleCreateField(
 /**
  * GET /admin/objects/:objectId/fields
  *
- * Returns all field definitions for the specified object, ordered by sort_order.
+ * Returns field definitions for the specified object, ordered by sort_order.
+ *
+ * Query parameters:
+ *   limit?:  number — results per page (default 50, max 200)
+ *   offset?: number — results to skip (default 0)
  *
  * Responses:
- *   200  – array of field definitions
+ *   200  – { data, pagination: { total, limit, offset, hasMore } }
+ *   400  – invalid pagination parameters
  *   401  – missing or invalid Bearer token
  *   404  – parent object not found
  *   500  – unexpected server error
@@ -115,9 +122,22 @@ export async function handleListFields(
 ): Promise<void> {
   const { objectId } = req.params as { objectId: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const fields = await listFieldDefinitions(req.user!.tenantId!, objectId);
-    res.status(200).json(fields);
+    res.status(200).json(paginateInMemory(fields, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/adminLayouts.ts
+++ b/apps/api/src/routes/adminLayouts.ts
@@ -13,6 +13,8 @@ import {
 } from '../services/layoutDefinitionService.js';
 import type { UpdateLayoutDefinitionParams, LayoutSectionInput } from '../services/layoutDefinitionService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminLayoutsRouter = Router({ mergeParams: true });
 
@@ -102,9 +104,22 @@ export async function handleListLayouts(
 ): Promise<void> {
   const { objectId } = req.params as { objectId: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const layouts = await listLayoutDefinitions(req.user!.tenantId!, objectId);
-    res.status(200).json(layouts);
+    res.status(200).json(paginateInMemory(layouts, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/adminObjects.ts
+++ b/apps/api/src/routes/adminObjects.ts
@@ -17,6 +17,8 @@ import { adminObjectRelationshipsRouter } from './adminRelationships.js';
 import { adminLayoutsRouter } from './adminLayouts.js';
 import { adminPageLayoutsRouter } from './adminPageLayouts.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminObjectsRouter = Router();
 
@@ -95,13 +97,18 @@ export async function handleCreateObject(
 /**
  * GET /admin/objects
  *
- * Returns all object definitions with field count and record count.
+ * Returns object definitions with field count and record count.
  * Includes both system and custom objects.
  *
  * Requires: valid Bearer token (requireAuth).
  *
+ * Query parameters:
+ *   limit?:  number — results per page (default 50, max 200)
+ *   offset?: number — results to skip (default 0)
+ *
  * Responses:
- *   200  – array of object definitions with counts
+ *   200  – { data, pagination: { total, limit, offset, hasMore } }
+ *   400  – invalid pagination parameters
  *   401  – missing or invalid Bearer token
  *   500  – unexpected server error
  */
@@ -109,9 +116,22 @@ export async function handleListObjects(
   req: AuthenticatedRequest,
   res: Response,
 ): Promise<void> {
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const objects = await listObjectDefinitions(req.user!.tenantId!);
-    res.status(200).json(objects);
+    res.status(200).json(paginateInMemory(objects, pagination));
   } catch (err: unknown) {
     logger.error({ err }, 'Unexpected error listing object definitions');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/adminPageLayouts.ts
+++ b/apps/api/src/routes/adminPageLayouts.ts
@@ -17,6 +17,8 @@ import {
 import type { CreatePageLayoutParams, UpdatePageLayoutParams } from '../services/pageLayoutService.js';
 import { COMPONENT_REGISTRY } from '../lib/componentRegistry.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 import rateLimit from 'express-rate-limit';
 
 const adminPageLayoutsRateLimiter = rateLimit({
@@ -113,9 +115,22 @@ export async function handleListPageLayouts(
 ): Promise<void> {
   const { objectId } = req.params as { objectId: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const layouts = await listPageLayouts(req.user!.tenantId!, objectId);
-    res.status(200).json(layouts);
+    res.status(200).json(paginateInMemory(layouts, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 
@@ -286,9 +301,22 @@ export async function handleListPageLayoutVersions(
 ): Promise<void> {
   const { objectId, id } = req.params as { objectId: string; id: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const versions = await listPageLayoutVersions(req.user!.tenantId!, objectId, id);
-    res.status(200).json(versions);
+    res.status(200).json(paginateInMemory(versions, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/adminPipelines.ts
+++ b/apps/api/src/routes/adminPipelines.ts
@@ -16,6 +16,8 @@ import {
 } from '../services/pipelineService.js';
 import type { UpdatePipelineParams } from '../services/pipelineService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminPipelinesRouter = Router();
 
@@ -107,9 +109,22 @@ export async function handleListPipelines(
   req: AuthenticatedRequest,
   res: Response,
 ): Promise<void> {
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const pipelines = await listPipelines(req.user!.tenantId!);
-    res.status(200).json(pipelines);
+    res.status(200).json(paginateInMemory(pipelines, pagination));
   } catch (err: unknown) {
     logger.error({ err }, 'Unexpected error listing pipelines');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/adminRelationships.ts
+++ b/apps/api/src/routes/adminRelationships.ts
@@ -9,6 +9,8 @@ import {
   deleteRelationshipDefinition,
 } from '../services/relationshipDefinitionService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminRelationshipsRouter = Router();
 export const adminObjectRelationshipsRouter = Router({ mergeParams: true });
@@ -116,9 +118,22 @@ export async function handleListRelationships(
 ): Promise<void> {
   const { objectId } = req.params as { objectId: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const relationships = await listRelationshipDefinitions(req.user!.tenantId!, objectId);
-    res.status(200).json(relationships);
+    res.status(200).json(paginateInMemory(relationships, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/adminStageGates.ts
+++ b/apps/api/src/routes/adminStageGates.ts
@@ -11,6 +11,8 @@ import {
 } from '../services/stageGateService.js';
 import type { UpdateStageGateParams } from '../services/stageGateService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminStageGatesRouter = Router({ mergeParams: true });
 
@@ -31,9 +33,22 @@ export async function handleListGates(
 ): Promise<void> {
   const { stageId } = req.params as { stageId: string };
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const gates = await listStageGates(req.user!.tenantId!, stageId);
-    res.status(200).json(gates);
+    res.status(200).json(paginateInMemory(gates, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/adminTargets.ts
+++ b/apps/api/src/routes/adminTargets.ts
@@ -10,6 +10,8 @@ import {
 } from '../services/salesTargetService.js';
 import type { CreateTargetParams } from '../services/salesTargetService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 import rateLimit from 'express-rate-limit';
 
 export const adminTargetsRouter = Router();
@@ -117,9 +119,22 @@ export async function handleListTargets(
   const periodStart = query.period_start ?? query.periodStart;
   const periodEnd = query.period_end ?? query.periodEnd;
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const targets = await listTargets(req.user!.tenantId!, periodStart, periodEnd);
-    res.status(200).json(targets);
+    res.status(200).json(paginateInMemory(targets, pagination));
   } catch (err: unknown) {
     logger.error({ err }, 'Unexpected error listing targets');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/adminUsers.ts
+++ b/apps/api/src/routes/adminUsers.ts
@@ -11,6 +11,8 @@ import {
   removeUserFromTenant,
 } from '../services/adminUserService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const adminUsersRouter = Router();
 
@@ -88,9 +90,22 @@ export async function handleListUsers(
 ): Promise<void> {
   const tenantId = req.user!.tenantId!;
 
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
   try {
     const users = await listTenantUsers(tenantId);
-    res.status(200).json(users);
+    res.status(200).json(paginateInMemory(users, pagination));
   } catch (err: unknown) {
     logger.error({ err, tenantId }, 'Unexpected error listing tenant users');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/platformTenants.ts
+++ b/apps/api/src/routes/platformTenants.ts
@@ -12,6 +12,8 @@ import {
 } from '../services/tenantProvisioning.js';
 import { listTenantUsers, inviteUser } from '../services/adminUserService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginatedResponse } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const platformTenantsRouter = Router();
 
@@ -84,23 +86,33 @@ export async function handleCreateTenant(
 /**
  * GET /api/platform/tenants
  *
- * Lists all tenants with optional pagination.
+ * Lists all tenants with pagination.
  * Super-admin only.
  *
  * Query params:
- *   limit  – max records to return (default 50, max 100)
+ *   limit  – max records to return (default 50, max 200)
  *   offset – number of records to skip (default 0)
  */
 export async function handleListTenants(
   req: AuthenticatedRequest,
   res: Response,
 ): Promise<void> {
-  const limit = Math.min(parseInt(req.query['limit'] as string || '50', 10) || 50, 100);
-  const offset = Math.max(parseInt(req.query['offset'] as string || '0', 10) || 0, 0);
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
 
   try {
-    const { tenants, total } = await listTenants(limit, offset);
-    res.json({ tenants, total, limit, offset });
+    const { tenants, total } = await listTenants(pagination.limit, pagination.offset);
+    res.json(paginatedResponse(tenants, total, pagination));
   } catch (err: unknown) {
     logger.error({ err }, 'Unexpected error listing tenants');
     res.status(500).json({ error: 'An unexpected error occurred' });
@@ -202,7 +214,7 @@ export async function handleDeleteTenant(
 /**
  * GET /api/platform/tenants/:id/users
  *
- * Lists all users belonging to a specific tenant.
+ * Lists all users belonging to a specific tenant with pagination.
  * Super-admin only.
  */
 export async function handleListTenantUsers(
@@ -212,9 +224,26 @@ export async function handleListTenantUsers(
   const { id } = req.params;
   const tenantId = resolveParam(id);
 
+  let pagination;
   try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
+
+  try {
+    // Descope management SDK returns all users for a tenant in a single call;
+    // paginate in-memory to honour the canonical envelope.
     const users = await listTenantUsers(tenantId);
-    res.json(users);
+    const total = users.length;
+    const page = users.slice(pagination.offset, pagination.offset + pagination.limit);
+    res.json(paginatedResponse(page, total, pagination));
   } catch (err: unknown) {
     logger.error({ err, tenantId }, 'Unexpected error listing tenant users');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/routes/recordRelationships.ts
+++ b/apps/api/src/routes/recordRelationships.ts
@@ -9,6 +9,8 @@ import {
   getRelatedRecords,
 } from '../services/recordRelationshipService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginatedResponse } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 export const recordRelationshipsRouter = Router();
 
@@ -114,11 +116,12 @@ export async function handleUnlinkRecords(
  * Includes name and key field values for display.
  *
  * Query parameters:
- *   page?: number  — page number, defaults to 1
- *   limit?: number — results per page, defaults to 20 (max 100)
+ *   limit?:  number — results per page (default 50, max 200)
+ *   offset?: number — results to skip (default 0)
  *
  * Responses:
- *   200  – { data: RelatedRecordRow[], total, page, limit }
+ *   200  – { data, pagination: { total, limit, offset, hasMore } }
+ *   400  – invalid pagination parameters
  *   401  – missing or invalid Bearer token
  *   403  – no active tenant context
  *   404  – record or object type not found
@@ -131,13 +134,29 @@ export async function handleGetRelatedRecords(
   const { id, objectApiName } = req.params as { id: string; objectApiName: string };
   const { userId: ownerId } = req.user!;
 
-  const query = req.query as { page?: string; limit?: string };
-  const page = Math.max(1, parseInt(query.page ?? '1', 10) || 1);
-  const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20', 10) || 20));
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(req.query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
 
   try {
-    const result = await getRelatedRecords(req.user!.tenantId!, id, objectApiName, ownerId, page, limit);
-    res.status(200).json(result);
+    const result = await getRelatedRecords(
+      req.user!.tenantId!,
+      id,
+      objectApiName,
+      ownerId,
+      pagination.limit,
+      pagination.offset,
+    );
+    res.status(200).json(paginatedResponse(result.data, result.total, pagination));
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/records.schema.ts
+++ b/apps/api/src/routes/records.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { registry } from '../lib/openapi.js';
 import { commonResponses } from '../lib/openapi.js';
+import { PaginationMetaSchema, PaginationOpenApiQuery } from '../lib/pagination.js';
 
 // Request schemas
 const LinkToSchema = z.object({
@@ -93,11 +94,9 @@ registry.registerPath({
     }),
     query: z.object({
       search: z.string().optional(),
-      page: z.string().optional(),
-      limit: z.string().optional(),
       sort_by: z.string().optional(),
       sort_dir: z.enum(['asc', 'desc']).optional(),
-    }),
+    }).merge(PaginationOpenApiQuery),
   },
   responses: {
     200: {
@@ -106,14 +105,13 @@ registry.registerPath({
         'application/json': {
           schema: z.object({
             data: z.array(RecordSchema),
-            total: z.number(),
-            page: z.number(),
-            limit: z.number(),
+            pagination: PaginationMetaSchema,
             object: ObjectDefinitionSummarySchema,
           }),
         },
       },
     },
+    400: commonResponses[400],
     401: commonResponses[401],
     404: commonResponses[404],
     500: commonResponses[500],

--- a/apps/api/src/routes/records.ts
+++ b/apps/api/src/routes/records.ts
@@ -15,6 +15,8 @@ import { convertLead } from '../services/leadConversionService.js';
 import { moveRecordStage } from '../services/stageMovementService.js';
 import type { GateValidationError } from '../services/stageMovementService.js';
 import { logger } from '../lib/logger.js';
+import { parsePaginationQuery, paginatedResponse } from '../lib/pagination.js';
+import { isAppError } from '../lib/appError.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -125,14 +127,15 @@ export async function handleCreateRecord(
  * Supports searching, sorting, and pagination.
  *
  * Query parameters:
- *   search?: string  — matches against name and text/email fields
- *   page?: number    — page number, defaults to 1
- *   limit?: number   — results per page, defaults to 20 (max 100)
- *   sort_by?: string — field api_name or "name"/"created_at"/"updated_at"
+ *   search?: string   — matches against name and text/email fields
+ *   limit?:  number   — results per page (default 50, max 200)
+ *   offset?: number   — number of results to skip (default 0)
+ *   sort_by?: string  — field api_name or "name"/"created_at"/"updated_at"
  *   sort_dir?: string — "asc" or "desc"
  *
  * Responses:
- *   200  – { data: Record[], total, page, limit, object: ObjectDefinition }
+ *   200  – { data, pagination: { total, limit, offset, hasMore }, object }
+ *   400  – invalid pagination parameters
  *   401  – missing or invalid Bearer token
  *   403  – no active tenant context
  *   404  – object type not found
@@ -147,14 +150,24 @@ export async function handleListRecords(
 
   const query = req.query as {
     search?: string;
-    page?: string;
     limit?: string;
+    offset?: string;
     sort_by?: string;
     sort_dir?: string;
   };
 
-  const page = Math.max(1, parseInt(query.page ?? '1', 10) || 1);
-  const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20', 10) || 20));
+  let pagination;
+  try {
+    pagination = parsePaginationQuery(query);
+  } catch (err) {
+    if (isAppError(err)) {
+      res
+        .status(err.statusCode)
+        .json({ error: err.message, code: err.code, ...(err.details ?? {}) });
+      return;
+    }
+    throw err;
+  }
 
   try {
     const result = await listRecords({
@@ -162,13 +175,14 @@ export async function handleListRecords(
       apiName,
       ownerId,
       search: query.search,
-      page,
-      limit,
+      limit: pagination.limit,
+      offset: pagination.offset,
       sortBy: query.sort_by,
       sortDir: query.sort_dir,
     });
 
-    res.status(200).json(result);
+    const envelope = paginatedResponse(result.data, result.total, pagination);
+    res.status(200).json({ ...envelope, object: result.object });
   } catch (err: unknown) {
     const code = (err as Error & { code?: string }).code;
 

--- a/apps/api/src/routes/remaining.schema.ts
+++ b/apps/api/src/routes/remaining.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { registry } from '../lib/openapi.js';
 import { commonResponses } from '../lib/openapi.js';
+import { paginatedResponseSchema, PaginationOpenApiQuery } from '../lib/pagination.js';
 
 // Simple schemas for remaining admin routes
 
@@ -246,12 +247,7 @@ const ProvisionTenantResultSchema = z.object({
   inviteUrl: z.string().optional(),
 }).passthrough();
 
-const ListTenantsResponseSchema = z.object({
-  tenants: z.array(TenantSchema),
-  total: z.number(),
-  limit: z.number(),
-  offset: z.number(),
-});
+const ListTenantsResponseSchema = paginatedResponseSchema(TenantSchema);
 
 registry.registerPath({
   method: 'post',
@@ -279,13 +275,11 @@ registry.registerPath({
   tags: ['Platform - Tenants'],
   security: [{ bearerAuth: [] }],
   request: {
-    query: z.object({
-      limit: z.string().optional(),
-      offset: z.string().optional(),
-    }),
+    query: PaginationOpenApiQuery,
   },
   responses: {
     200: { description: 'Paginated list of tenants', content: { 'application/json': { schema: ListTenantsResponseSchema } } },
+    400: commonResponses[400],
     401: commonResponses[401],
     403: commonResponses[403],
     500: commonResponses[500],
@@ -485,25 +479,18 @@ registry.registerPath({
   security: [{ bearerAuth: [] }],
   request: {
     params: z.object({ id: z.string(), objectApiName: z.string() }),
-    query: z.object({
-      page: z.string().optional(),
-      limit: z.string().optional(),
-    }),
+    query: PaginationOpenApiQuery,
   },
   responses: {
     200: {
       description: 'Paginated related records',
       content: {
         'application/json': {
-          schema: z.object({
-            data: z.array(RelatedRecordRowSchema),
-            total: z.number(),
-            page: z.number(),
-            limit: z.number(),
-          }),
+          schema: paginatedResponseSchema(RelatedRecordRowSchema),
         },
       },
     },
+    400: commonResponses[400],
     401: commonResponses[401],
     403: commonResponses[403],
     404: commonResponses[404],

--- a/apps/api/src/services/__tests__/accountService.test.ts
+++ b/apps/api/src/services/__tests__/accountService.test.ts
@@ -386,13 +386,13 @@ describe('listAccounts', () => {
     const result = await listAccounts({
       tenantId: 'tenant-abc',
       ownerId: 'user-123',
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(2);
     expect(result.total).toBe(2);
-    expect(result.page).toBe(1);
+    expect(result.offset).toBe(0);
     expect(result.limit).toBe(20);
   });
 
@@ -400,8 +400,8 @@ describe('listAccounts', () => {
     const result = await listAccounts({
       tenantId: 'tenant-abc',
       ownerId: 'user-123',
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(0);
@@ -415,8 +415,8 @@ describe('listAccounts', () => {
     const result = await listAccounts({
       tenantId: 'tenant-abc',
       ownerId: 'user-123',
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(1);

--- a/apps/api/src/services/__tests__/recordRelationshipService.test.ts
+++ b/apps/api/src/services/__tests__/recordRelationshipService.test.ts
@@ -355,7 +355,7 @@ describe('getRelatedRecords', () => {
 
   it('throws NOT_FOUND when record does not exist', async () => {
     await expect(
-      getRelatedRecords(TENANT_ID, 'missing-id', 'account', 'user-123', 1, 20),
+      getRelatedRecords(TENANT_ID, 'missing-id', 'account', 'user-123', 20, 0),
     ).rejects.toThrow('Record not found');
   });
 
@@ -363,18 +363,18 @@ describe('getRelatedRecords', () => {
     fakeRecords.set('rec-1', { id: 'rec-1', owner_id: 'user-123', object_id: 'obj-1' });
 
     await expect(
-      getRelatedRecords(TENANT_ID, 'rec-1', 'nonexistent', 'user-123', 1, 20),
+      getRelatedRecords(TENANT_ID, 'rec-1', 'nonexistent', 'user-123', 20, 0),
     ).rejects.toThrow("Object type 'nonexistent' not found");
   });
 
   it('returns empty result for records with no relationships', async () => {
     fakeRecords.set('rec-1', { id: 'rec-1', owner_id: 'user-123', object_id: 'obj-1' });
 
-    const result = await getRelatedRecords(TENANT_ID, 'rec-1', 'account', 'user-123', 1, 20);
+    const result = await getRelatedRecords(TENANT_ID, 'rec-1', 'account', 'user-123', 20, 0);
 
     expect(result.data).toEqual([]);
     expect(result.total).toBe(0);
-    expect(result.page).toBe(1);
+    expect(result.offset).toBe(0);
     expect(result.limit).toBe(20);
   });
 });

--- a/apps/api/src/services/__tests__/recordService.test.ts
+++ b/apps/api/src/services/__tests__/recordService.test.ts
@@ -699,11 +699,11 @@ describe('listRecords', () => {
       tenantId: TENANT_ID,
       apiName: 'account',
       ownerId: 'user-123',
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
-    expect(result.page).toBe(1);
+    expect(result.offset).toBe(0);
     expect(result.limit).toBe(20);
     expect(result.object.apiName).toBe('account');
     expect(Array.isArray(result.data)).toBe(true);
@@ -711,7 +711,7 @@ describe('listRecords', () => {
 
   it('throws NOT_FOUND for unknown object type', async () => {
     await expect(
-      listRecords({ tenantId: TENANT_ID, apiName: 'nonexistent', ownerId: 'user-123', page: 1, limit: 20 }),
+      listRecords({ tenantId: TENANT_ID, apiName: 'nonexistent', ownerId: 'user-123', limit: 20, offset: 0 }),
     ).rejects.toThrow("Object type 'nonexistent' not found");
   });
 });

--- a/apps/api/src/services/__tests__/tenantIsolation.test.ts
+++ b/apps/api/src/services/__tests__/tenantIsolation.test.ts
@@ -372,8 +372,8 @@ describe('Record isolation', () => {
       tenantId: TENANT_A,
       apiName: 'account',
       ownerId: OWNER_A,
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(0);
@@ -414,8 +414,8 @@ describe('Record isolation', () => {
       tenantId: TENANT_B,
       apiName: 'account',
       ownerId: OWNER_B,
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(result.data).toHaveLength(0);
@@ -431,8 +431,8 @@ describe('Record isolation', () => {
       apiName: 'account',
       ownerId: OWNER_A,
       search: 'Shared',
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(resultA.total).toBe(1);
@@ -449,16 +449,16 @@ describe('Record isolation', () => {
       tenantId: TENANT_A,
       apiName: 'account',
       ownerId: OWNER_A,
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     const resultB = await listRecords({
       tenantId: TENANT_B,
       apiName: 'account',
       ownerId: OWNER_B,
-      page: 1,
       limit: 20,
+      offset: 0,
     });
 
     expect(resultA.total).toBe(2);

--- a/apps/api/src/services/accountService.ts
+++ b/apps/api/src/services/accountService.ts
@@ -90,8 +90,8 @@ export interface ListAccountsParams {
   tenantId: string;
   ownerId: string;
   search?: string;
-  page: number;
   limit: number;
+  offset: number;
 }
 
 /**
@@ -107,8 +107,8 @@ export interface AccountListItem extends Account {
 export interface ListAccountsResult {
   data: AccountListItem[];
   total: number;
-  page: number;
   limit: number;
+  offset: number;
 }
 
 // ─── Validation ───────────────────────────────────────────────────────────────
@@ -305,8 +305,7 @@ export async function createAccount(
 export async function listAccounts(
   params: ListAccountsParams,
 ): Promise<ListAccountsResult> {
-  const { tenantId, ownerId, search, page, limit } = params;
-  const offset = (page - 1) * limit;
+  const { tenantId, ownerId, search, limit, offset } = params;
 
   const queryParams: unknown[] = [tenantId, ownerId];
   let whereClause = 'WHERE a.tenant_id = $1 AND a.owner_id = $2';
@@ -335,8 +334,8 @@ export async function listAccounts(
   return {
     data: dataResult.rows.map(rowToAccountListItem),
     total,
-    page,
     limit,
+    offset,
   };
 }
 

--- a/apps/api/src/services/recordRelationshipService.ts
+++ b/apps/api/src/services/recordRelationshipService.ts
@@ -23,8 +23,8 @@ export interface RelatedRecordRow {
 export interface RelatedRecordsResult {
   data: RelatedRecordRow[];
   total: number;
-  page: number;
   limit: number;
+  offset: number;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -240,9 +240,10 @@ export async function getRelatedRecords(
   recordId: string,
   objectApiName: string,
   ownerId: string,
-  page: number,
   limit: number,
+  offset: number,
 ): Promise<RelatedRecordsResult> {
+  void ownerId;
   // Verify the record exists within the tenant
   const recordResult = await pool.query(
     'SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2',
@@ -265,7 +266,6 @@ export async function getRelatedRecords(
   // Find related records in both directions:
   // 1. Records where our record is the source and the target belongs to the specified object type
   // 2. Records where our record is the target and the source belongs to the specified object type
-  const offset = (page - 1) * limit;
 
   const countResult = await pool.query(
     `SELECT COUNT(*) AS total FROM (
@@ -304,5 +304,5 @@ export async function getRelatedRecords(
     rowToRelatedRecord(row),
   );
 
-  return { data, total, page, limit };
+  return { data, total, limit, offset };
 }

--- a/apps/api/src/services/recordService.ts
+++ b/apps/api/src/services/recordService.ts
@@ -81,8 +81,8 @@ export interface RecordDetail extends RecordWithLabels {
 export interface ListRecordsResult {
   data: RecordWithLabels[];
   total: number;
-  page: number;
   limit: number;
+  offset: number;
   object: ObjectDefinitionRow;
 }
 
@@ -672,12 +672,14 @@ export async function listRecords(params: {
   apiName: string;
   ownerId: string;
   search?: string;
-  page: number;
   limit: number;
+  offset: number;
   sortBy?: string;
   sortDir?: string;
 }): Promise<ListRecordsResult> {
-  const { tenantId, apiName, ownerId, search, page, limit, sortBy, sortDir } = params;
+  const { tenantId, apiName, ownerId, search, limit, offset, sortBy, sortDir } = params;
+  // ownerId is currently used via filters at the route/service level (reserved for future scoping)
+  void ownerId;
 
   const objectDef = await resolveObjectByApiName(tenantId, apiName);
   const fieldDefs = await getFieldDefinitions(tenantId, objectDef.id);
@@ -734,7 +736,6 @@ export async function listRecords(params: {
     }
   }
 
-  const offset = (page - 1) * limit;
   queryParams.push(limit, offset);
 
   const dataResult = await pool.query(
@@ -788,7 +789,7 @@ export async function listRecords(params: {
     }
   }
 
-  return { data, total, page, limit, object: objectDef };
+  return { data, total, limit, offset, object: objectDef };
 }
 
 /**

--- a/apps/web/src/__tests__/AccountsPage.test.tsx
+++ b/apps/web/src/__tests__/AccountsPage.test.tsx
@@ -21,7 +21,10 @@ function renderPage() {
 function mockFetchSuccess(data: unknown[] = [], total = 0) {
   vi.mocked(fetch).mockResolvedValue({
     ok: true,
-    json: async () => ({ data, total, page: 1, limit: 20 }),
+    json: async () => ({
+      data,
+      pagination: { total, limit: 20, offset: 0, hasMore: total > data.length },
+    }),
   } as Response);
 }
 
@@ -84,9 +87,7 @@ describe('AccountsPage', () => {
             opportunityCount: 3,
           },
         ],
-        total: 1,
-        page: 1,
-        limit: 20,
+        pagination: { total: 1, limit: 20, offset: 0, hasMore: false },
       }),
     } as Response);
 
@@ -157,9 +158,7 @@ describe('AccountsPage', () => {
           name: `Account ${i}`,
           opportunityCount: 0,
         })),
-        total: 45,
-        page: 1,
-        limit: 20,
+        pagination: { total: 45, limit: 20, offset: 0, hasMore: true },
       }),
     } as Response);
 
@@ -184,9 +183,7 @@ describe('AccountsPage', () => {
             opportunityCount: 1,
           },
         ],
-        total: 1,
-        page: 1,
-        limit: 20,
+        pagination: { total: 1, limit: 20, offset: 0, hasMore: false },
       }),
     } as Response);
 

--- a/apps/web/src/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/__tests__/DashboardPage.test.tsx
@@ -17,13 +17,19 @@ function mockFetchCounts(opportunityTotal = 0, accountTotal = 0) {
       if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity')) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ total: opportunityTotal }),
+          json: async () => ({
+            data: [],
+            pagination: { total: opportunityTotal, limit: 1, offset: 0, hasMore: false },
+          }),
         });
       }
       if (typeof url === 'string' && url.includes('/api/v1/objects/account')) {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ total: accountTotal }),
+          json: async () => ({
+            data: [],
+            pagination: { total: accountTotal, limit: 1, offset: 0, hasMore: false },
+          }),
         });
       }
       return Promise.resolve({ ok: false });

--- a/apps/web/src/__tests__/PlatformTenantsPage.test.tsx
+++ b/apps/web/src/__tests__/PlatformTenantsPage.test.tsx
@@ -21,7 +21,15 @@ function renderPage() {
 function mockFetchSuccess(data: { tenants: unknown[]; total: number }) {
   vi.mocked(fetch).mockResolvedValue({
     ok: true,
-    json: async () => data,
+    json: async () => ({
+      data: data.tenants,
+      pagination: {
+        total: data.total,
+        limit: 50,
+        offset: 0,
+        hasMore: false,
+      },
+    }),
   } as Response);
 }
 

--- a/apps/web/src/__tests__/RecordListPage.test.tsx
+++ b/apps/web/src/__tests__/RecordListPage.test.tsx
@@ -29,18 +29,22 @@ function makeRecordsResponse(
   }> = [],
   total = 0,
 ) {
+  const data = records.map((r) => ({
+    ...r,
+    fieldValues: {},
+    ownerId: 'user-1',
+    ownerName: r.ownerName,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  }));
   return {
-    data: records.map((r) => ({
-      ...r,
-      fieldValues: {},
-      ownerId: 'user-1',
-      ownerName: r.ownerName,
-      createdAt: '2025-01-01T00:00:00Z',
-      updatedAt: '2025-01-01T00:00:00Z',
-    })),
-    total,
-    page: 1,
-    limit: 20,
+    data,
+    pagination: {
+      total,
+      limit: 20,
+      offset: 0,
+      hasMore: total > data.length,
+    },
     object: {
       id: 'obj-1',
       apiName: 'account',
@@ -351,9 +355,7 @@ describe('RecordListPage', () => {
           updatedAt: '2025-01-01T00:00:00Z',
         },
       ],
-      total: 1,
-      page: 1,
-      limit: 20,
+      pagination: { total: 1, limit: 20, offset: 0, hasMore: false },
       object: {
         id: 'obj-1',
         apiName: 'account',

--- a/apps/web/src/__tests__/ViewToggle.test.tsx
+++ b/apps/web/src/__tests__/ViewToggle.test.tsx
@@ -26,9 +26,7 @@ function renderPage(apiName = 'opportunity', initialView?: 'list' | 'pipeline') 
 function makeRecordsResponse(total = 0) {
   return {
     data: [],
-    total,
-    page: 1,
-    limit: 20,
+    pagination: { total, limit: 20, offset: 0, hasMore: false },
     object: {
       id: 'obj-1',
       apiName: 'opportunity',

--- a/apps/web/src/components/InlineRecordForm.tsx
+++ b/apps/web/src/components/InlineRecordForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { FieldInput } from './FieldInput.js';
 import styles from './InlineRecordForm.module.css';
 
@@ -74,10 +74,10 @@ export function InlineRecordForm({
           return;
         }
 
-        const allObjects = (await objRes.json()) as Array<{
+        const allObjects = unwrapList<{
           id: string;
           apiName: string;
-        }>;
+        }>(await objRes.json());
         const obj = allObjects.find((o) => o.apiName === relatedObjectApiName);
         if (!obj || cancelled) {
           setLoading(false);
@@ -93,7 +93,7 @@ export function InlineRecordForm({
           return;
         }
 
-        const fieldDefs = (await fieldsRes.json()) as FieldDefinition[];
+        const fieldDefs = unwrapList<FieldDefinition>(await fieldsRes.json());
 
         // Show only essential fields: required fields and first few fields
         // Exclude formula fields (computed, not user-provided)

--- a/apps/web/src/components/LayoutBuilderTab.tsx
+++ b/apps/web/src/components/LayoutBuilderTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { PrimaryButton } from './PrimaryButton.js';
 import styles from './LayoutBuilderTab.module.css';
 
@@ -202,7 +202,7 @@ export function LayoutBuilderTab({ objectId, fields }: LayoutBuilderTabProps) {
       const response = await api.request(`/api/v1/admin/objects/${objectId}/layouts`);
 
       if (response.ok) {
-        const data = (await response.json()) as LayoutDefinition[];
+        const data = unwrapList<LayoutDefinition>(await response.json());
         setLayouts(data);
 
         setSelectedLayoutId((prev) => {

--- a/apps/web/src/components/ObjectTabs.tsx
+++ b/apps/web/src/components/ObjectTabs.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { ObjectIcon } from './ObjectIcon.js';
 import styles from './ObjectTabs.module.css';
 
@@ -31,12 +31,12 @@ export function ObjectTabs() {
 
         if (cancelled || !response.ok) return;
 
-        const objects = (await response.json()) as Array<{
+        const objects = unwrapList<{
           id: string;
           apiName: string;
           pluralLabel: string;
           icon?: string;
-        }>;
+        }>(await response.json());
 
         if (!cancelled) {
           const HIDDEN_FROM_NAV = new Set(['user', 'team']);

--- a/apps/web/src/components/StageFieldRenderer.tsx
+++ b/apps/web/src/components/StageFieldRenderer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { GateFailureModal } from './GateFailureModal.js';
 import type { GateFailure } from './GateFailureModal.js';
 import styles from './StageFieldRenderer.module.css';
@@ -137,9 +137,9 @@ export function StageFieldRenderer({
           return;
         }
 
-        const pipelines = (await response.json()) as Array<
+        const pipelines = unwrapList<
           PipelineDefinition & { objectId?: string; object_id?: string }
-        >;
+        >(await response.json());
         const match = pipelines.find(
           (p) => (p.objectId ?? p.object_id) === objectId,
         );

--- a/apps/web/src/features/field-builder/hooks/useFieldDefinitions.ts
+++ b/apps/web/src/features/field-builder/hooks/useFieldDefinitions.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../../../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../../../lib/apiClient.js';
 import type {
   FieldDefinition,
   ObjectDefinitionDetail,
@@ -72,7 +72,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
       const response = await api.request(`/api/v1/admin/objects/${objectId}/relationships`);
 
       if (response.ok) {
-        const data = (await response.json()) as RelationshipDefinition[];
+        const data = unwrapList<RelationshipDefinition>(await response.json());
         setRelationships(data);
       } else {
         setRelationshipsError('Failed to load relationships.');
@@ -91,7 +91,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
       const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
-        const data = (await response.json()) as ObjectDefinitionListItem[];
+        const data = unwrapList<ObjectDefinitionListItem>(await response.json());
         setAllObjects(data);
       }
     } catch {
@@ -111,7 +111,7 @@ export function useFieldDefinitions(objectId: string | undefined) {
       const response = await api.request(`/api/v1/admin/objects/${objectId}/page-layouts`);
 
       if (response.ok) {
-        const data = (await response.json()) as PageLayoutListItem[];
+        const data = unwrapList<PageLayoutListItem>(await response.json());
         setPageLayouts(data);
       } else {
         setPageLayoutsError('Failed to load page layouts.');

--- a/apps/web/src/features/page-builder/hooks/usePageLayout.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayout.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../../../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../../../lib/apiClient.js';
 import {
   useSensor,
   useSensors,
@@ -104,7 +104,7 @@ export function usePageLayout(objectId: string | undefined) {
       setFields(objData.fields ?? []);
 
       if (relRes.ok) {
-        const relData = (await relRes.json()) as RelationshipApiItem[];
+        const relData = unwrapList<RelationshipApiItem>(await relRes.json());
         setRelationships(
           relData.map((r) => ({
             id: r.id,
@@ -157,12 +157,12 @@ export function usePageLayout(objectId: string | undefined) {
       }
 
       if (regRes.ok) {
-        const regData = (await regRes.json()) as ComponentDefinition[];
+        const regData = unwrapList<ComponentDefinition>(await regRes.json());
         setRegistry(regData);
       }
 
       if (layoutsRes.ok) {
-        const layoutsData = (await layoutsRes.json()) as PageLayoutListItem[];
+        const layoutsData = unwrapList<PageLayoutListItem>(await layoutsRes.json());
         setAllLayouts(layoutsData);
 
         if (layoutsData.length > 0) {

--- a/apps/web/src/features/page-builder/hooks/usePageLayoutActions.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayoutActions.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../../../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../../../lib/apiClient.js';
 import type {
   BuilderLayout,
   PageLayoutListItem,
@@ -234,7 +234,7 @@ export function usePageLayoutActions({
       );
 
       if (res.ok) {
-        const data = (await res.json()) as VersionEntry[];
+        const data = unwrapList<VersionEntry>(await res.json());
         setVersions(data);
       }
     } catch {

--- a/apps/web/src/features/record-detail/hooks/useRecord.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecord.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../../../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../../../lib/apiClient.js';
 import { usePageLayout } from '../../../usePageLayout.js';
 import { groupFieldsBySection } from '../helpers.js';
 import type {
@@ -59,7 +59,7 @@ export function useRecord(
 
         const objResponse = await api.request('/api/v1/admin/objects');
         if (objResponse.ok) {
-          const allObjects = (await objResponse.json()) as ObjectDefinition[];
+          const allObjects = unwrapList<ObjectDefinition>(await objResponse.json());
           const obj = allObjects.find((o) => o.apiName === apiName);
           if (obj) setObjectDef(obj);
         }
@@ -90,10 +90,10 @@ export function useRecord(
         const objResponse = await api.request('/api/v1/admin/objects');
         if (cancelled || !objResponse.ok) return;
 
-        const allObjects = (await objResponse.json()) as Array<{
+        const allObjects = unwrapList<{
           id: string;
           apiName: string;
-        }>;
+        }>(await objResponse.json());
         const obj = allObjects.find((o) => o.apiName === apiName);
         if (!obj || cancelled) return;
 
@@ -102,7 +102,7 @@ export function useRecord(
         );
         if (cancelled || !layoutsResponse.ok) return;
 
-        const layouts = (await layoutsResponse.json()) as LayoutListItem[];
+        const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
         const formLayout =
           layouts.find((l) => l.layoutType === 'form' && l.isDefault) ??
           layouts.find((l) => l.layoutType === 'form');

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -491,3 +491,43 @@ export async function clearServerSession(): Promise<void> {
     // Best-effort — Descope logout will still clear the client-side session.
   }
 }
+
+// ─── Pagination helpers ─────────────────────────────────────────────────────
+
+/**
+ * Canonical pagination metadata returned by every API list endpoint.
+ */
+export interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+/**
+ * Canonical list-response envelope returned by every API list endpoint.
+ */
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: PaginationMeta;
+}
+
+/**
+ * Extracts the `data` array from a paginated list response. Accepts either
+ * the canonical `{data, pagination}` envelope or a bare array so callers can
+ * tolerate legacy responses during migrations and tests.
+ */
+export function unwrapList<T>(payload: unknown): T[] {
+  if (Array.isArray(payload)) {
+    return payload as T[];
+  }
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'data' in payload &&
+    Array.isArray((payload as { data: unknown }).data)
+  ) {
+    return (payload as { data: T[] }).data;
+  }
+  return [];
+}

--- a/apps/web/src/pages/AccountsPage.tsx
+++ b/apps/web/src/pages/AccountsPage.tsx
@@ -17,11 +17,16 @@ interface AccountListItem {
   opportunityCount: number;
 }
 
+interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
 interface AccountsResponse {
   data: AccountListItem[];
-  total: number;
-  page: number;
-  limit: number;
+  pagination: PaginationMeta;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -81,8 +86,8 @@ export function AccountsPage() {
       setError(null);
 
       const params = new URLSearchParams({
-        page: String(page),
         limit: String(PAGE_SIZE),
+        offset: String((page - 1) * PAGE_SIZE),
       });
       if (debouncedSearch.trim()) {
         params.set('search', debouncedSearch.trim());
@@ -97,7 +102,7 @@ export function AccountsPage() {
           const data = (await response.json()) as AccountsResponse;
           if (!cancelled) {
             setAccounts(data.data);
-            setTotal(data.total);
+            setTotal(data.pagination.total);
           }
         } else {
           if (!cancelled) setError('Failed to load accounts.');

--- a/apps/web/src/pages/AdminTargetsPage.tsx
+++ b/apps/web/src/pages/AdminTargetsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import styles from './AdminTargetsPage.module.css';
 
 /* ── Types ────────────────────────────────────────────────── */
@@ -269,7 +269,7 @@ export function AdminTargetsPage() {
         return;
       }
 
-      const targets = (await response.json()) as SalesTarget[];
+      const targets = unwrapList<SalesTarget>(await response.json());
 
       // Group by type
       const biz = targets.find((t) => t.target_type === 'business');

--- a/apps/web/src/pages/AdminTenantSettingsPage.tsx
+++ b/apps/web/src/pages/AdminTenantSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import styles from './AdminTenantSettingsPage.module.css';
 
 /* ── Types ────────────────────────────────────────────────── */
@@ -138,7 +138,7 @@ export function AdminTenantSettingsPage() {
         }
 
         if (pipelinesRes.ok) {
-          const pipelineData = (await pipelinesRes.json()) as PipelineDefinition[];
+          const pipelineData = unwrapList<PipelineDefinition>(await pipelinesRes.json());
           if (!cancelled) setPipelines(pipelineData);
         }
       } catch {

--- a/apps/web/src/pages/CreateRecordPage.tsx
+++ b/apps/web/src/pages/CreateRecordPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { FieldInput } from '../components/FieldInput.js';
 import { StageFieldRenderer } from '../components/StageFieldRenderer.js';
 import styles from './CreateRecordPage.module.css';
@@ -131,7 +131,7 @@ export function CreateRecordPage() {
           return;
         }
 
-        const allObjects = (await objResponse.json()) as ObjectDefinition[];
+        const allObjects = unwrapList<ObjectDefinition>(await objResponse.json());
         const obj = allObjects.find((o) => o.apiName === apiName);
 
         if (!obj) {
@@ -151,7 +151,7 @@ export function CreateRecordPage() {
 
         let fieldDefs: FieldDefinition[] = [];
         if (fieldsResponse.ok) {
-          fieldDefs = (await fieldsResponse.json()) as FieldDefinition[];
+          fieldDefs = unwrapList<FieldDefinition>(await fieldsResponse.json());
         }
 
         // Fetch layouts
@@ -164,7 +164,7 @@ export function CreateRecordPage() {
         let layoutSections: LayoutSection[] | null = null;
 
         if (layoutsResponse.ok) {
-          const layouts = (await layoutsResponse.json()) as LayoutListItem[];
+          const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
           const formLayout =
             layouts.find((l) => l.layoutType === 'form' && l.isDefault) ??
             layouts.find((l) => l.layoutType === 'form');

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -102,20 +102,20 @@ export function DashboardPage() {
   useEffect(() => {
     if (!sessionToken) return;
 
-    api.request('/api/v1/objects/opportunity/records?limit=1&page=1')
+    api.request('/api/v1/objects/opportunity/records?limit=1&offset=0')
       .then((r) => (r.ok ? r.json() : null))
-      .then((data: { total?: number } | null) => {
-        if (data && typeof data.total === 'number') {
-          setOpportunityCount(data.total);
+      .then((data: { pagination?: { total?: number } } | null) => {
+        if (data?.pagination && typeof data.pagination.total === 'number') {
+          setOpportunityCount(data.pagination.total);
         }
       })
       .catch(() => { /* best-effort */ });
 
-    api.request('/api/v1/objects/account/records?limit=1&page=1')
+    api.request('/api/v1/objects/account/records?limit=1&offset=0')
       .then((r) => (r.ok ? r.json() : null))
-      .then((data: { total?: number } | null) => {
-        if (data && typeof data.total === 'number') {
-          setAccountCount(data.total);
+      .then((data: { pagination?: { total?: number } } | null) => {
+        if (data?.pagination && typeof data.pagination.total === 'number') {
+          setAccountCount(data.pagination.total);
         }
       })
       .catch(() => { /* best-effort */ });

--- a/apps/web/src/pages/ObjectManagerPage.tsx
+++ b/apps/web/src/pages/ObjectManagerPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import { ObjectIcon } from '../components/ObjectIcon.js';
 import { slugify } from '../utils.js';
@@ -125,7 +125,7 @@ export function ObjectManagerPage() {
       const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
-        const data = (await response.json()) as ObjectDefinitionListItem[];
+        const data = unwrapList<ObjectDefinitionListItem>(await response.json());
         setObjects(data);
       } else {
         setError('Failed to load object definitions.');

--- a/apps/web/src/pages/PipelineDetailPage.tsx
+++ b/apps/web/src/pages/PipelineDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import { slugify } from '../utils.js';
 import styles from './PipelineDetailPage.module.css';
@@ -220,7 +220,7 @@ export function PipelineDetailPage() {
       const response = await api.request(`/api/v1/admin/objects/${pipeline.objectId}/fields`);
 
       if (response.ok) {
-        const data = (await response.json()) as FieldOption[];
+        const data = unwrapList<FieldOption>(await response.json());
         setFields(data);
       }
     } catch {
@@ -243,7 +243,7 @@ export function PipelineDetailPage() {
       const response = await api.request(`/api/v1/admin/stages/${stageId}/gates`);
 
       if (response.ok) {
-        const data = (await response.json()) as StageGate[];
+        const data = unwrapList<StageGate>(await response.json());
         setGates(data);
       }
     } catch {

--- a/apps/web/src/pages/PipelineManagerPage.tsx
+++ b/apps/web/src/pages/PipelineManagerPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import { slugify } from '../utils.js';
 import styles from './PipelineManagerPage.module.css';
@@ -97,7 +97,7 @@ export function PipelineManagerPage() {
       const response = await api.request('/api/v1/admin/pipelines');
 
       if (response.ok) {
-        const data = (await response.json()) as PipelineListItem[];
+        const data = unwrapList<PipelineListItem>(await response.json());
         setPipelines(data);
       } else {
         setError('Failed to load pipelines.');
@@ -118,7 +118,7 @@ export function PipelineManagerPage() {
       const response = await api.request('/api/v1/admin/objects');
 
       if (response.ok) {
-        const data = (await response.json()) as ObjectOption[];
+        const data = unwrapList<ObjectOption>(await response.json());
         setObjects(data);
       }
     } catch {

--- a/apps/web/src/pages/PlatformTenantDetailPage.tsx
+++ b/apps/web/src/pages/PlatformTenantDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import styles from './PlatformTenantDetailPage.module.css';
 
@@ -154,7 +154,7 @@ export function PlatformTenantDetailPage() {
       const response = await api.request(`/api/v1/platform/tenants/${id}/users`);
 
       if (response.ok) {
-        const data = (await response.json()) as TenantUser[];
+        const data = unwrapList<TenantUser>(await response.json());
         setUsers(data);
       }
     } catch {

--- a/apps/web/src/pages/PlatformTenantsPage.tsx
+++ b/apps/web/src/pages/PlatformTenantsPage.tsx
@@ -18,8 +18,8 @@ interface TenantListItem {
 }
 
 interface TenantListResponse {
-  tenants: TenantListItem[];
-  total: number;
+  data: TenantListItem[];
+  pagination: { total: number; limit: number; offset: number; hasMore: boolean };
 }
 
 interface CreateTenantForm {
@@ -125,7 +125,7 @@ export function PlatformTenantsPage() {
 
       if (response.ok) {
         const data = (await response.json()) as TenantListResponse;
-        setTenants(data.tenants);
+        setTenants(data.data);
       } else {
         setError('Failed to load tenants.');
       }

--- a/apps/web/src/pages/RecordCreatePage.tsx
+++ b/apps/web/src/pages/RecordCreatePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../lib/apiClient.js';
+import { useApiClient, unwrapList } from '../lib/apiClient.js';
 import { FieldInput } from '../components/FieldInput.js';
 import { StageFieldRenderer } from '../components/StageFieldRenderer.js';
 import { RelationshipSearchDropdown } from '../components/RelationshipSearchDropdown.js';
@@ -267,7 +267,7 @@ export function RecordCreatePage() {
           return;
         }
 
-        const allObjects = (await objResponse.json()) as ObjectDefinition[];
+        const allObjects = unwrapList<ObjectDefinition>(await objResponse.json());
         const obj = allObjects.find((o) => o.apiName === apiName);
 
         if (!obj) {
@@ -289,7 +289,7 @@ export function RecordCreatePage() {
         // Process layouts
         let layoutResolved = false;
         if (layoutsResponse.ok) {
-          const layouts = (await layoutsResponse.json()) as LayoutListItem[];
+          const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
           const formLayout =
             layouts.find((l) => l.layoutType === 'form' && l.isDefault) ??
             layouts.find((l) => l.layoutType === 'form');
@@ -323,7 +323,7 @@ export function RecordCreatePage() {
           if (cancelled) return;
 
           if (fieldsResponse.ok) {
-            const fieldDefs = (await fieldsResponse.json()) as FieldDefinition[];
+            const fieldDefs = unwrapList<FieldDefinition>(await fieldsResponse.json());
             if (fieldDefs.length > 0) {
               setLayoutSections(fieldDefsToLayoutFields(fieldDefs, obj.label));
             }
@@ -332,7 +332,7 @@ export function RecordCreatePage() {
 
         // Process relationships
         if (relsResponse.ok && !cancelled) {
-          const rels = (await relsResponse.json()) as RelationshipDef[];
+          const rels = unwrapList<RelationshipDef>(await relsResponse.json());
           // Only show relationships where this object is the source (lookup from this object)
           const sourceRels = rels.filter(
             (r) => r.sourceObjectId === obj.id,

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useSession } from '@descope/react-sdk';
-import { ApiError, useApiClient } from '../lib/apiClient.js';
+import { ApiError, useApiClient, unwrapList } from '../lib/apiClient.js';
 import { ApiErrorDisplay } from '../components/ApiErrorDisplay.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import { FieldRenderer } from '../components/FieldRenderer.js';
@@ -44,11 +44,16 @@ interface RecordItem {
   updatedAt: string;
 }
 
+interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
 interface RecordsResponse {
   data: RecordItem[];
-  total: number;
-  page: number;
-  limit: number;
+  pagination: PaginationMeta;
   object: ObjectDefinition;
 }
 
@@ -193,10 +198,10 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
         if (!objResponse.ok) return;
 
-        const allObjects = (await objResponse.json()) as Array<{
+        const allObjects = unwrapList<{
           id: string;
           apiName: string;
-        }>;
+        }>(await objResponse.json());
         const obj = allObjects.find((o) => o.apiName === apiName);
         if (!obj || cancelled) return;
 
@@ -211,7 +216,8 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
           })
           .then((pipelines) => {
             if (cancelled || !pipelines) return;
-            const match = (pipelines as Array<{ objectId?: string; object_id?: string }>).find(
+            const list = unwrapList<{ objectId?: string; object_id?: string }>(pipelines);
+            const match = list.find(
               (p) => (p.objectId ?? p.object_id) === obj.id,
             );
             if (!cancelled) setHasPipeline(!!match);
@@ -225,7 +231,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
         if (cancelled || !layoutsResponse.ok) return;
 
-        const layouts = (await layoutsResponse.json()) as LayoutListItem[];
+        const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
         const listLayout = layouts.find(
           (l) => l.layoutType === 'list' && l.isDefault,
         ) ?? layouts.find((l) => l.layoutType === 'list');
@@ -266,8 +272,8 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
       setError(null);
 
       const params = new URLSearchParams({
-        page: String(page),
         limit: String(PAGE_SIZE),
+        offset: String((page - 1) * PAGE_SIZE),
       });
       if (debouncedSearch.trim()) {
         params.set('search', debouncedSearch.trim());
@@ -284,7 +290,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
         if (!cancelled) {
           setRecords(data.data);
-          setTotal(data.total);
+          setTotal(data.pagination.total);
           setObjectDef(data.object);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- All list endpoints now accept `limit`/`offset` query params, default to `limit=50`, reject `limit > 200` with HTTP 400, and return the canonical `{ data, pagination: { total, limit, offset, hasMore } }` envelope.
- New `apps/api/src/lib/pagination.ts` with `parsePaginationQuery`, `paginatedResponse`, `paginateInMemory`, and OpenAPI schemas for the shared envelope.
- Frontend consumers use a shared `unwrapList` helper that tolerates both the envelope and raw arrays, and list pages now page via `limit`/`offset` instead of `page`/`limit`.

## Changes
- **API**: applied pagination to accounts, records, recordRelationships, platformTenants, and every admin route (objects, fields, layouts, pageLayouts, pipelines, relationships, stageGates, targets, users). Validation enforced at the Zod schema layer so malformed params can't reach the service.
- **Web**: updated `RecordListPage`, `AccountsPage`, `DashboardPage`, `PipelineManagerPage`, `ObjectManagerPage`, `AdminTargetsPage`, `PlatformTenants*Page`, `PipelineDetailPage`, `LayoutBuilderTab`, `ObjectTabs`, `StageFieldRenderer`, `InlineRecordForm`, `CreateRecordPage`, `RecordCreatePage`, `useRecord`, `usePageLayout`, `usePageLayoutActions`, `useFieldDefinitions`, and `AdminTenantSettingsPage`.
- **Tests**: added `pagination.test.ts` for the helper (defaults, coercion, rejection of out-of-range/non-numeric/negative/fractional values). Every route test file asserts the new envelope shape and 400 rejection when `limit > MAX_LIMIT`.

## Test plan
- [x] `apps/api` vitest — 1287/1287 passing
- [x] `apps/web` vitest — 634/634 passing
- [x] `apps/api` tsc — clean
- [x] `apps/web` tsc — clean

Resolves Brianclark490/CPCRM#376.

https://claude.ai/code/session_01TfPPAuEAqtXv5TmTYuVVMm