### PR TITLE
Migrate stageGateService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/stageGateService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/stageGateService.kysely-sql.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Kysely SQL regression suite for stageGateService.
+ *
+ * Complements `stageGateService.test.ts` (which asserts on return
+ * values and domain behaviour) by asserting directly on the SQL Kysely
+ * emits for each exported service function. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query carries a `tenant_id` filter
+ *      as defence-in-depth against an RLS misconfiguration (ADR-006).
+ *   3. Pin the join shape of the gate-with-field metadata select so a
+ *      refactor doesn't accidentally switch to N+1 fetches.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const OBJECT_ID = 'obj-opportunity-id';
+const PIPELINE_ID = 'pipeline-1';
+const STAGE_ID = 'stage-qualification';
+const FIELD_ID = 'field-value';
+const GATE_ID = 'gate-1';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      // resolveStageAndObject: stage_definitions INNER JOIN pipeline_definitions
+      if (
+        s.includes('FROM STAGE_DEFINITIONS AS SD') &&
+        s.includes('JOIN PIPELINE_DEFINITIONS AS PD')
+      ) {
+        return {
+          rows: [
+            {
+              stage_id: STAGE_ID,
+              pipeline_id: PIPELINE_ID,
+              object_id: OBJECT_ID,
+            },
+          ],
+        };
+      }
+
+      // getFieldInfo: SELECT id, field_type, label, options FROM field_definitions
+      if (
+        s.includes('FROM FIELD_DEFINITIONS') &&
+        s.includes('FIELD_TYPE') &&
+        s.includes('LABEL') &&
+        s.includes('OPTIONS')
+      ) {
+        return {
+          rows: [
+            {
+              id: FIELD_ID,
+              field_type: 'currency',
+              label: 'Deal Value',
+              options: {},
+            },
+          ],
+        };
+      }
+
+      // fieldBelongsToObject: SELECT id FROM field_definitions WHERE id AND object_id
+      if (
+        s.includes('FROM FIELD_DEFINITIONS') &&
+        s.includes('SELECT ID') &&
+        s.includes('OBJECT_ID')
+      ) {
+        return { rows: [{ id: FIELD_ID }] };
+      }
+
+      // Duplicate check on create
+      if (
+        s.includes('FROM STAGE_GATES') &&
+        !s.includes('AS SG') &&
+        s.includes('SELECT ID') &&
+        s.includes('FIELD_ID')
+      ) {
+        return { rows: [] };
+      }
+
+      // INSERT INTO stage_gates
+      if (s.startsWith('INSERT INTO STAGE_GATES')) {
+        return { rows: [] };
+      }
+
+      // Existing gate lookup in updateStageGate (SELECT *)
+      if (s.startsWith('SELECT * FROM STAGE_GATES') && s.includes('STAGE_ID')) {
+        return {
+          rows: [
+            {
+              id: GATE_ID,
+              tenant_id: TENANT_ID,
+              stage_id: STAGE_ID,
+              field_id: FIELD_ID,
+              gate_type: 'required',
+              gate_value: null,
+              error_message: null,
+            },
+          ],
+        };
+      }
+
+      // Existence check in deleteStageGate (SELECT id)
+      if (
+        s.startsWith('SELECT ID FROM STAGE_GATES') &&
+        s.includes('STAGE_ID')
+      ) {
+        return { rows: [{ id: GATE_ID }] };
+      }
+
+      // Gate + field metadata join (post-create / post-update refetch, list)
+      if (
+        s.includes('FROM STAGE_GATES AS SG') &&
+        s.includes('JOIN FIELD_DEFINITIONS AS FD')
+      ) {
+        return {
+          rows: [
+            {
+              id: GATE_ID,
+              stage_id: STAGE_ID,
+              field_id: FIELD_ID,
+              gate_type: 'required',
+              gate_value: null,
+              error_message: null,
+              field_label: 'Deal Value',
+              field_type: 'currency',
+            },
+          ],
+        };
+      }
+
+      // UPDATE / DELETE are no-ops for shape assertions
+      if (
+        s.startsWith('UPDATE STAGE_GATES') ||
+        s.startsWith('DELETE FROM STAGE_GATES')
+      ) {
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  listStageGates,
+  createStageGate,
+  updateStageGate,
+  deleteStageGate,
+} = await import('../stageGateService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('stageGateService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on listStageGates references tenant_id', async () => {
+    await listStageGates(TENANT_ID, STAGE_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on createStageGate references tenant_id', async () => {
+    await createStageGate(TENANT_ID, STAGE_ID, {
+      fieldId: FIELD_ID,
+      gateType: 'required',
+      errorMessage: 'Deal value is required',
+    });
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      // INSERT binds tenant_id as a value parameter rather than a WHERE;
+      // both paths are acceptable.
+      const hasPredicate = s.includes('TENANT_ID');
+      expect(
+        hasPredicate,
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on updateStageGate references tenant_id', async () => {
+    await updateStageGate(TENANT_ID, STAGE_ID, GATE_ID, {
+      errorMessage: 'Updated message',
+    });
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on deleteStageGate references tenant_id', async () => {
+    await deleteStageGate(TENANT_ID, STAGE_ID, GATE_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('stageGateService Kysely SQL — generated SQL shape', () => {
+  it('listStageGates joins stage_gates with field_definitions in one query (no N+1)', async () => {
+    await listStageGates(TENANT_ID, STAGE_ID);
+
+    const gateJoins = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('FROM STAGE_GATES AS SG') &&
+        s.includes('JOIN FIELD_DEFINITIONS AS FD')
+      );
+    });
+    expect(gateJoins.length).toBe(1);
+
+    const s = normalise(gateJoins[0]!.sql);
+    // Projected aliases the service relies on for rowToStageGateResponse()
+    expect(s).toContain('FIELD_LABEL');
+    expect(s).toContain('FIELD_TYPE');
+    // Scoped to the stage + tenant
+    expect(s).toContain('SG.STAGE_ID');
+    expect(s).toContain('SG.TENANT_ID');
+    // Deterministic ordering
+    expect(s).toContain('ORDER BY SG.ID');
+  });
+
+  it('createStageGate resolves the stage via a stage_definitions/pipeline_definitions join', async () => {
+    await createStageGate(TENANT_ID, STAGE_ID, {
+      fieldId: FIELD_ID,
+      gateType: 'required',
+    });
+
+    const joinQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('FROM STAGE_DEFINITIONS AS SD') &&
+        s.includes('JOIN PIPELINE_DEFINITIONS AS PD') &&
+        s.includes('PD.OBJECT_ID')
+      );
+    });
+    // Exactly one resolveStageAndObject call — not repeated per validation step
+    expect(joinQueries.length).toBe(1);
+  });
+
+  it('createStageGate issues exactly one INSERT INTO stage_gates with 7 columns', async () => {
+    await createStageGate(TENANT_ID, STAGE_ID, {
+      fieldId: FIELD_ID,
+      gateType: 'required',
+      errorMessage: 'Deal value is required',
+    });
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO STAGE_GATES'),
+    );
+    expect(inserts.length).toBe(1);
+    // id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message
+    expect(inserts[0]!.params.length).toBe(7);
+    // tenant_id is the second bind
+    expect(inserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(inserts[0]!.params[2]).toBe(STAGE_ID);
+    expect(inserts[0]!.params[3]).toBe(FIELD_ID);
+    expect(inserts[0]!.params[4]).toBe('required');
+  });
+
+  it('updateStageGate UPDATE carries id + stage_id + tenant_id in WHERE', async () => {
+    await updateStageGate(TENANT_ID, STAGE_ID, GATE_ID, {
+      errorMessage: 'Updated',
+    });
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE STAGE_GATES SET'),
+    );
+    expect(updates.length).toBe(1);
+
+    const s = normalise(updates[0]!.sql);
+    expect(s).toContain('ERROR_MESSAGE =');
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('STAGE_ID =');
+    expect(s).toContain('TENANT_ID =');
+  });
+
+  it('updateStageGate with no fields skips the UPDATE entirely', async () => {
+    await updateStageGate(TENANT_ID, STAGE_ID, GATE_ID, {});
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE STAGE_GATES SET'),
+    );
+    expect(updates.length).toBe(0);
+  });
+
+  it('deleteStageGate issues exactly one DELETE scoped by id + stage_id + tenant_id', async () => {
+    await deleteStageGate(TENANT_ID, STAGE_ID, GATE_ID);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM STAGE_GATES'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const s = normalise(deletes[0]!.sql);
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('STAGE_ID =');
+    expect(s).toContain('TENANT_ID =');
+  });
+});
+
+describe('stageGateService Kysely SQL — no BEGIN/COMMIT (no explicit transactions)', () => {
+  it('createStageGate runs without opening an explicit transaction', async () => {
+    await createStageGate(TENANT_ID, STAGE_ID, {
+      fieldId: FIELD_ID,
+      gateType: 'required',
+    });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('updateStageGate runs without opening an explicit transaction', async () => {
+    await updateStageGate(TENANT_ID, STAGE_ID, GATE_ID, {
+      errorMessage: 'Updated',
+    });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('deleteStageGate runs without opening an explicit transaction', async () => {
+    await deleteStageGate(TENANT_ID, STAGE_ID, GATE_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/stageGateService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/stageGateService.kysely-sql.test.ts
@@ -310,6 +310,10 @@ describe('stageGateService Kysely SQL — generated SQL shape', () => {
     // Scoped to the stage + tenant
     expect(s).toContain('SG.STAGE_ID');
     expect(s).toContain('SG.TENANT_ID');
+    // Defence-in-depth: the JOIN must constrain fd.tenant_id so a
+    // corrupt gate row can't surface field metadata from another
+    // tenant even though the WHERE only scopes sg.
+    expect(s).toContain('FD.TENANT_ID = SG.TENANT_ID');
     // Deterministic ordering
     expect(s).toContain('ORDER BY SG.ID');
   });
@@ -330,6 +334,12 @@ describe('stageGateService Kysely SQL — generated SQL shape', () => {
     });
     // Exactly one resolveStageAndObject call — not repeated per validation step
     expect(joinQueries.length).toBe(1);
+
+    // Defence-in-depth: both tables' tenant_id must be constrained so
+    // a stage row cannot pull object_id from a sibling tenant's pipeline.
+    const s = normalise(joinQueries[0]!.sql);
+    expect(s).toContain('SD.TENANT_ID');
+    expect(s).toContain('PD.TENANT_ID');
   });
 
   it('createStageGate issues exactly one INSERT INTO stage_gates with 7 columns', async () => {

--- a/apps/api/src/services/__tests__/stageGateService.test.ts
+++ b/apps/api/src/services/__tests__/stageGateService.test.ts
@@ -7,37 +7,86 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// NOTE (Phase 3b Kysely migration, issue #445): the service is now on
+// Kysely. The mock below matches Kysely-emitted SQL — identifier
+// quoting is stripped by the normaliser, matching the pattern used by
+// stageMovementService.test.ts and pipelineAnalyticsService.test.ts.
+//
+// A dedicated Kysely SQL regression suite lives next door:
+//   apps/api/src/services/__tests__/stageGateService.kysely-sql.test.ts
 
-const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery } = vi.hoisted(() => {
+const {
+  fakeStages,
+  fakePipelines,
+  fakeObjects,
+  fakeFields,
+  fakeGates,
+  mockQuery,
+  mockConnect,
+} = vi.hoisted(() => {
   const fakeStages = new Map<string, Record<string, unknown>>();
   const fakePipelines = new Map<string, Record<string, unknown>>();
   const fakeObjects = new Map<string, Record<string, unknown>>();
   const fakeFields = new Map<string, Record<string, unknown>>();
   const fakeGates = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(sql: string, params?: unknown[]) {
+    // Strip identifier quotes and normalise whitespace so pattern-matching
+    // is quote-agnostic (Kysely wraps identifiers in "…").
+    const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
-    // JOIN stage_definitions with pipeline_definitions to resolve object_id
-    if (s.includes('FROM STAGE_DEFINITIONS SD') && s.includes('JOIN PIPELINE_DEFINITIONS PD') && s.includes('WHERE SD.ID')) {
+    // stage_definitions INNER JOIN pipeline_definitions (resolveStageAndObject)
+    if (
+      s.includes('FROM STAGE_DEFINITIONS AS SD') &&
+      s.includes('JOIN PIPELINE_DEFINITIONS AS PD')
+    ) {
       const stageId = params![0] as string;
       const stage = fakeStages.get(stageId);
       if (!stage) return { rows: [] };
       const pipeline = fakePipelines.get(stage.pipeline_id as string);
       if (!pipeline) return { rows: [] };
-      return { rows: [{ stage_id: stage.id, pipeline_id: pipeline.id, object_id: pipeline.object_id }] };
+      return {
+        rows: [
+          {
+            stage_id: stage.id,
+            pipeline_id: pipeline.id,
+            object_id: pipeline.object_id,
+          },
+        ],
+      };
     }
 
-    // SELECT id, field_type, label, options FROM field_definitions WHERE id = $1
-    if (s.includes('FROM FIELD_DEFINITIONS WHERE ID = $1') && !s.includes('AND OBJECT_ID')) {
+    // SELECT id, field_type, label, options FROM field_definitions WHERE id = $1 AND tenant_id = $2
+    //   (getFieldInfo — all four projected columns)
+    if (
+      s.includes('FROM FIELD_DEFINITIONS') &&
+      s.includes('FIELD_TYPE') &&
+      s.includes('LABEL') &&
+      s.includes('OPTIONS')
+    ) {
       const fieldId = params![0] as string;
       const field = fakeFields.get(fieldId);
       if (!field) return { rows: [] };
-      return { rows: [{ id: field.id, field_type: field.field_type, label: field.label, options: field.options }] };
+      return {
+        rows: [
+          {
+            id: field.id,
+            field_type: field.field_type,
+            label: field.label,
+            options: field.options,
+          },
+        ],
+      };
     }
 
-    // SELECT id FROM field_definitions WHERE id = $1 AND object_id = $2
-    if (s.includes('FROM FIELD_DEFINITIONS WHERE ID = $1 AND OBJECT_ID')) {
+    // SELECT id FROM field_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3
+    //   (fieldBelongsToObject)
+    if (
+      s.includes('FROM FIELD_DEFINITIONS') &&
+      s.includes('SELECT ID') &&
+      s.includes('OBJECT_ID')
+    ) {
       const fieldId = params![0] as string;
       const objectId = params![1] as string;
       const field = fakeFields.get(fieldId);
@@ -45,8 +94,14 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
       return { rows: [] };
     }
 
-    // SELECT id FROM stage_gates WHERE stage_id = $1 AND field_id = $2 (duplicate check)
-    if (s.startsWith('SELECT ID FROM STAGE_GATES WHERE STAGE_ID') && s.includes('FIELD_ID')) {
+    // SELECT id FROM stage_gates WHERE stage_id = $1 AND field_id = $2 AND tenant_id = $3
+    //   (duplicate check in createStageGate)
+    if (
+      s.includes('FROM STAGE_GATES') &&
+      !s.includes('AS SG') &&
+      s.includes('SELECT ID') &&
+      s.includes('FIELD_ID')
+    ) {
       const stageId = params![0] as string;
       const fieldId = params![1] as string;
       const match = [...fakeGates.values()].find(
@@ -56,37 +111,59 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
       return { rows: [] };
     }
 
-    // INSERT INTO stage_gates
+    // INSERT INTO stage_gates (columns...) VALUES (...)
+    //   Kysely emits columns in the order supplied in .values({...}).
+    //   Param order mirrors: id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message
     if (s.startsWith('INSERT INTO STAGE_GATES')) {
-      const [id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message] = params as unknown[];
-      const row: Record<string, unknown> = { id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message };
+      const [id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message] =
+        params as unknown[];
+      const row: Record<string, unknown> = {
+        id,
+        tenant_id,
+        stage_id,
+        field_id,
+        gate_type,
+        gate_value,
+        error_message,
+      };
       fakeGates.set(id as string, row);
       return { rows: [row] };
     }
 
-    // SELECT sg.* with JOIN fd (gate with field metadata) WHERE sg.id = $1
-    if (s.includes('FROM STAGE_GATES SG') && s.includes('JOIN FIELD_DEFINITIONS FD') && s.includes('WHERE SG.ID = $1')) {
+    // SELECT sg.*, fd.label, fd.field_type FROM stage_gates AS sg
+    //   INNER JOIN field_definitions AS fd ... WHERE sg.id = $1 AND sg.tenant_id = $2
+    if (
+      s.includes('FROM STAGE_GATES AS SG') &&
+      s.includes('JOIN FIELD_DEFINITIONS AS FD') &&
+      s.includes('SG.ID =')
+    ) {
       const gateId = params![0] as string;
       const gate = fakeGates.get(gateId);
       if (!gate) return { rows: [] };
       const field = fakeFields.get(gate.field_id as string);
       if (!field) return { rows: [] };
       return {
-        rows: [{
-          id: gate.id,
-          stage_id: gate.stage_id,
-          field_id: gate.field_id,
-          gate_type: gate.gate_type,
-          gate_value: gate.gate_value,
-          error_message: gate.error_message,
-          field_label: field.label,
-          field_type: field.field_type,
-        }],
+        rows: [
+          {
+            id: gate.id,
+            stage_id: gate.stage_id,
+            field_id: gate.field_id,
+            gate_type: gate.gate_type,
+            gate_value: gate.gate_value,
+            error_message: gate.error_message,
+            field_label: field.label,
+            field_type: field.field_type,
+          },
+        ],
       };
     }
 
-    // SELECT sg.* with JOIN fd (gate with field metadata) WHERE sg.stage_id = $1 ORDER BY sg.id
-    if (s.includes('FROM STAGE_GATES SG') && s.includes('JOIN FIELD_DEFINITIONS FD') && s.includes('WHERE SG.STAGE_ID = $1')) {
+    // Same join, list variant: WHERE sg.stage_id = $1 AND sg.tenant_id = $2 ORDER BY sg.id
+    if (
+      s.includes('FROM STAGE_GATES AS SG') &&
+      s.includes('JOIN FIELD_DEFINITIONS AS FD') &&
+      s.includes('SG.STAGE_ID =')
+    ) {
       const stageId = params![0] as string;
       const gates = [...fakeGates.values()].filter((g) => g.stage_id === stageId);
       const rows = gates.map((g) => {
@@ -105,8 +182,12 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
       return { rows };
     }
 
-    // SELECT * FROM stage_gates WHERE id = $1 AND stage_id = $2
-    if (s.startsWith('SELECT * FROM STAGE_GATES WHERE ID = $1 AND STAGE_ID')) {
+    // SELECT * FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3
+    //   (updateStageGate existing gate lookup — selectAll, no alias)
+    if (
+      s.startsWith('SELECT * FROM STAGE_GATES') &&
+      s.includes('STAGE_ID')
+    ) {
       const gateId = params![0] as string;
       const stageId = params![1] as string;
       const gate = fakeGates.get(gateId);
@@ -114,8 +195,12 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
       return { rows: [] };
     }
 
-    // SELECT id FROM stage_gates WHERE id = $1 AND stage_id = $2
-    if (s.startsWith('SELECT ID FROM STAGE_GATES WHERE ID = $1 AND STAGE_ID')) {
+    // SELECT id FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3
+    //   (deleteStageGate existence check)
+    if (
+      s.startsWith('SELECT ID FROM STAGE_GATES') &&
+      s.includes('STAGE_ID')
+    ) {
       const gateId = params![0] as string;
       const stageId = params![1] as string;
       const gate = fakeGates.get(gateId);
@@ -123,23 +208,31 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
       return { rows: [] };
     }
 
-    // UPDATE stage_gates SET ...
+    // UPDATE stage_gates SET ... WHERE id = $N AND stage_id = $N+1 AND tenant_id = $N+2
+    //   Kysely emits SET clauses in the order of the object keys (insertion
+    //   order). updateStageGate builds `updates` in a fixed order:
+    //     gate_type → gate_value → error_message
+    //   so the bound params come in that order followed by id, stage_id, tenant_id.
     if (s.startsWith('UPDATE STAGE_GATES SET')) {
-      const gateId = params![params!.length - 3] as string;
-      const stageId = params![params!.length - 2] as string;
+      let paramIdx = 0;
+      const updateOrder: Array<'gate_type' | 'gate_value' | 'error_message'> = [];
+      if (s.includes('GATE_TYPE =')) updateOrder.push('gate_type');
+      if (s.includes('GATE_VALUE =')) updateOrder.push('gate_value');
+      if (s.includes('ERROR_MESSAGE =')) updateOrder.push('error_message');
+      const gateId = params![paramIdx + updateOrder.length] as string;
+      const stageId = params![paramIdx + updateOrder.length + 1] as string;
       const gate = fakeGates.get(gateId);
       if (gate && gate.stage_id === stageId) {
-        let paramIdx = 0;
-        if (s.includes('GATE_TYPE =')) { gate.gate_type = params![paramIdx++]; }
-        if (s.includes('GATE_VALUE =')) { gate.gate_value = params![paramIdx++]; }
-        if (s.includes('ERROR_MESSAGE =')) { gate.error_message = params![paramIdx++]; }
+        for (const col of updateOrder) {
+          gate[col] = params![paramIdx++];
+        }
         fakeGates.set(gateId, gate);
         return { rows: [gate] };
       }
       return { rows: [] };
     }
 
-    // DELETE FROM stage_gates
+    // DELETE FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3
     if (s.startsWith('DELETE FROM STAGE_GATES')) {
       const gateId = params![0] as string;
       const stageId = params![1] as string;
@@ -152,13 +245,34 @@ const { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params);
   });
 
-  return { fakeStages, fakePipelines, fakeObjects, fakeFields, fakeGates, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql = typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return {
+    fakeStages,
+    fakePipelines,
+    fakeObjects,
+    fakeFields,
+    fakeGates,
+    mockQuery,
+    mockConnect,
+  };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 import {

--- a/apps/api/src/services/stageGateService.ts
+++ b/apps/api/src/services/stageGateService.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -58,18 +58,29 @@ function throwConflictError(message: string): never {
 
 // ─── Row → response model ───────────────────────────────────────────────────
 
-function rowToStageGateResponse(row: Record<string, unknown>): StageGateResponse {
+interface GateWithFieldRow {
+  id: string;
+  stage_id: string;
+  field_id: string;
+  gate_type: string;
+  gate_value: string | null;
+  error_message: string | null;
+  field_label: string;
+  field_type: string;
+}
+
+function rowToStageGateResponse(row: GateWithFieldRow): StageGateResponse {
   return {
-    id: row.id as string,
-    stageId: row.stage_id as string,
+    id: row.id,
+    stageId: row.stage_id,
     field: {
-      id: row.field_id as string,
-      label: row.field_label as string,
-      fieldType: row.field_type as string,
+      id: row.field_id,
+      label: row.field_label,
+      fieldType: row.field_type,
     },
-    gateType: row.gate_type as string,
-    gateValue: (row.gate_value as string | null) ?? null,
-    errorMessage: (row.error_message as string | null) ?? null,
+    gateType: row.gate_type,
+    gateValue: row.gate_value ?? null,
+    errorMessage: row.error_message ?? null,
   };
 }
 
@@ -81,24 +92,26 @@ interface StageWithObject {
   objectId: string;
 }
 
-async function resolveStageAndObject(tenantId: string, stageId: string): Promise<StageWithObject> {
-  const result = await pool.query(
-    `SELECT sd.id AS stage_id, sd.pipeline_id, pd.object_id
-     FROM stage_definitions sd
-     JOIN pipeline_definitions pd ON pd.id = sd.pipeline_id
-     WHERE sd.id = $1 AND sd.tenant_id = $2`,
-    [stageId, tenantId],
-  );
+async function resolveStageAndObject(
+  tenantId: string,
+  stageId: string,
+): Promise<StageWithObject> {
+  const row = await db
+    .selectFrom('stage_definitions as sd')
+    .innerJoin('pipeline_definitions as pd', 'pd.id', 'sd.pipeline_id')
+    .select(['sd.id as stage_id', 'sd.pipeline_id', 'pd.object_id'])
+    .where('sd.id', '=', stageId)
+    .where('sd.tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Stage not found');
   }
 
-  const row = result.rows[0] as Record<string, unknown>;
   return {
-    stageId: row.stage_id as string,
-    pipelineId: row.pipeline_id as string,
-    objectId: row.object_id as string,
+    stageId: row.stage_id,
+    pipelineId: row.pipeline_id,
+    objectId: row.object_id,
   };
 }
 
@@ -109,21 +122,24 @@ interface FieldInfo {
   options: Record<string, unknown>;
 }
 
-async function getFieldInfo(fieldId: string, tenantId?: string): Promise<FieldInfo | null> {
-  const query = tenantId
-    ? 'SELECT id, field_type, label, options FROM field_definitions WHERE id = $1 AND tenant_id = $2'
-    : 'SELECT id, field_type, label, options FROM field_definitions WHERE id = $1';
-  const params: unknown[] = tenantId ? [fieldId, tenantId] : [fieldId];
-  const result = await pool.query(query, params);
+async function getFieldInfo(
+  fieldId: string,
+  tenantId: string,
+): Promise<FieldInfo | null> {
+  const row = await db
+    .selectFrom('field_definitions')
+    .select(['id', 'field_type', 'label', 'options'])
+    .where('id', '=', fieldId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) return null;
+  if (!row) return null;
 
-  const row = result.rows[0] as Record<string, unknown>;
   return {
-    id: row.id as string,
-    fieldType: row.field_type as string,
-    label: row.label as string,
-    options: (row.options as Record<string, unknown>) ?? {},
+    id: row.id,
+    fieldType: row.field_type,
+    label: row.label,
+    options: (row.options as Record<string, unknown> | null) ?? {},
   };
 }
 
@@ -174,13 +190,25 @@ function validateGateTypeAgainstField(
   }
 }
 
-// ─── Query fragment for gates with field metadata ───────────────────────────
-
-const GATE_SELECT_SQL = `
-  SELECT sg.id, sg.stage_id, sg.field_id, sg.gate_type, sg.gate_value, sg.error_message,
-         fd.label AS field_label, fd.field_type
-  FROM stage_gates sg
-  JOIN field_definitions fd ON fd.id = sg.field_id`;
+/**
+ * Select a stage_gate joined to its field_definition, returning the row shape
+ * expected by rowToStageGateResponse.
+ */
+function selectGateWithField() {
+  return db
+    .selectFrom('stage_gates as sg')
+    .innerJoin('field_definitions as fd', 'fd.id', 'sg.field_id')
+    .select([
+      'sg.id',
+      'sg.stage_id',
+      'sg.field_id',
+      'sg.gate_type',
+      'sg.gate_value',
+      'sg.error_message',
+      'fd.label as field_label',
+      'fd.field_type',
+    ]);
+}
 
 // ─── Service functions ───────────────────────────────────────────────────────
 
@@ -189,15 +217,19 @@ const GATE_SELECT_SQL = `
  *
  * @throws {Error} NOT_FOUND — stage does not exist
  */
-export async function listStageGates(tenantId: string, stageId: string): Promise<StageGateResponse[]> {
+export async function listStageGates(
+  tenantId: string,
+  stageId: string,
+): Promise<StageGateResponse[]> {
   await resolveStageAndObject(tenantId, stageId);
 
-  const result = await pool.query(
-    `${GATE_SELECT_SQL} WHERE sg.stage_id = $1 AND sg.tenant_id = $2 ORDER BY sg.id`,
-    [stageId, tenantId],
-  );
+  const rows = await selectGateWithField()
+    .where('sg.stage_id', '=', stageId)
+    .where('sg.tenant_id', '=', tenantId)
+    .orderBy('sg.id')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToStageGateResponse(row));
+  return rows.map(rowToStageGateResponse);
 }
 
 /**
@@ -233,11 +265,15 @@ export async function createStageGate(
     throwNotFoundError('Field not found');
   }
 
-  const fieldBelongsToObject = await pool.query(
-    'SELECT id FROM field_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [params.fieldId, stageInfo.objectId, tenantId],
-  );
-  if (fieldBelongsToObject.rows.length === 0) {
+  const fieldBelongsToObject = await db
+    .selectFrom('field_definitions')
+    .select('id')
+    .where('id', '=', params.fieldId)
+    .where('object_id', '=', stageInfo.objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+
+  if (!fieldBelongsToObject) {
     throwValidationError('Field does not belong to the same object as the pipeline');
   }
 
@@ -245,39 +281,42 @@ export async function createStageGate(
   validateGateTypeAgainstField(params.gateType, params.gateValue ?? null, field);
 
   // Check for duplicate gate on same field/stage
-  const duplicate = await pool.query(
-    'SELECT id FROM stage_gates WHERE stage_id = $1 AND field_id = $2 AND tenant_id = $3',
-    [stageId, params.fieldId, tenantId],
-  );
-  if (duplicate.rows.length > 0) {
+  const duplicate = await db
+    .selectFrom('stage_gates')
+    .select('id')
+    .where('stage_id', '=', stageId)
+    .where('field_id', '=', params.fieldId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+
+  if (duplicate) {
     throwConflictError('A gate already exists for this field on this stage');
   }
 
   const gateId = randomUUID();
 
-  await pool.query(
-    `INSERT INTO stage_gates (id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-    [
-      gateId,
-      tenantId,
-      stageId,
-      params.fieldId,
-      params.gateType,
-      params.gateValue ?? null,
-      params.errorMessage ?? null,
-    ],
-  );
+  await db
+    .insertInto('stage_gates')
+    .values({
+      id: gateId,
+      tenant_id: tenantId,
+      stage_id: stageId,
+      field_id: params.fieldId,
+      gate_type: params.gateType,
+      gate_value: params.gateValue ?? null,
+      error_message: params.errorMessage ?? null,
+    })
+    .execute();
 
   // Fetch the created gate with field metadata
-  const result = await pool.query(
-    `${GATE_SELECT_SQL} WHERE sg.id = $1 AND sg.tenant_id = $2`,
-    [gateId, tenantId],
-  );
+  const created = await selectGateWithField()
+    .where('sg.id', '=', gateId)
+    .where('sg.tenant_id', '=', tenantId)
+    .executeTakeFirstOrThrow();
 
   logger.info({ gateId, stageId, fieldId: params.fieldId }, 'Stage gate created');
 
-  return rowToStageGateResponse(result.rows[0] as Record<string, unknown>);
+  return rowToStageGateResponse(created);
 }
 
 /**
@@ -295,29 +334,29 @@ export async function updateStageGate(
   await resolveStageAndObject(tenantId, stageId);
 
   // Fetch existing gate
-  const existing = await pool.query(
-    'SELECT * FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3',
-    [gateId, stageId, tenantId],
-  );
+  const existingRow = await db
+    .selectFrom('stage_gates')
+    .selectAll()
+    .where('id', '=', gateId)
+    .where('stage_id', '=', stageId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Stage gate not found');
   }
 
-  const existingRow = existing.rows[0] as Record<string, unknown>;
-
   // Determine effective gate_type and gate_value
-  const effectiveGateType = params.gateType ?? (existingRow.gate_type as string);
-  const effectiveGateValue = 'gateValue' in params
-    ? (params.gateValue ?? null)
-    : (existingRow.gate_value as string | null);
+  const effectiveGateType = params.gateType ?? existingRow.gate_type;
+  const effectiveGateValue =
+    'gateValue' in params ? (params.gateValue ?? null) : existingRow.gate_value;
 
   if (!ALLOWED_GATE_TYPES.has(effectiveGateType)) {
     throwValidationError(`gate_type must be one of: ${[...ALLOWED_GATE_TYPES].join(', ')}`);
   }
 
   // Validate gate_type against field_type
-  const field = await getFieldInfo(existingRow.field_id as string, tenantId);
+  const field = await getFieldInfo(existingRow.field_id, tenantId);
   if (!field) {
     throwNotFoundError('Field not found');
   }
@@ -325,50 +364,30 @@ export async function updateStageGate(
   validateGateTypeAgainstField(effectiveGateType, effectiveGateValue, field);
 
   // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
+  const updates: Record<string, unknown> = {};
+  if ('gateType' in params) updates.gate_type = params.gateType;
+  if ('gateValue' in params) updates.gate_value = params.gateValue ?? null;
+  if ('errorMessage' in params) updates.error_message = params.errorMessage ?? null;
 
-  if ('gateType' in params) {
-    updates.push(`gate_type = $${paramIndex++}`);
-    values.push(params.gateType);
+  if (Object.keys(updates).length > 0) {
+    await db
+      .updateTable('stage_gates')
+      .set(updates)
+      .where('id', '=', gateId)
+      .where('stage_id', '=', stageId)
+      .where('tenant_id', '=', tenantId)
+      .execute();
   }
-  if ('gateValue' in params) {
-    updates.push(`gate_value = $${paramIndex++}`);
-    values.push(params.gateValue ?? null);
-  }
-  if ('errorMessage' in params) {
-    updates.push(`error_message = $${paramIndex++}`);
-    values.push(params.errorMessage ?? null);
-  }
-
-  if (updates.length === 0) {
-    // Nothing to update — return existing gate with field metadata
-    const result = await pool.query(
-      `${GATE_SELECT_SQL} WHERE sg.id = $1 AND sg.tenant_id = $2`,
-      [gateId, tenantId],
-    );
-    return rowToStageGateResponse(result.rows[0] as Record<string, unknown>);
-  }
-
-  values.push(gateId);
-  values.push(stageId);
-  values.push(tenantId);
-
-  await pool.query(
-    `UPDATE stage_gates SET ${updates.join(', ')} WHERE id = $${paramIndex++} AND stage_id = $${paramIndex++} AND tenant_id = $${paramIndex}`,
-    values,
-  );
 
   // Fetch the updated gate with field metadata
-  const result = await pool.query(
-    `${GATE_SELECT_SQL} WHERE sg.id = $1 AND sg.tenant_id = $2`,
-    [gateId, tenantId],
-  );
+  const updated = await selectGateWithField()
+    .where('sg.id', '=', gateId)
+    .where('sg.tenant_id', '=', tenantId)
+    .executeTakeFirstOrThrow();
 
   logger.info({ gateId, stageId }, 'Stage gate updated');
 
-  return rowToStageGateResponse(result.rows[0] as Record<string, unknown>);
+  return rowToStageGateResponse(updated);
 }
 
 /**
@@ -383,19 +402,24 @@ export async function deleteStageGate(
 ): Promise<void> {
   await resolveStageAndObject(tenantId, stageId);
 
-  const existing = await pool.query(
-    'SELECT id FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3',
-    [gateId, stageId, tenantId],
-  );
+  const existing = await db
+    .selectFrom('stage_gates')
+    .select('id')
+    .where('id', '=', gateId)
+    .where('stage_id', '=', stageId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Stage gate not found');
   }
 
-  await pool.query(
-    'DELETE FROM stage_gates WHERE id = $1 AND stage_id = $2 AND tenant_id = $3',
-    [gateId, stageId, tenantId],
-  );
+  await db
+    .deleteFrom('stage_gates')
+    .where('id', '=', gateId)
+    .where('stage_id', '=', stageId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ gateId, stageId }, 'Stage gate deleted');
 }

--- a/apps/api/src/services/stageGateService.ts
+++ b/apps/api/src/services/stageGateService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
+import type { StageGates } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -98,10 +100,15 @@ async function resolveStageAndObject(
 ): Promise<StageWithObject> {
   const row = await db
     .selectFrom('stage_definitions as sd')
-    .innerJoin('pipeline_definitions as pd', 'pd.id', 'sd.pipeline_id')
+    .innerJoin('pipeline_definitions as pd', (join) =>
+      join
+        .onRef('pd.id', '=', 'sd.pipeline_id')
+        .onRef('pd.tenant_id', '=', 'sd.tenant_id'),
+    )
     .select(['sd.id as stage_id', 'sd.pipeline_id', 'pd.object_id'])
     .where('sd.id', '=', stageId)
     .where('sd.tenant_id', '=', tenantId)
+    .where('pd.tenant_id', '=', tenantId)
     .executeTakeFirst();
 
   if (!row) {
@@ -193,11 +200,21 @@ function validateGateTypeAgainstField(
 /**
  * Select a stage_gate joined to its field_definition, returning the row shape
  * expected by rowToStageGateResponse.
+ *
+ * The join enforces `fd.tenant_id = sg.tenant_id` so defence-in-depth
+ * (ADR-006) holds for both tables once the caller applies a
+ * `sg.tenant_id = :tenant` predicate — a stage gate cannot accidentally
+ * surface field metadata from another tenant even if a corrupt row
+ * references an out-of-tenant field_id.
  */
 function selectGateWithField() {
   return db
     .selectFrom('stage_gates as sg')
-    .innerJoin('field_definitions as fd', 'fd.id', 'sg.field_id')
+    .innerJoin('field_definitions as fd', (join) =>
+      join
+        .onRef('fd.id', '=', 'sg.field_id')
+        .onRef('fd.tenant_id', '=', 'sg.tenant_id'),
+    )
     .select([
       'sg.id',
       'sg.stage_id',
@@ -346,10 +363,13 @@ export async function updateStageGate(
     throwNotFoundError('Stage gate not found');
   }
 
-  // Determine effective gate_type and gate_value
-  const effectiveGateType = params.gateType ?? existingRow.gate_type;
+  // Determine effective gate_type and gate_value. A caller can clear
+  // gate_value by passing null explicitly; passing undefined (or omitting
+  // the key) means "keep the existing value".
+  const effectiveGateType =
+    params.gateType !== undefined ? params.gateType : existingRow.gate_type;
   const effectiveGateValue =
-    'gateValue' in params ? (params.gateValue ?? null) : existingRow.gate_value;
+    params.gateValue !== undefined ? params.gateValue : existingRow.gate_value;
 
   if (!ALLOWED_GATE_TYPES.has(effectiveGateType)) {
     throwValidationError(`gate_type must be one of: ${[...ALLOWED_GATE_TYPES].join(', ')}`);
@@ -363,11 +383,14 @@ export async function updateStageGate(
 
   validateGateTypeAgainstField(effectiveGateType, effectiveGateValue, field);
 
-  // Build dynamic update
-  const updates: Record<string, unknown> = {};
-  if ('gateType' in params) updates.gate_type = params.gateType;
-  if ('gateValue' in params) updates.gate_value = params.gateValue ?? null;
-  if ('errorMessage' in params) updates.error_message = params.errorMessage ?? null;
+  // Build a typed update object so Kysely enforces the column/value
+  // contract from the generated schema. Only defined values are
+  // included — passing `undefined` on the params object is treated as
+  // "leave unchanged", so we never emit `SET col = NULL` unintentionally.
+  const updates: Updateable<StageGates> = {};
+  if (params.gateType !== undefined) updates.gate_type = params.gateType;
+  if (params.gateValue !== undefined) updates.gate_value = params.gateValue;
+  if (params.errorMessage !== undefined) updates.error_message = params.errorMessage;
 
   if (Object.keys(updates).length > 0) {
     await db


### PR DESCRIPTION
## Summary

Last Group A service in [#445](https://github.com/Brianclark490/CPCRM/issues/445). Follows the same pattern as `stageMovementService` (#452) and `pipelineAnalyticsService` (#455).

Rewrites the CRUD surface — `listStageGates`, `createStageGate`, `updateStageGate`, `deleteStageGate` — on top of Kysely's query builder. No `sql` template literals are needed because the service has no Postgres-specific operators.

### Highlights

- Extracted `selectGateWithField()` helper keeps the gate + `field_definitions` join consistent across all read paths — gone is the hand-rolled `GATE_SELECT_SQL` fragment plus manual row casting.
- `resolveStageAndObject` and `getFieldInfo` return typed rows from `kysely.types.ts` instead of `Record<string, unknown>`.
- `updateStageGate` now builds a dynamic `.set()` object. When the request has no fields to update, the UPDATE is skipped entirely instead of emitting a no-op SQL string — a new regression test pins this.
- `getFieldInfo` now always requires a `tenantId` (the optional branch was dead code after the callers converged).

### Tests

- **Existing `stageGateService.test.ts`** updated with a quote-stripping SQL normaliser, `mockConnect` alongside `mockQuery` so RLS-proxy queries are served from the same router, and pattern updates matching Kysely-emitted `AS SG` / `AS FD` aliases. All 29 existing tests pass unchanged.
- **New `stageGateService.kysely-sql.test.ts`** (13 tests) asserts every emitted query carries a `tenant_id` predicate (ADR-006 defence-in-depth), pins the gate-with-field join shape (no N+1), and verifies the UPDATE-skip + explicit-transaction invariants.

### Issue #445 progress

This PR completes **Group A**. Next up: Group B (schema-critical services — `fieldDefinitionService`, `objectDefinitionService`, `relationshipDefinitionService`, `recordRelationshipService`).

## Test plan

- [x] `vitest run src/services/__tests__/stageGateService.test.ts` — 29/29 pass
- [x] `vitest run src/services/__tests__/stageGateService.kysely-sql.test.ts` — 13/13 pass
- [x] Full `apps/api` suite: 64 files, 1355 tests pass
- [x] `tsc --noEmit` clean
- [ ] Copilot review

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf