### PR TITLE
Migrate pipelineAnalyticsService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/pipelineAnalyticsService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/pipelineAnalyticsService.kysely-sql.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Kysely SQL regression suite for pipelineAnalyticsService.
+ *
+ * Complements `pipelineAnalyticsService.test.ts` (which asserts on return
+ * values and domain behaviour) by asserting directly on the SQL Kysely
+ * emits for each exported service function. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query carries a `tenant_id` filter
+ *      as defence-in-depth against an RLS misconfiguration (ADR-006).
+ *   3. Verify the JSONB aggregates and subquery shape the service depends
+ *      on for the won/lost totals and avg-days-to-close metric.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const OBJECT_ID = 'obj-opportunity-id';
+const PIPELINE_ID = 'pipeline-1';
+const OWNER_ID = 'user-123';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  /** 'pool' = direct pool.query, 'client' = checked-out client */
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    const fakePipelines = new Map<string, Record<string, unknown>>();
+    const fakeStages = new Map<string, Record<string, unknown>>();
+    const fakeRecords = new Map<string, Record<string, unknown>>();
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      // Pipeline lookup
+      if (s.startsWith('SELECT ID, NAME, OBJECT_ID FROM PIPELINE_DEFINITIONS')) {
+        const id = params![0] as string;
+        const row = fakePipelines.get(id);
+        if (row) {
+          return {
+            rows: [{ id: row.id, name: row.name, object_id: row.object_id }],
+          };
+        }
+        return { rows: [] };
+      }
+
+      // Stage list — summary variant (includes default_probability)
+      if (
+        s.includes('STAGE_DEFINITIONS') &&
+        s.includes('DEFAULT_PROBABILITY') &&
+        s.includes('EXPECTED_DAYS')
+      ) {
+        const pipelineId = params![0] as string;
+        const rows = [...fakeStages.values()]
+          .filter((st) => st.pipeline_id === pipelineId)
+          .sort((a, b) => (a.sort_order as number) - (b.sort_order as number));
+        return { rows };
+      }
+
+      // Stage list — velocity variant (no default_probability)
+      if (
+        s.includes('STAGE_DEFINITIONS') &&
+        s.includes('EXPECTED_DAYS') &&
+        !s.includes('DEFAULT_PROBABILITY')
+      ) {
+        const pipelineId = params![0] as string;
+        const rows = [...fakeStages.values()]
+          .filter((st) => st.pipeline_id === pipelineId)
+          .sort((a, b) => (a.sort_order as number) - (b.sort_order as number));
+        return { rows };
+      }
+
+      // Records query for summary
+      if (
+        s.includes('FROM RECORDS') &&
+        s.includes('FIELD_VALUES') &&
+        s.includes('CURRENT_STAGE_ID') &&
+        s.includes('STAGE_ENTERED_AT') &&
+        !s.includes('JOIN') &&
+        !s.includes('DAYS_IN_STAGE')
+      ) {
+        const rows = [...fakeRecords.values()].map((r) => ({
+          id: r.id,
+          field_values: r.field_values,
+          current_stage_id: r.current_stage_id ?? null,
+          stage_entered_at: r.stage_entered_at ?? null,
+        }));
+        return { rows };
+      }
+
+      // Won / Lost aggregates
+      if (s.includes('WON_COUNT') && s.includes('WON_VALUE')) {
+        return { rows: [{ won_count: 0, won_value: '0' }] };
+      }
+      if (s.includes('LOST_COUNT')) {
+        return { rows: [{ lost_count: 0 }] };
+      }
+
+      // Entered counts
+      if (
+        s.includes('TO_STAGE_ID AS STAGE_ID') &&
+        s.includes('ENTERED') &&
+        s.includes('GROUP BY')
+      ) {
+        return { rows: [] };
+      }
+
+      // Exited counts
+      if (
+        s.includes('FROM_STAGE_ID AS STAGE_ID') &&
+        s.includes('EXITED') &&
+        s.includes('GROUP BY')
+      ) {
+        return { rows: [] };
+      }
+
+      // Avg days to close
+      if (s.includes('AVG_DAYS') && s.includes('DURATION_DAYS')) {
+        return { rows: [{ avg_days: '0' }] };
+      }
+
+      // Overdue records
+      if (
+        s.includes('DAYS_IN_STAGE') &&
+        s.includes('STAGE_NAME') &&
+        s.includes('FROM RECORDS')
+      ) {
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+      fakePipelines.clear();
+      fakeStages.clear();
+      fakeRecords.clear();
+
+      fakePipelines.set(PIPELINE_ID, {
+        id: PIPELINE_ID,
+        name: 'Sales Pipeline',
+        object_id: OBJECT_ID,
+      });
+
+      const stages: Array<Record<string, unknown>> = [
+        {
+          id: 'stage-prospect',
+          pipeline_id: PIPELINE_ID,
+          name: 'Prospecting',
+          api_name: 'prospecting',
+          stage_type: 'open',
+          sort_order: 0,
+          default_probability: 10,
+          expected_days: 14,
+        },
+        {
+          id: 'stage-qualification',
+          pipeline_id: PIPELINE_ID,
+          name: 'Qualification',
+          api_name: 'qualification',
+          stage_type: 'open',
+          sort_order: 1,
+          default_probability: 25,
+          expected_days: 14,
+        },
+        {
+          id: 'stage-won',
+          pipeline_id: PIPELINE_ID,
+          name: 'Closed Won',
+          api_name: 'closed_won',
+          stage_type: 'won',
+          sort_order: 2,
+          default_probability: 100,
+          expected_days: null,
+        },
+        {
+          id: 'stage-lost',
+          pipeline_id: PIPELINE_ID,
+          name: 'Closed Lost',
+          api_name: 'closed_lost',
+          stage_type: 'lost',
+          sort_order: 3,
+          default_probability: 0,
+          expected_days: null,
+        },
+      ];
+      for (const st of stages) fakeStages.set(st.id as string, st);
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: {
+    query: mockQuery,
+    connect: mockConnect,
+  },
+}));
+
+const { getPipelineSummary, getPipelineVelocity, getOverdueRecords } =
+  await import('../pipelineAnalyticsService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pipelineAnalyticsService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on getPipelineSummary references tenant_id', async () => {
+    await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on getPipelineVelocity (30d) references tenant_id', async () => {
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, '30d');
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on getPipelineVelocity (all) references tenant_id', async () => {
+    // The `all` period skips the cutoffDate WHERE — make sure the
+    // $if() branch elision does not strip the tenant_id predicate.
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, 'all');
+
+    for (const q of dataQueries()) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on getOverdueRecords references tenant_id', async () => {
+    await getOverdueRecords(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('pipelineAnalyticsService Kysely SQL — generated SQL shape', () => {
+  it('getPipelineSummary issues its won aggregate with JSONB ->> and ::numeric coercions', async () => {
+    await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const wonQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return s.includes('WON_COUNT') && s.includes('WON_VALUE');
+    });
+    expect(wonQueries.length).toBe(1);
+
+    const raw = wonQueries[0]!.sql; // preserve original casing for JSONB keys
+    // JSONB value extraction with the three canonical keys
+    expect(raw).toContain("'value'");
+    expect(raw).toContain("'amount'");
+    expect(raw).toContain("'deal_value'");
+    // Numeric coercion and distinct record count
+    const upper = normalise(raw);
+    expect(upper).toContain('::NUMERIC');
+    expect(upper).toContain('COUNT(DISTINCT');
+    // Joins stage_definitions + records onto stage_history
+    expect(upper).toContain('FROM STAGE_HISTORY');
+    expect(upper).toContain('JOIN STAGE_DEFINITIONS');
+    expect(upper).toContain('JOIN RECORDS');
+  });
+
+  it('getPipelineSummary issues exactly one records query with the pipeline_id OR (object_id AND pipeline_id IS NULL) predicate', async () => {
+    await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const recordQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('FROM RECORDS') &&
+        s.includes('FIELD_VALUES') &&
+        s.includes('CURRENT_STAGE_ID') &&
+        s.includes('STAGE_ENTERED_AT') &&
+        !s.includes('JOIN')
+      );
+    });
+    expect(recordQueries.length).toBe(1);
+
+    const s = normalise(recordQueries[0]!.sql);
+    // OR clause wiring pipeline_id vs object_id fallback
+    expect(s).toContain('PIPELINE_ID');
+    expect(s).toContain('OBJECT_ID');
+    expect(s).toContain('IS NULL');
+    expect(s).toContain('OR');
+  });
+
+  it('getPipelineVelocity issues grouped entered/exited counts from stage_history', async () => {
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, '90d');
+
+    const queries = dataQueries().map((q) => normalise(q.sql));
+
+    const entered = queries.filter(
+      (s) =>
+        s.includes('TO_STAGE_ID AS STAGE_ID') &&
+        s.includes('ENTERED') &&
+        s.includes('GROUP BY'),
+    );
+    const exited = queries.filter(
+      (s) =>
+        s.includes('FROM_STAGE_ID AS STAGE_ID') &&
+        s.includes('EXITED') &&
+        s.includes('GROUP BY'),
+    );
+
+    expect(entered.length).toBe(1);
+    expect(exited.length).toBe(1);
+    // Exited query averages days_in_previous_stage
+    expect(exited[0]).toContain('AVG(SH.DAYS_IN_PREVIOUS_STAGE)');
+    // Exited query filters out NULL from_stage_id
+    expect(exited[0]).toContain('FROM_STAGE_ID IS NOT NULL');
+  });
+
+  it('getPipelineVelocity avg-days-to-close runs a subquery with stage_history self-join', async () => {
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, '30d');
+
+    const avgQuery = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('AVG_DAYS') && s.includes('DURATION_DAYS');
+    });
+    expect(avgQuery).toBeDefined();
+
+    const s = normalise(avgQuery!.sql);
+    // Subquery references the self-joined aliases
+    expect(s).toContain('SH_WON');
+    expect(s).toContain('SH_FIRST');
+    // Uses EXTRACT(EPOCH FROM ...) / 86400 to compute duration
+    expect(s).toContain('EXTRACT(EPOCH FROM');
+    expect(s).toContain('/ 86400');
+    // Joined to stage_definitions and records
+    expect(s).toContain('STAGE_DEFINITIONS');
+    expect(s).toContain('RECORDS');
+    // Wrapping select averages duration_days
+    expect(s).toContain('AVG(DURATION_DAYS)');
+  });
+
+  it('getPipelineVelocity with period=all omits the changed_at cutoff from the entered query', async () => {
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, 'all');
+
+    const entered = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('TO_STAGE_ID AS STAGE_ID') &&
+        s.includes('ENTERED') &&
+        s.includes('GROUP BY')
+      );
+    });
+    expect(entered).toBeDefined();
+    const s = normalise(entered!.sql);
+    expect(s).not.toContain('CHANGED_AT >=');
+  });
+
+  it('getOverdueRecords orders by (days_in_stage - expected_days) DESC and carries the JSONB value fallback', async () => {
+    await getOverdueRecords(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const overdueQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('DAYS_IN_STAGE') &&
+        s.includes('STAGE_NAME') &&
+        s.includes('FROM RECORDS')
+      );
+    });
+    expect(overdueQueries.length).toBe(1);
+
+    const raw = overdueQueries[0]!.sql;
+    const s = normalise(raw);
+
+    // Joins stage_definitions for expected_days / stage name
+    expect(s).toContain('JOIN STAGE_DEFINITIONS');
+    // Overdue predicate present in WHERE
+    expect(s).toContain('EXTRACT(EPOCH FROM (NOW() - R.STAGE_ENTERED_AT))');
+    expect(s).toContain('> SD.EXPECTED_DAYS');
+    // ORDER BY the overdue delta DESC
+    expect(s).toContain('ORDER BY');
+    expect(s).toContain('DESC');
+    // JSONB value fallback across the three canonical keys
+    expect(raw).toContain("'value'");
+    expect(raw).toContain("'amount'");
+    expect(raw).toContain("'deal_value'");
+    expect(s).toContain('::NUMERIC');
+  });
+
+  it('getOverdueRecords WHERE clause carries the pipeline_id OR (object_id AND pipeline_id IS NULL) predicate', async () => {
+    await getOverdueRecords(TENANT_ID, PIPELINE_ID, OWNER_ID);
+
+    const q = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('DAYS_IN_STAGE') &&
+        s.includes('STAGE_NAME') &&
+        s.includes('FROM RECORDS')
+      );
+    });
+    expect(q).toBeDefined();
+    const s = normalise(q!.sql);
+    expect(s).toContain('PIPELINE_ID');
+    expect(s).toContain('OBJECT_ID');
+    expect(s).toContain('IS NULL');
+    expect(s).toContain('OR');
+  });
+});
+
+describe('pipelineAnalyticsService Kysely SQL — no BEGIN/COMMIT (read-only)', () => {
+  it('getPipelineSummary runs without opening a transaction', async () => {
+    await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('getPipelineVelocity runs without opening a transaction', async () => {
+    await getPipelineVelocity(TENANT_ID, PIPELINE_ID, OWNER_ID, '30d');
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('getOverdueRecords runs without opening a transaction', async () => {
+    await getOverdueRecords(TENANT_ID, PIPELINE_ID, OWNER_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/pipelineAnalyticsService.test.ts
+++ b/apps/api/src/services/__tests__/pipelineAnalyticsService.test.ts
@@ -7,6 +7,15 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// NOTE (Phase 3b Kysely migration, issue #445): the service is now on
+// Kysely. The mock below therefore matches Kysely-emitted SQL. Identifier
+// quoting is stripped by the normaliser, matching the pattern used by
+// stageMovementService.test.ts. The test bodies further down are kept
+// semantically unchanged — only the mock router is updated.
+//
+// A dedicated Kysely SQL regression suite lives next door:
+//   apps/api/src/services/__tests__/pipelineAnalyticsService.kysely-sql.test.ts
 
 const {
   fakePipelines,
@@ -14,16 +23,19 @@ const {
   fakeRecords,
   fakeStageHistory,
   mockQuery,
+  mockConnect,
 } = vi.hoisted(() => {
   const fakePipelines = new Map<string, Record<string, unknown>>();
   const fakeStages = new Map<string, Record<string, unknown>>();
   const fakeRecords = new Map<string, Record<string, unknown>>();
   const fakeStageHistory = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(sql: string, params?: unknown[]) {
+    // Strip identifier quotes and normalise whitespace so pattern-matching
+    // is quote-agnostic (Kysely wraps identifiers in "…").
+    const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
-    // SELECT id, name, object_id FROM pipeline_definitions WHERE id = $1
+    // SELECT id, name, object_id FROM pipeline_definitions WHERE id = $1 AND tenant_id = $2
     if (s.startsWith('SELECT ID, NAME, OBJECT_ID FROM PIPELINE_DEFINITIONS WHERE ID')) {
       const id = params![0] as string;
       const row = fakePipelines.get(id);
@@ -48,8 +60,7 @@ const {
       return { rows };
     }
 
-    // SELECT id, name, expected_days FROM stage_definitions WHERE pipeline_id
-    // OR: SELECT id, name, stage_type, expected_days FROM stage_definitions WHERE pipeline_id
+    // SELECT id, name, stage_type, expected_days FROM stage_definitions WHERE pipeline_id (velocity variant)
     if (s.includes('EXPECTED_DAYS') && s.includes('STAGE_DEFINITIONS WHERE PIPELINE_ID') && !s.includes('DEFAULT_PROBABILITY')) {
       const pipelineId = params![0] as string;
       const rows = [...fakeStages.values()]
@@ -59,9 +70,16 @@ const {
       return { rows };
     }
 
-    // Fetch all records for summary (new query pattern — fetches individual records)
-    // Exclude overdue/joined queries by checking for absence of STAGE_DEFINITIONS join
-    if (s.includes('R.FIELD_VALUES') && s.includes('R.CURRENT_STAGE_ID') && s.includes('R.STAGE_ENTERED_AT') && s.includes('R.OBJECT_ID') && !s.includes('JOIN STAGE_DEFINITIONS')) {
+    // Records for summary: SELECT id, field_values, current_stage_id, stage_entered_at
+    //   FROM records WHERE tenant_id = $1 AND (pipeline_id = $2 OR (object_id = $3 AND pipeline_id IS NULL))
+    // Params order: [tenantId, pipelineId, objectId]
+    if (
+      s.includes('FROM RECORDS') &&
+      s.includes('FIELD_VALUES') &&
+      s.includes('CURRENT_STAGE_ID') &&
+      s.includes('STAGE_ENTERED_AT') &&
+      !s.includes('JOIN STAGE_DEFINITIONS')
+    ) {
       const pipelineId = params![1] as string;
       const objectId = params![2] as string;
       const matching = [...fakeRecords.values()].filter(
@@ -77,10 +95,11 @@ const {
       return { rows };
     }
 
-    // Won this month (COUNT DISTINCT + SUM)
+    // Won this month (COUNT DISTINCT + SUM) — emits alias COUNT(DISTINCT sh.record_id)::int AS won_count
+    // Params order: [pipelineId, tenantId, 'won', monthStart]
     if (s.includes('WON_COUNT') && s.includes('WON_VALUE')) {
       const pipelineId = params![0] as string;
-      const monthStart = params![2] as Date;
+      const monthStart = params![3] as Date;
       const wonStageIds = [...fakeStages.values()]
         .filter((st) => st.stage_type === 'won')
         .map((st) => st.id as string);
@@ -105,10 +124,10 @@ const {
       return { rows: [{ won_count: wonCount, won_value: wonValue }] };
     }
 
-    // Lost this month
+    // Lost this month — Params order: [pipelineId, tenantId, 'lost', monthStart]
     if (s.includes('LOST_COUNT')) {
       const pipelineId = params![0] as string;
-      const monthStart = params![2] as Date;
+      const monthStart = params![3] as Date;
       const lostStageIds = [...fakeStages.values()]
         .filter((st) => st.stage_type === 'lost')
         .map((st) => st.id as string);
@@ -130,7 +149,7 @@ const {
       return { rows: [{ lost_count: lostCount }] };
     }
 
-    // Entered count (to_stage_id)
+    // Entered count (to_stage_id) — Kysely emits: sh.to_stage_id as stage_id
     if (s.includes('TO_STAGE_ID AS STAGE_ID') && s.includes('ENTERED') && s.includes('GROUP BY')) {
       const pipelineId = params![0] as string;
       const history = [...fakeStageHistory.values()].filter((h) => {
@@ -173,14 +192,14 @@ const {
       return { rows };
     }
 
-    // Avg days to close
+    // Avg days to close — returned by the wrapping SELECT over the subquery alias
     if (s.includes('AVG_DAYS') && s.includes('DURATION_DAYS')) {
       return { rows: [{ avg_days: 0 }] };
     }
 
-    // Overdue records (for getOverdueRecords)
-    if (s.includes('DAYS_IN_STAGE') && s.includes('STAGE_NAME') && s.includes('RECORDS R')) {
-      const pipelineId = params![0] as string;
+    // Overdue records — Params order: [tenantId, pipelineId, objectId]
+    if (s.includes('DAYS_IN_STAGE') && s.includes('STAGE_NAME') && s.includes('FROM RECORDS')) {
+      const pipelineId = params![1] as string;
       const objectId = params![2] as string;
       const results: Array<Record<string, unknown>> = [];
       for (const r of fakeRecords.values()) {
@@ -217,13 +236,26 @@ const {
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params);
   });
 
-  return { fakePipelines, fakeStages, fakeRecords, fakeStageHistory, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakePipelines, fakeStages, fakeRecords, fakeStageHistory, mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 const {

--- a/apps/api/src/services/pipelineAnalyticsService.ts
+++ b/apps/api/src/services/pipelineAnalyticsService.ts
@@ -488,10 +488,10 @@ export async function getPipelineVelocity(
 
   const avgRow = await db
     .selectFrom(subquery.as('sub'))
-    .select(sql<string>`COALESCE(AVG(duration_days), 0)`.as('avg_days'))
+    .select(sql<number>`COALESCE(AVG(duration_days), 0)`.as('avg_days'))
     .executeTakeFirstOrThrow();
 
-  const avgDaysToClose = Math.round(Number(avgRow.avg_days) || 0);
+  const avgDaysToClose = Math.round(avgRow.avg_days || 0);
 
   logger.info({ pipelineId, ownerId, period }, 'Pipeline velocity generated');
 

--- a/apps/api/src/services/pipelineAnalyticsService.ts
+++ b/apps/api/src/services/pipelineAnalyticsService.ts
@@ -1,5 +1,6 @@
+import { sql } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -91,17 +92,18 @@ async function resolvePipeline(
   tenantId: string,
   pipelineId: string,
 ): Promise<{ id: string; name: string; objectId: string }> {
-  const result = await pool.query(
-    'SELECT id, name, object_id FROM pipeline_definitions WHERE id = $1 AND tenant_id = $2',
-    [pipelineId, tenantId],
-  );
+  const row = await db
+    .selectFrom('pipeline_definitions')
+    .select(['id', 'name', 'object_id'])
+    .where('id', '=', pipelineId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Pipeline not found');
   }
 
-  const row = result.rows[0] as Record<string, unknown>;
-  return { id: row.id as string, name: row.name as string, objectId: row.object_id as string };
+  return { id: row.id, name: row.name, objectId: row.object_id };
 }
 
 /**
@@ -162,12 +164,22 @@ export async function getPipelineSummary(
   const pipeline = await resolvePipeline(tenantId, pipelineId);
 
   // Fetch all stages for this pipeline (include api_name for field_values.stage resolution)
-  const stagesResult = await pool.query(
-    'SELECT id, name, api_name, stage_type, default_probability, expected_days FROM stage_definitions WHERE pipeline_id = $1 AND tenant_id = $2 ORDER BY sort_order ASC',
-    [pipelineId, tenantId],
-  );
+  const stageRows = await db
+    .selectFrom('stage_definitions')
+    .select([
+      'id',
+      'name',
+      'api_name',
+      'stage_type',
+      'default_probability',
+      'expected_days',
+    ])
+    .where('pipeline_id', '=', pipelineId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('sort_order', 'asc')
+    .execute();
 
-  const stages = stagesResult.rows as Array<Record<string, unknown>>;
+  const stages = stageRows as unknown as Array<Record<string, unknown>>;
 
   // Build stage lookup maps for resolving field_values.stage (same logic as kanban board)
   const stageById = new Map<string, Record<string, unknown>>();
@@ -184,15 +196,22 @@ export async function getPipelineSummary(
   // assigned a pipeline_id (created before auto-assignment was working).
   // Scoped to tenant — not owner — so analytics match the kanban board
   // which shows all tenant records.
-  const recordsResult = await pool.query(
-    `SELECT r.id, r.field_values, r.current_stage_id, r.stage_entered_at
-     FROM records r
-     WHERE r.tenant_id = $1
-       AND (r.pipeline_id = $2 OR (r.object_id = $3 AND r.pipeline_id IS NULL))`,
-    [tenantId, pipelineId, pipeline.objectId],
-  );
+  const recordRows = await db
+    .selectFrom('records')
+    .select(['id', 'field_values', 'current_stage_id', 'stage_entered_at'])
+    .where('tenant_id', '=', tenantId)
+    .where((eb) =>
+      eb.or([
+        eb('pipeline_id', '=', pipelineId),
+        eb.and([
+          eb('object_id', '=', pipeline.objectId),
+          eb('pipeline_id', 'is', null),
+        ]),
+      ]),
+    )
+    .execute();
 
-  const records = recordsResult.rows as Array<Record<string, unknown>>;
+  const records = recordRows as unknown as Array<Record<string, unknown>>;
 
   // Calculate per-stage aggregates in application code (mirrors kanban board logic)
   const stageAggregates = new Map<
@@ -273,45 +292,37 @@ export async function getPipelineSummary(
   monthStart.setDate(1);
   monthStart.setHours(0, 0, 0, 0);
 
-  const wonThisMonthResult = await pool.query(
-    `SELECT
-       COUNT(DISTINCT sh.record_id)::int AS won_count,
-       COALESCE(SUM(
-         COALESCE(
-           (r.field_values->>'value')::numeric,
-           (r.field_values->>'amount')::numeric,
-           (r.field_values->>'deal_value')::numeric,
-           0
-         )
-       ), 0) AS won_value
-     FROM stage_history sh
-     JOIN stage_definitions sd ON sd.id = sh.to_stage_id
-     JOIN records r ON r.id = sh.record_id
-     WHERE sh.pipeline_id = $1
-       AND r.tenant_id = $2
-       AND sd.stage_type = 'won'
-       AND sh.changed_at >= $3`,
-    [pipelineId, tenantId, monthStart],
-  );
+  const wonRow = await db
+    .selectFrom('stage_history as sh')
+    .innerJoin('stage_definitions as sd', 'sd.id', 'sh.to_stage_id')
+    .innerJoin('records as r', 'r.id', 'sh.record_id')
+    .where('sh.pipeline_id', '=', pipelineId)
+    .where('r.tenant_id', '=', tenantId)
+    .where('sd.stage_type', '=', 'won')
+    .where('sh.changed_at', '>=', monthStart)
+    .select([
+      sql<number>`COUNT(DISTINCT sh.record_id)::int`.as('won_count'),
+      sql<string>`COALESCE(SUM(COALESCE((r.field_values->>'value')::numeric, (r.field_values->>'amount')::numeric, (r.field_values->>'deal_value')::numeric, 0)), 0)`.as(
+        'won_value',
+      ),
+    ])
+    .executeTakeFirstOrThrow();
 
-  const wonRow = wonThisMonthResult.rows[0] as Record<string, unknown>;
-  const wonThisMonth = (wonRow.won_count as number) ?? 0;
+  const wonThisMonth = Number(wonRow.won_count) || 0;
   const wonValueThisMonth = Number(wonRow.won_value) || 0;
 
-  const lostThisMonthResult = await pool.query(
-    `SELECT COUNT(DISTINCT sh.record_id)::int AS lost_count
-     FROM stage_history sh
-     JOIN stage_definitions sd ON sd.id = sh.to_stage_id
-     JOIN records r ON r.id = sh.record_id
-     WHERE sh.pipeline_id = $1
-       AND r.tenant_id = $2
-       AND sd.stage_type = 'lost'
-       AND sh.changed_at >= $3`,
-    [pipelineId, tenantId, monthStart],
-  );
+  const lostRow = await db
+    .selectFrom('stage_history as sh')
+    .innerJoin('stage_definitions as sd', 'sd.id', 'sh.to_stage_id')
+    .innerJoin('records as r', 'r.id', 'sh.record_id')
+    .where('sh.pipeline_id', '=', pipelineId)
+    .where('r.tenant_id', '=', tenantId)
+    .where('sd.stage_type', '=', 'lost')
+    .where('sh.changed_at', '>=', monthStart)
+    .select(sql<number>`COUNT(DISTINCT sh.record_id)::int`.as('lost_count'))
+    .executeTakeFirstOrThrow();
 
-  const lostRow = lostThisMonthResult.rows[0] as Record<string, unknown>;
-  const lostThisMonth = (lostRow.lost_count as number) ?? 0;
+  const lostThisMonth = Number(lostRow.lost_count) || 0;
 
   logger.info({ pipelineId, ownerId }, 'Pipeline summary generated');
 
@@ -353,62 +364,57 @@ export async function getPipelineVelocity(
   void pipeline; // used for validation only
 
   // Fetch stages
-  const stagesResult = await pool.query(
-    'SELECT id, name, stage_type, expected_days FROM stage_definitions WHERE pipeline_id = $1 AND tenant_id = $2 ORDER BY sort_order ASC',
-    [pipelineId, tenantId],
-  );
-  const stages = stagesResult.rows as Array<Record<string, unknown>>;
+  const stageRows = await db
+    .selectFrom('stage_definitions')
+    .select(['id', 'name', 'stage_type', 'expected_days'])
+    .where('pipeline_id', '=', pipelineId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('sort_order', 'asc')
+    .execute();
+
+  const stages = stageRows as unknown as Array<Record<string, unknown>>;
 
   const days = periodToDays(period);
-
-  // Compute cutoff date as a parameter (null means no date filter)
-  const cutoffDate = days !== null
-    ? new Date(Date.now() - days * 86400 * 1000)
-    : null;
-
-  // Build parameterised date filter clause
-  const dateFilterClause = cutoffDate !== null ? 'AND sh.changed_at >= $3' : '';
-  const baseParams: unknown[] = cutoffDate !== null
-    ? [pipelineId, tenantId, cutoffDate]
-    : [pipelineId, tenantId];
+  const cutoffDate =
+    days !== null ? new Date(Date.now() - days * 86400 * 1000) : null;
 
   // Entered: count of records that transitioned INTO each stage
-  const enteredResult = await pool.query(
-    `SELECT
-       sh.to_stage_id AS stage_id,
-       COUNT(*)::int AS entered
-     FROM stage_history sh
-     JOIN records r ON r.id = sh.record_id
-     WHERE sh.pipeline_id = $1
-       AND r.tenant_id = $2
-       ${dateFilterClause}
-     GROUP BY sh.to_stage_id`,
-    baseParams,
-  );
+  const enteredRows = await db
+    .selectFrom('stage_history as sh')
+    .innerJoin('records as r', 'r.id', 'sh.record_id')
+    .where('sh.pipeline_id', '=', pipelineId)
+    .where('r.tenant_id', '=', tenantId)
+    .$if(cutoffDate !== null, (qb) => qb.where('sh.changed_at', '>=', cutoffDate!))
+    .select([
+      'sh.to_stage_id as stage_id',
+      sql<number>`COUNT(*)::int`.as('entered'),
+    ])
+    .groupBy('sh.to_stage_id')
+    .execute();
 
   const enteredByStage = new Map<string, number>();
-  for (const row of enteredResult.rows as Array<Record<string, unknown>>) {
+  for (const row of enteredRows as unknown as Array<Record<string, unknown>>) {
     enteredByStage.set(row.stage_id as string, row.entered as number);
   }
 
   // Exited: count of records that transitioned FROM each stage + avg days
-  const exitedResult = await pool.query(
-    `SELECT
-       sh.from_stage_id AS stage_id,
-       COUNT(*)::int AS exited,
-       COALESCE(AVG(sh.days_in_previous_stage), 0) AS avg_days
-     FROM stage_history sh
-     JOIN records r ON r.id = sh.record_id
-     WHERE sh.pipeline_id = $1
-       AND r.tenant_id = $2
-       AND sh.from_stage_id IS NOT NULL
-       ${dateFilterClause}
-     GROUP BY sh.from_stage_id`,
-    baseParams,
-  );
+  const exitedRows = await db
+    .selectFrom('stage_history as sh')
+    .innerJoin('records as r', 'r.id', 'sh.record_id')
+    .where('sh.pipeline_id', '=', pipelineId)
+    .where('r.tenant_id', '=', tenantId)
+    .where('sh.from_stage_id', 'is not', null)
+    .$if(cutoffDate !== null, (qb) => qb.where('sh.changed_at', '>=', cutoffDate!))
+    .select([
+      'sh.from_stage_id as stage_id',
+      sql<number>`COUNT(*)::int`.as('exited'),
+      sql<string>`COALESCE(AVG(sh.days_in_previous_stage), 0)`.as('avg_days'),
+    ])
+    .groupBy('sh.from_stage_id')
+    .execute();
 
   const exitedByStage = new Map<string, { exited: number; avgDays: number }>();
-  for (const row of exitedResult.rows as Array<Record<string, unknown>>) {
+  for (const row of exitedRows as unknown as Array<Record<string, unknown>>) {
     exitedByStage.set(row.stage_id as string, {
       exited: row.exited as number,
       avgDays: Math.round(Number(row.avg_days)),
@@ -457,31 +463,35 @@ export async function getPipelineVelocity(
   }
 
   // Avg days to close: average total duration from first stage entry to won stage
-  const wonDateFilterClause = cutoffDate !== null ? 'AND sh_won.changed_at >= $3' : '';
+  const subquery = db
+    .selectFrom('stage_history as sh_won')
+    .innerJoin('stage_definitions as sd_won', 'sd_won.id', 'sh_won.to_stage_id')
+    .innerJoin('records as r', 'r.id', 'sh_won.record_id')
+    .innerJoin('stage_history as sh_first', (join) =>
+      join
+        .onRef('sh_first.record_id', '=', 'sh_won.record_id')
+        .onRef('sh_first.pipeline_id', '=', 'sh_won.pipeline_id'),
+    )
+    .where('sh_won.pipeline_id', '=', pipelineId)
+    .where('r.tenant_id', '=', tenantId)
+    .where('sd_won.stage_type', '=', 'won')
+    .$if(cutoffDate !== null, (qb) =>
+      qb.where('sh_won.changed_at', '>=', cutoffDate!),
+    )
+    .select([
+      'sh_won.record_id',
+      sql<number>`EXTRACT(EPOCH FROM (sh_won.changed_at - MIN(sh_first.changed_at))) / 86400`.as(
+        'duration_days',
+      ),
+    ])
+    .groupBy(['sh_won.record_id', 'sh_won.changed_at']);
 
-  const avgDaysToCloseResult = await pool.query(
-    `SELECT COALESCE(AVG(duration_days), 0) AS avg_days
-     FROM (
-       SELECT
-         sh_won.record_id,
-         EXTRACT(EPOCH FROM (sh_won.changed_at - MIN(sh_first.changed_at))) / 86400 AS duration_days
-       FROM stage_history sh_won
-       JOIN stage_definitions sd_won ON sd_won.id = sh_won.to_stage_id
-       JOIN records r ON r.id = sh_won.record_id
-       JOIN stage_history sh_first ON sh_first.record_id = sh_won.record_id
-         AND sh_first.pipeline_id = sh_won.pipeline_id
-       WHERE sh_won.pipeline_id = $1
-         AND r.tenant_id = $2
-         AND sd_won.stage_type = 'won'
-         ${wonDateFilterClause}
-       GROUP BY sh_won.record_id, sh_won.changed_at
-     ) sub`,
-    baseParams,
-  );
+  const avgRow = await db
+    .selectFrom(subquery.as('sub'))
+    .select(sql<string>`COALESCE(AVG(duration_days), 0)`.as('avg_days'))
+    .executeTakeFirstOrThrow();
 
-  const avgDaysToClose = Math.round(
-    Number((avgDaysToCloseResult.rows[0] as Record<string, unknown>).avg_days) || 0,
-  );
+  const avgDaysToClose = Math.round(Number(avgRow.avg_days) || 0);
 
   logger.info({ pipelineId, ownerId, period }, 'Pipeline velocity generated');
 
@@ -508,34 +518,47 @@ export async function getOverdueRecords(
 ): Promise<OverdueRecord[]> {
   const pipeline = await resolvePipeline(tenantId, pipelineId);
 
-  const result = await pool.query(
-    `SELECT
-       r.id,
-       r.name,
-       COALESCE(
-         (r.field_values->>'value')::numeric,
-         (r.field_values->>'amount')::numeric,
-         (r.field_values->>'deal_value')::numeric
-       ) AS value,
-       EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400 AS days_in_stage,
-       sd.expected_days,
-       sd.name AS stage_name,
-       r.owner_id
-     FROM records r
-     JOIN stage_definitions sd ON sd.id = r.current_stage_id
-     WHERE (r.pipeline_id = $1 OR (r.object_id = $3 AND r.pipeline_id IS NULL))
-       AND r.tenant_id = $2
-       AND r.current_stage_id IS NOT NULL
-       AND sd.expected_days IS NOT NULL
-       AND r.stage_entered_at IS NOT NULL
-       AND EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400 > sd.expected_days
-     ORDER BY (EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400 - sd.expected_days) DESC`,
-    [pipelineId, tenantId, pipeline.objectId],
-  );
+  const rows = await db
+    .selectFrom('records as r')
+    .innerJoin('stage_definitions as sd', 'sd.id', 'r.current_stage_id')
+    .where('r.tenant_id', '=', tenantId)
+    .where('r.current_stage_id', 'is not', null)
+    .where('sd.expected_days', 'is not', null)
+    .where('r.stage_entered_at', 'is not', null)
+    .where((eb) =>
+      eb.or([
+        eb('r.pipeline_id', '=', pipelineId),
+        eb.and([
+          eb('r.object_id', '=', pipeline.objectId),
+          eb('r.pipeline_id', 'is', null),
+        ]),
+      ]),
+    )
+    .where(
+      sql<boolean>`EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400 > sd.expected_days`,
+    )
+    .select([
+      'r.id',
+      'r.name',
+      sql<string | null>`COALESCE((r.field_values->>'value')::numeric, (r.field_values->>'amount')::numeric, (r.field_values->>'deal_value')::numeric)`.as(
+        'value',
+      ),
+      sql<number>`EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400`.as(
+        'days_in_stage',
+      ),
+      'sd.expected_days',
+      'sd.name as stage_name',
+      'r.owner_id',
+    ])
+    .orderBy(
+      sql`(EXTRACT(EPOCH FROM (NOW() - r.stage_entered_at)) / 86400 - sd.expected_days)`,
+      'desc',
+    )
+    .execute();
 
-  logger.info({ pipelineId, ownerId, count: result.rows.length }, 'Overdue records fetched');
+  logger.info({ pipelineId, ownerId, count: rows.length }, 'Overdue records fetched');
 
-  return (result.rows as Array<Record<string, unknown>>).map((row) => ({
+  return (rows as unknown as Array<Record<string, unknown>>).map((row) => ({
     id: row.id as string,
     name: row.name as string,
     value: row.value !== null && row.value !== undefined ? Number(row.value) : null,


### PR DESCRIPTION
## Summary

Next service in [#445](https://github.com/Brianclark490/CPCRM/issues/445) Group A (complex SQL services). Follows the same pattern as the `stageMovementService` migration landed in #452.

Rewrites the three analytics service functions — `getPipelineSummary`, `getPipelineVelocity`, `getOverdueRecords` — on top of Kysely's query builder. PostgreSQL-specific operators (`JSONB ->>`, `::numeric`, `EXTRACT(EPOCH FROM ...)`, `COUNT(DISTINCT)`) use `sql` template literals where the builder has no first-class support.

### Highlights

- `resolvePipeline`, stage lookups, and records queries are fully typed via the existing `kysely.types.ts` interfaces.
- The won/lost month aggregates keep the three-key JSONB fallback (`value` / `amount` / `deal_value`).
- `avg-days-to-close` is emitted as a Kysely subquery (`selectFrom(sub)`) with an `onRef` self-join between `sh_won` and `sh_first`.
- Velocity uses `.$if(cutoffDate !== null, ...)` so the `all` period correctly elides the `changed_at` predicate.
- Overdue records keeps the `pipeline_id OR (object_id AND pipeline_id IS NULL)` fallback so records pre-dating auto-assignment still surface on the dashboard.

### Tests

- **Existing `pipelineAnalyticsService.test.ts`** is updated with a quote-stripping SQL normaliser and fixed param indices (Kysely emits WHERE predicates in a different order than Postgres.js). `mockConnect` is added alongside `mockQuery` so queries routed via the RLS proxy are served from the same fake data router. All 20 existing tests still pass.
- **New `pipelineAnalyticsService.kysely-sql.test.ts`** (14 tests) asserts every emitted query carries a `tenant_id` predicate (ADR-006 defence-in-depth) and pins the JSONB / subquery / `ORDER BY` shapes so refactors catch drift.

## Test plan

- [x] `vitest run src/services/__tests__/pipelineAnalyticsService.test.ts` — 20/20 pass
- [x] `vitest run src/services/__tests__/pipelineAnalyticsService.kysely-sql.test.ts` — 14/14 pass
- [x] Full `apps/api` suite: 63 files, 1342 tests pass
- [x] `tsc --noEmit` clean
- [ ] Copilot review

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf