### PR TITLE
fix(web): unwrap paginated envelope from /admin/pipelines in KanbanBoard

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -318,7 +318,7 @@ describe('KanbanBoard', () => {
     // board into its error state. Render the board against a real-
     // shape response and assert the stages render — which can only
     // happen if unwrapList peeled off `data` successfully.
-    vi.stubGlobal('fetch', mockFetch());
+    mockFetch();
 
     renderBoard();
 

--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -9,6 +9,19 @@ vi.mock('@descope/react-sdk', () => ({
 
 const { useSession } = await import('@descope/react-sdk');
 
+/**
+ * Wraps a list of items in the paginated envelope returned by the real
+ * `/api/v1/admin/pipelines` endpoint (`paginateInMemory`). Using this in
+ * mocks keeps the tests honest about the response shape so regressions
+ * like unwrapping a `.find()` call directly on the envelope are caught.
+ */
+function paginated<T>(items: readonly T[]) {
+  return {
+    data: items,
+    pagination: { total: items.length, limit: 20, offset: 0, hasMore: false },
+  };
+}
+
 const mockPipeline = {
   id: 'pipe-1',
   name: 'Sales Pipeline',
@@ -128,7 +141,7 @@ function mockFetch() {
     if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
       return Promise.resolve({
         ok: true,
-        json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
+        json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
       } as Response);
     }
 
@@ -283,7 +296,7 @@ describe('KanbanBoard', () => {
         if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
-            json: async () => [],
+            json: async () => paginated([]),
           } as Response);
         }
         return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
@@ -294,6 +307,25 @@ describe('KanbanBoard', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('no-pipeline')).toBeInTheDocument();
+    });
+  });
+
+  it('unwraps the paginated envelope returned by /admin/pipelines', async () => {
+    // Regression test for the "Failed to load pipeline configuration"
+    // bug: the admin/pipelines endpoint returns a `{ data, pagination }`
+    // envelope (via paginateInMemory), not a raw array. Calling
+    // `.find()` directly on that object throws TypeError and flips the
+    // board into its error state. Render the board against a real-
+    // shape response and assert the stages render — which can only
+    // happen if unwrapList peeled off `data` successfully.
+    vi.stubGlobal('fetch', mockFetch());
+
+    renderBoard();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByText('Prospecting')).toBeInTheDocument();
+      expect(screen.getByText('Qualification')).toBeInTheDocument();
     });
   });
 
@@ -349,7 +381,7 @@ describe('KanbanBoard', () => {
         if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
-            json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
+            json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
           } as Response);
         }
         if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
@@ -452,7 +484,7 @@ describe('KanbanBoard', () => {
       if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
         return Promise.resolve({
           ok: true,
-          json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
+          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
         } as Response);
       }
       if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
@@ -538,7 +570,7 @@ describe('KanbanBoard', () => {
       if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
         return Promise.resolve({
           ok: true,
-          json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
+          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
         } as Response);
       }
       if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
@@ -627,7 +659,7 @@ describe('KanbanBoard', () => {
         if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
           return Promise.resolve({
             ok: true,
-            json: async () => [{ ...mockPipeline, object_id: 'obj-1' }],
+            json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
           } as Response);
         }
         if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSession } from '@descope/react-sdk';
-import { ApiError, useApiClient } from '../lib/apiClient.js';
+import { ApiError, unwrapList, useApiClient } from '../lib/apiClient.js';
 import { useTenantLocale } from '../useTenantLocale.js';
 import { KanbanCard } from './KanbanCard.js';
 import type { KanbanCardRecord } from './KanbanCard.js';
@@ -228,14 +228,18 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
 
     const loadAll = async () => {
       try {
-        // 1. Find pipeline for this object
+        // 1. Find pipeline for this object. The admin/pipelines endpoint
+        // returns a paginated `{ data, pagination }` envelope, so unwrap
+        // via unwrapList (which also tolerates a bare array for future-
+        // proofing against endpoint shape changes).
         let pipelines: Array<
           PipelineDefinition & { objectId?: string; object_id?: string }
         >;
         try {
-          pipelines = await api.get<
-            Array<PipelineDefinition & { objectId?: string; object_id?: string }>
-          >('/api/v1/admin/pipelines');
+          const payload = await api.get<unknown>('/api/v1/admin/pipelines');
+          pipelines = unwrapList<
+            PipelineDefinition & { objectId?: string; object_id?: string }
+          >(payload);
         } catch {
           if (!cancelled) {
             setError('Failed to load pipeline configuration.');


### PR DESCRIPTION
## Summary

Fixes the "Failed to load pipeline configuration." banner that appears on the Opportunities Pipeline view.

Root cause: `GET /api/v1/admin/pipelines` wraps its result with `paginateInMemory`, so the response body is `{ data, pagination }`, not a raw `PipelineDefinition[]`. `KanbanBoard.loadAll` typed the fetch as `Array<PipelineDefinition>` and called `.find()` directly on the result, which at runtime is the envelope object. `TypeError: pipelines.find is not a function` gets swallowed by the outer catch and surfaces as the error banner.

Every other frontend call site that hits `/admin/pipelines` (AdminTenantSettingsPage, RecordListPage, PipelineManagerPage, StageFieldRenderer) already routes the response through `unwrapList` — KanbanBoard was the only outlier.

## Changes

- `apps/web/src/components/KanbanBoard.tsx` — route the admin/pipelines fetch through `unwrapList`, which tolerates both the paginated envelope and (for future-proofing) a bare array.
- `apps/web/src/__tests__/KanbanBoard.test.tsx` — the existing mocks returned raw arrays, which is why the tests passed despite the production bug. Introduced a `paginated()` helper and wired every `/admin/pipelines` mock through it so the mocks now mirror the real backend contract. Added an explicit regression test (`unwraps the paginated envelope returned by /admin/pipelines`) that asserts the board reaches a rendered state instead of its error state when served the real shape.

## How this was discovered

Manually verified by a human operator during the Phase 3a soak window (#451). The Network tab showed the `/admin/pipelines` request returning 304 (cached, successful), which ruled out a network/auth issue and pointed at post-fetch JS. Tracing through the code path found the shape mismatch.

## Test plan

- [x] `npm run typecheck --workspace @cpcrm/web` — clean
- [x] `npm test --workspace @cpcrm/web` — 635/635 pass
- [ ] After merge + deploy: reload the Opportunities Pipeline view and confirm the board renders instead of showing "Failed to load pipeline configuration."

## Notes

- Unrelated to the Phase 3b Kysely migration (#452). That PR is still on soak until ~2026-04-21.
- This is a frontend-only fix; no API or DB changes. Safe to merge immediately.

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf