### PR TITLE
Remove local rate limiters from route handlers

### DIFF
--- a/apps/api/src/routes/adminPageLayouts.ts
+++ b/apps/api/src/routes/adminPageLayouts.ts
@@ -19,14 +19,6 @@ import { COMPONENT_REGISTRY } from '../lib/componentRegistry.js';
 import { logger } from '../lib/logger.js';
 import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
 import { isAppError } from '../lib/appError.js';
-import rateLimit from 'express-rate-limit';
-
-const adminPageLayoutsRateLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 export const adminPageLayoutsRouter = Router({ mergeParams: true });
 
@@ -481,15 +473,15 @@ export async function handleRevertLayout(
   }
 }
 
-adminPageLayoutsRouter.post('/', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleCreatePageLayout);
-adminPageLayoutsRouter.get('/', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleListPageLayouts);
-adminPageLayoutsRouter.get('/:id', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleGetPageLayout);
-adminPageLayoutsRouter.put('/:id', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleUpdatePageLayout);
-adminPageLayoutsRouter.post('/:id/publish', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handlePublishPageLayout);
-adminPageLayoutsRouter.get('/:id/versions', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleListPageLayoutVersions);
-adminPageLayoutsRouter.post('/:id/copy', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleCopyLayout);
-adminPageLayoutsRouter.post('/:id/revert', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleRevertLayout);
-adminPageLayoutsRouter.delete('/:id', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleDeletePageLayout);
+adminPageLayoutsRouter.post('/', requireAuth, requireTenant, handleCreatePageLayout);
+adminPageLayoutsRouter.get('/', requireAuth, requireTenant, handleListPageLayouts);
+adminPageLayoutsRouter.get('/:id', requireAuth, requireTenant, handleGetPageLayout);
+adminPageLayoutsRouter.put('/:id', requireAuth, requireTenant, handleUpdatePageLayout);
+adminPageLayoutsRouter.post('/:id/publish', requireAuth, requireTenant, handlePublishPageLayout);
+adminPageLayoutsRouter.get('/:id/versions', requireAuth, requireTenant, handleListPageLayoutVersions);
+adminPageLayoutsRouter.post('/:id/copy', requireAuth, requireTenant, handleCopyLayout);
+adminPageLayoutsRouter.post('/:id/revert', requireAuth, requireTenant, handleRevertLayout);
+adminPageLayoutsRouter.delete('/:id', requireAuth, requireTenant, handleDeletePageLayout);
 
 export const componentRegistryRouter = Router();
-componentRegistryRouter.get('/', requireAuth, adminPageLayoutsRateLimiter, requireTenant, handleGetComponentRegistry);
+componentRegistryRouter.get('/', requireAuth, requireTenant, handleGetComponentRegistry);

--- a/apps/api/src/routes/adminTargets.ts
+++ b/apps/api/src/routes/adminTargets.ts
@@ -12,16 +12,8 @@ import type { CreateTargetParams } from '../services/salesTargetService.js';
 import { logger } from '../lib/logger.js';
 import { parsePaginationQuery, paginateInMemory } from '../lib/pagination.js';
 import { isAppError } from '../lib/appError.js';
-import rateLimit from 'express-rate-limit';
 
 export const adminTargetsRouter = Router();
-
-const adminTargetsLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per window
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
@@ -177,6 +169,6 @@ export async function handleDeleteTarget(
 
 // ─── Route registration ──────────────────────────────────────────────────────
 
-adminTargetsRouter.post('/', requireAuth, requireTenant, adminTargetsLimiter, handleCreateTarget);
-adminTargetsRouter.get('/', requireAuth, requireTenant, adminTargetsLimiter, handleListTargets);
-adminTargetsRouter.delete('/:id', requireAuth, requireTenant, adminTargetsLimiter, handleDeleteTarget);
+adminTargetsRouter.post('/', requireAuth, requireTenant, handleCreateTarget);
+adminTargetsRouter.get('/', requireAuth, requireTenant, handleListTargets);
+adminTargetsRouter.delete('/:id', requireAuth, requireTenant, handleDeleteTarget);

--- a/apps/api/src/routes/pageLayouts.ts
+++ b/apps/api/src/routes/pageLayouts.ts
@@ -5,22 +5,8 @@ import { requireTenant } from '../middleware/tenant.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { pool } from '../db/client.js';
 import { logger } from '../lib/logger.js';
-import rateLimit from 'express-rate-limit';
 
 export const pageLayoutsRouter = Router({ mergeParams: true });
-
-/**
- * Stricter rate limiter for page layout lookups.
- * This endpoint queries the database and should be protected against DoS via
- * excessive lookups. The global limiter (100/min) is too permissive for this
- * expensive operation, so we apply a dedicated limit of 100 req/15 min.
- */
-const pageLayoutsRateLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per 15 minutes
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 /**
  * GET /objects/:apiName/page-layout
@@ -107,7 +93,6 @@ export async function handleGetEffectivePageLayout(
 
 pageLayoutsRouter.get(
   '/',
-  pageLayoutsRateLimiter,
   requireAuth,
   requireTenant,
   handleGetEffectivePageLayout,


### PR DESCRIPTION
## Summary
This PR removes local rate limiting middleware from three route files (`adminPageLayouts.ts`, `pageLayouts.ts`, and `adminTargets.ts`). The rate limiters were defined at the route level and applied to individual endpoints.

## Key Changes
- **adminPageLayouts.ts**: Removed `adminPageLayoutsRateLimiter` (15 min window, 100 req/IP limit) from all 10 route handlers and the component registry endpoint
- **pageLayouts.ts**: Removed `pageLayoutsRateLimiter` (15 min window, 100 req/IP limit) from the page layout lookup endpoint, along with its explanatory comment about protecting against DoS
- **adminTargets.ts**: Removed `adminTargetsLimiter` (15 min window, 100 req/IP limit) from all 3 route handlers

## Implementation Details
All rate limiting middleware instances have been completely removed from route definitions. The routes now only use `requireAuth` and `requireTenant` middleware. This suggests rate limiting is being handled at a higher level (likely globally via a centralized middleware or API gateway) rather than at individual route handlers.

https://claude.ai/code/session_013j6gkwkof2v3BiJbtd5B3K