### PR TITLE
Migrate fieldDefinitionService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/fieldDefinitionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/fieldDefinitionService.kysely-sql.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Kysely SQL regression suite for fieldDefinitionService.
+ *
+ * Complements `fieldDefinitionService.test.ts` (behavioural assertions)
+ * by asserting directly on the SQL Kysely emits for each exported
+ * service function. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query carries a `tenant_id` filter
+ *      as defence-in-depth against an RLS misconfiguration (ADR-006).
+ *   3. Pin the latent layout_fields.tenant_id fix so a future refactor
+ *      doesn't reintroduce the NOT-NULL violation.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const OBJECT_ID = 'obj-test-001';
+const FIELD_ID = 'field-test-001';
+const LAYOUT_ID = 'layout-test-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      // assertObjectExists
+      if (
+        s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+        s.includes('WHERE ID')
+      ) {
+        return { rows: [{ id: OBJECT_ID }] };
+      }
+
+      // uniqueness check: SELECT id FROM field_definitions WHERE object_id AND api_name
+      if (
+        s.startsWith('SELECT ID FROM FIELD_DEFINITIONS') &&
+        s.includes('API_NAME')
+      ) {
+        return { rows: [] };
+      }
+
+      // reorder existence check: SELECT id FROM field_definitions WHERE object_id (no api_name)
+      if (
+        s.startsWith('SELECT ID FROM FIELD_DEFINITIONS') &&
+        s.includes('OBJECT_ID') &&
+        !s.includes('API_NAME')
+      ) {
+        return { rows: [{ id: FIELD_ID }, { id: 'field-2' }] };
+      }
+
+      // MAX(sort_order) FROM field_definitions
+      if (
+        s.includes('MAX(SORT_ORDER)') &&
+        s.includes('FIELD_DEFINITIONS')
+      ) {
+        return { rows: [{ max_sort: '0' }] };
+      }
+
+      // MAX(sort_order) FROM layout_fields
+      if (s.includes('MAX(SORT_ORDER)') && s.includes('LAYOUT_FIELDS')) {
+        return { rows: [{ max_sort: '0' }] };
+      }
+
+      // INSERT INTO field_definitions
+      if (s.startsWith('INSERT INTO FIELD_DEFINITIONS')) {
+        return {
+          rows: [
+            {
+              id: FIELD_ID,
+              tenant_id: TENANT_ID,
+              object_id: OBJECT_ID,
+              api_name: 'test_field',
+              label: 'Test Field',
+              field_type: 'text',
+              description: null,
+              required: false,
+              default_value: null,
+              options: {},
+              sort_order: 1,
+              is_system: false,
+              created_at: new Date(),
+              updated_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // SELECT id FROM layout_definitions WHERE object_id AND layout_type = 'form' AND is_default
+      if (
+        s.includes('FROM LAYOUT_DEFINITIONS') &&
+        s.includes('LAYOUT_TYPE') &&
+        s.includes('IS_DEFAULT')
+      ) {
+        return { rows: [{ id: LAYOUT_ID }] };
+      }
+
+      // INSERT INTO layout_fields
+      if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
+        return { rows: [] };
+      }
+
+      // SELECT * FROM field_definitions (lookup before update/delete)
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM FIELD_DEFINITIONS') &&
+        s.includes('WHERE ID =')
+      ) {
+        return {
+          rows: [
+            {
+              id: FIELD_ID,
+              tenant_id: TENANT_ID,
+              object_id: OBJECT_ID,
+              api_name: 'test_field',
+              label: 'Test Field',
+              field_type: 'text',
+              description: null,
+              required: false,
+              default_value: null,
+              options: {},
+              sort_order: 1,
+              is_system: false,
+              created_at: new Date(),
+              updated_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // listFieldDefinitions / reorder return — SELECT * ... ORDER BY sort_order
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM FIELD_DEFINITIONS') &&
+        s.includes('ORDER BY')
+      ) {
+        return { rows: [] };
+      }
+
+      // UPDATE field_definitions RETURNING *
+      if (s.startsWith('UPDATE FIELD_DEFINITIONS SET')) {
+        return {
+          rows: [
+            {
+              id: FIELD_ID,
+              tenant_id: TENANT_ID,
+              object_id: OBJECT_ID,
+              api_name: 'test_field',
+              label: 'Updated',
+              field_type: 'text',
+              description: null,
+              required: false,
+              default_value: null,
+              options: {},
+              sort_order: 1,
+              is_system: false,
+              created_at: new Date(),
+              updated_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // COUNT(*) FROM records
+      if (s.includes('FROM RECORDS') && s.includes('COUNT(*)')) {
+        return { rows: [{ count: '0' }] };
+      }
+
+      // DELETE FROM field_definitions
+      if (s.startsWith('DELETE FROM FIELD_DEFINITIONS')) {
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createFieldDefinition,
+  listFieldDefinitions,
+  updateFieldDefinition,
+  deleteFieldDefinition,
+  reorderFieldDefinitions,
+} = await import('../fieldDefinitionService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('fieldDefinitionService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on createFieldDefinition references tenant_id', async () => {
+    await createFieldDefinition(TENANT_ID, OBJECT_ID, {
+      apiName: 'company_name',
+      label: 'Company Name',
+      fieldType: 'text',
+    });
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on listFieldDefinitions references tenant_id', async () => {
+    await listFieldDefinitions(TENANT_ID, OBJECT_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on updateFieldDefinition references tenant_id', async () => {
+    await updateFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID, {
+      label: 'New Label',
+    });
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on deleteFieldDefinition references tenant_id', async () => {
+    await deleteFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on reorderFieldDefinitions references tenant_id', async () => {
+    await reorderFieldDefinitions(TENANT_ID, OBJECT_ID, [FIELD_ID]);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('fieldDefinitionService Kysely SQL — generated SQL shape', () => {
+  it('createFieldDefinition INSERT carries all 14 columns with tenant_id as second bind', async () => {
+    await createFieldDefinition(TENANT_ID, OBJECT_ID, {
+      apiName: 'company_name',
+      label: 'Company Name',
+      fieldType: 'text',
+    });
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO FIELD_DEFINITIONS'),
+    );
+    expect(inserts.length).toBe(1);
+    // id, tenant_id, object_id, api_name, label, field_type,
+    // description, required, default_value, options, sort_order,
+    // is_system, created_at, updated_at
+    expect(inserts[0]!.params.length).toBe(14);
+    expect(inserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(inserts[0]!.params[2]).toBe(OBJECT_ID);
+    expect(inserts[0]!.params[3]).toBe('company_name');
+    expect(inserts[0]!.params[4]).toBe('Company Name');
+    expect(inserts[0]!.params[5]).toBe('text');
+  });
+
+  it('createFieldDefinition INSERT into layout_fields includes tenant_id (latent bug fix)', async () => {
+    // Historical bug: the raw-pg implementation omitted tenant_id on the
+    // layout_fields insert, which would have failed the NOT NULL
+    // constraint on a real database. The Kysely migration fixes this
+    // and this assertion pins the fix.
+    await createFieldDefinition(TENANT_ID, OBJECT_ID, {
+      apiName: 'company_name',
+      label: 'Company Name',
+      fieldType: 'text',
+    });
+
+    const layoutInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO LAYOUT_FIELDS'),
+    );
+    expect(layoutInserts.length).toBe(1);
+
+    const s = normalise(layoutInserts[0]!.sql);
+    expect(s).toContain('TENANT_ID');
+    // id, tenant_id, layout_id, field_id, section, sort_order, width
+    expect(layoutInserts[0]!.params.length).toBe(7);
+    // tenant_id is the second bind (after id)
+    expect(layoutInserts[0]!.params[1]).toBe(TENANT_ID);
+  });
+
+  it('listFieldDefinitions orders by sort_order ascending', async () => {
+    await listFieldDefinitions(TENANT_ID, OBJECT_ID);
+
+    const selects = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM FIELD_DEFINITIONS') &&
+        s.includes('ORDER BY')
+      );
+    });
+    expect(selects.length).toBe(1);
+
+    const s = normalise(selects[0]!.sql);
+    expect(s).toContain('SORT_ORDER ASC');
+    expect(s).toContain('OBJECT_ID');
+    expect(s).toContain('TENANT_ID');
+  });
+
+  it('updateFieldDefinition with only label updates only the label and updated_at columns', async () => {
+    await updateFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID, {
+      label: 'New Label',
+    });
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE FIELD_DEFINITIONS SET'),
+    );
+    expect(updates.length).toBe(1);
+
+    const s = normalise(updates[0]!.sql);
+    expect(s).toContain('LABEL =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).not.toContain('FIELD_TYPE =');
+    expect(s).not.toContain('REQUIRED =');
+    expect(s).not.toContain('OPTIONS =');
+    // WHERE is scoped by id + object_id + tenant_id
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('OBJECT_ID =');
+    expect(s).toContain('TENANT_ID =');
+    // RETURNING used to avoid a follow-up SELECT
+    expect(s).toContain('RETURNING');
+  });
+
+  it('updateFieldDefinition with no fields skips the UPDATE entirely', async () => {
+    await updateFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID, {});
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE FIELD_DEFINITIONS SET'),
+    );
+    expect(updates.length).toBe(0);
+  });
+
+  it('deleteFieldDefinition issues exactly one DELETE scoped by id + object_id + tenant_id', async () => {
+    await deleteFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM FIELD_DEFINITIONS'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const s = normalise(deletes[0]!.sql);
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('OBJECT_ID =');
+    expect(s).toContain('TENANT_ID =');
+  });
+
+  it('reorderFieldDefinitions issues one UPDATE per field_id scoped by object_id + tenant_id', async () => {
+    await reorderFieldDefinitions(TENANT_ID, OBJECT_ID, [FIELD_ID, 'field-2']);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE FIELD_DEFINITIONS SET SORT_ORDER'),
+    );
+    expect(updates.length).toBe(2);
+
+    for (const u of updates) {
+      const s = normalise(u.sql);
+      expect(s).toContain('SORT_ORDER =');
+      expect(s).toContain('UPDATED_AT =');
+      expect(s).toContain('OBJECT_ID =');
+      expect(s).toContain('TENANT_ID =');
+    }
+  });
+});
+
+describe('fieldDefinitionService Kysely SQL — no BEGIN/COMMIT (no explicit transactions)', () => {
+  it('createFieldDefinition runs without opening an explicit transaction', async () => {
+    await createFieldDefinition(TENANT_ID, OBJECT_ID, {
+      apiName: 'company_name',
+      label: 'Company Name',
+      fieldType: 'text',
+    });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('updateFieldDefinition runs without opening an explicit transaction', async () => {
+    await updateFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID, {
+      label: 'Updated',
+    });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('deleteFieldDefinition runs without opening an explicit transaction', async () => {
+    await deleteFieldDefinition(TENANT_ID, OBJECT_ID, FIELD_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/fieldDefinitionService.test.ts
+++ b/apps/api/src/services/__tests__/fieldDefinitionService.test.ts
@@ -19,19 +19,39 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// NOTE (Phase 3b Kysely migration, issue #445): the service is now on
+// Kysely. The mock below matches Kysely-emitted SQL — identifier
+// quoting is stripped by the normaliser, matching the pattern used by
+// stageMovementService.test.ts and stageGateService.test.ts.
+//
+// A dedicated Kysely SQL regression suite lives next door:
+//   apps/api/src/services/__tests__/fieldDefinitionService.kysely-sql.test.ts
 
-const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, mockQuery } = vi.hoisted(() => {
+const {
+  fakeObjects,
+  fakeFields,
+  fakeRecords,
+  fakeLayouts,
+  fakeLayoutFields,
+  mockQuery,
+  mockConnect,
+} = vi.hoisted(() => {
   const fakeObjects = new Map<string, Record<string, unknown>>();
   const fakeFields = new Map<string, Record<string, unknown>>();
   const fakeRecords = new Map<string, Record<string, unknown>>();
   const fakeLayouts = new Map<string, Record<string, unknown>>();
   const fakeLayoutFields = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(rawSql: string, params?: unknown[]) {
+    // Strip identifier quoting so matching is quote-agnostic.
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
-    // SELECT id FROM object_definitions WHERE id = $1
-    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
+    // SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2
+    if (
+      s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+      s.includes('WHERE ID')
+    ) {
       const id = params![0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
@@ -39,7 +59,11 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
     }
 
     // SELECT id FROM field_definitions WHERE object_id = $1 AND api_name = $2
-    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS WHERE OBJECT_ID') && s.includes('API_NAME')) {
+    if (
+      s.startsWith('SELECT ID FROM FIELD_DEFINITIONS') &&
+      s.includes('OBJECT_ID') &&
+      s.includes('API_NAME')
+    ) {
       const objectId = params![0] as string;
       const apiName = params![1] as string;
       const match = [...fakeFields.values()].find(
@@ -60,43 +84,97 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
     // SELECT COALESCE(MAX(sort_order), 0) AS max_sort FROM layout_fields
     if (s.includes('MAX(SORT_ORDER)') && s.includes('LAYOUT_FIELDS')) {
       const layoutId = params![0] as string;
-      const lfs = [...fakeLayoutFields.values()].filter((lf) => lf.layout_id === layoutId);
-      const maxSort = lfs.reduce((max, lf) => Math.max(max, lf.sort_order as number), 0);
+      const lfs = [...fakeLayoutFields.values()].filter(
+        (lf) => lf.layout_id === layoutId,
+      );
+      const maxSort = lfs.reduce(
+        (max, lf) => Math.max(max, lf.sort_order as number),
+        0,
+      );
       return { rows: [{ max_sort: String(maxSort) }] };
     }
 
-    // INSERT INTO field_definitions
+    // INSERT INTO field_definitions — Kysely binds values in the column
+    // order declared in the service's `.values({...})` call.
     if (s.startsWith('INSERT INTO FIELD_DEFINITIONS')) {
-      const [id, _tenant_id, object_id, api_name, label, field_type, description, required, default_value, options, sort_order, is_system, created_at, updated_at] = params as unknown[];
+      const [
+        id,
+        _tenant_id,
+        object_id,
+        api_name,
+        label,
+        field_type,
+        description,
+        required,
+        default_value,
+        options,
+        sort_order,
+        is_system,
+        created_at,
+        updated_at,
+      ] = params as unknown[];
       const row: Record<string, unknown> = {
-        id, object_id, api_name, label, field_type, description, required,
-        default_value, options: typeof options === 'string' ? JSON.parse(options as string) : options,
-        sort_order, is_system, created_at, updated_at,
+        id,
+        tenant_id: _tenant_id,
+        object_id,
+        api_name,
+        label,
+        field_type,
+        description,
+        required,
+        default_value,
+        options:
+          typeof options === 'string' ? JSON.parse(options as string) : options,
+        sort_order,
+        is_system,
+        created_at,
+        updated_at,
       };
       fakeFields.set(id as string, row);
       return { rows: [row] };
     }
 
     // SELECT id FROM layout_definitions WHERE object_id AND layout_type = 'form'
-    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.includes('FORM') && s.includes('IS_DEFAULT')) {
+    if (
+      s.includes('FROM LAYOUT_DEFINITIONS') &&
+      s.includes('LAYOUT_TYPE') &&
+      s.includes('IS_DEFAULT')
+    ) {
       const objectId = params![0] as string;
       const match = [...fakeLayouts.values()].find(
-        (l) => l.object_id === objectId && l.layout_type === 'form' && l.is_default === true,
+        (l) =>
+          l.object_id === objectId &&
+          l.layout_type === 'form' &&
+          l.is_default === true,
       );
       if (match) return { rows: [{ id: match.id }] };
       return { rows: [] };
     }
 
-    // INSERT INTO layout_fields
+    // INSERT INTO layout_fields — columns: id, tenant_id, layout_id,
+    // field_id, section, sort_order, width
     if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
-      const [id, layout_id, field_id, section, sort_order, width] = params as unknown[];
-      const row: Record<string, unknown> = { id, layout_id, field_id, section, sort_order, width };
+      const [id, _tenant_id, layout_id, field_id, section, sort_order, width] =
+        params as unknown[];
+      const row: Record<string, unknown> = {
+        id,
+        tenant_id: _tenant_id,
+        layout_id,
+        field_id,
+        section,
+        sort_order,
+        width,
+      };
       fakeLayoutFields.set(id as string, row);
       return { rows: [row] };
     }
 
-    // SELECT * FROM field_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY sort_order
-    if (s.startsWith('SELECT * FROM FIELD_DEFINITIONS WHERE OBJECT_ID') && s.includes('ORDER BY')) {
+    // SELECT * FROM field_definitions WHERE object_id + ORDER BY sort_order
+    if (
+      s.includes('FROM FIELD_DEFINITIONS') &&
+      s.includes('OBJECT_ID') &&
+      s.includes('ORDER BY')
+    ) {
       const objectId = params![0] as string;
       const rows = [...fakeFields.values()]
         .filter((f) => f.object_id === objectId)
@@ -104,8 +182,13 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
       return { rows };
     }
 
-    // SELECT * FROM field_definitions WHERE id = $1 AND object_id = $2
-    if (s.startsWith('SELECT * FROM FIELD_DEFINITIONS WHERE ID = $1 AND OBJECT_ID')) {
+    // SELECT * FROM field_definitions WHERE id AND object_id AND tenant_id
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM FIELD_DEFINITIONS') &&
+      s.includes('WHERE ID =') &&
+      s.includes('OBJECT_ID')
+    ) {
       const fieldId = params![0] as string;
       const objectId = params![1] as string;
       const match = fakeFields.get(fieldId);
@@ -114,7 +197,11 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
     }
 
     // SELECT id FROM field_definitions WHERE object_id = $1 (for reorder)
-    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS WHERE OBJECT_ID')) {
+    if (
+      s.startsWith('SELECT ID FROM FIELD_DEFINITIONS') &&
+      s.includes('OBJECT_ID') &&
+      !s.includes('API_NAME')
+    ) {
       const objectId = params![0] as string;
       const rows = [...fakeFields.values()]
         .filter((f) => f.object_id === objectId)
@@ -123,7 +210,7 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
     }
 
     // UPDATE field_definitions SET sort_order (reorder)
-    if (s.startsWith('UPDATE FIELD_DEFINITIONS SET SORT_ORDER = $1')) {
+    if (s.startsWith('UPDATE FIELD_DEFINITIONS SET SORT_ORDER =')) {
       const sortOrder = params![0] as number;
       const updatedAt = params![1] as Date;
       const fieldId = params![2] as string;
@@ -136,24 +223,41 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
       return { rows: [] };
     }
 
-    // UPDATE field_definitions SET ... (general update)
+    // UPDATE field_definitions SET ... (general update) → ends with
+    // `... WHERE id = $N AND object_id = $N+1 AND tenant_id = $N+2`.
     if (s.startsWith('UPDATE FIELD_DEFINITIONS SET')) {
-      // The field id and object_id are the last two params
-      const fieldId = params![params!.length - 2] as string;
-      const objectId = params![params!.length - 1] as string;
+      const p = params as unknown[];
+      // id, object_id, tenant_id are the final three binds
+      const fieldId = p[p.length - 3] as string;
+      const objectId = p[p.length - 2] as string;
       const field = fakeFields.get(fieldId);
       if (field && field.object_id === objectId) {
-        const updated: Record<string, unknown> = { ...field, updated_at: new Date() };
-        // Parse SET clauses from the SQL to update fields
-        let paramIdx = 0;
-        if (s.includes('LABEL =')) { updated.label = params![paramIdx++]; }
-        if (s.includes('FIELD_TYPE =')) { updated.field_type = params![paramIdx++]; }
-        if (s.includes('DESCRIPTION =')) { updated.description = params![paramIdx++]; }
-        if (s.includes('REQUIRED =')) { updated.required = params![paramIdx++]; }
-        if (s.includes('DEFAULT_VALUE =')) { updated.default_value = params![paramIdx++]; }
+        const updated: Record<string, unknown> = { ...field };
+        let idx = 0;
+        // Match SET clauses in declaration order:
+        // label, field_type, description, required, default_value, options, updated_at
+        if (s.includes('SET LABEL =') || s.includes(', LABEL =')) {
+          updated.label = p[idx++];
+        }
+        if (s.includes('FIELD_TYPE =')) {
+          updated.field_type = p[idx++];
+        }
+        if (s.includes('DESCRIPTION =')) {
+          updated.description = p[idx++];
+        }
+        if (s.includes('REQUIRED =')) {
+          updated.required = p[idx++];
+        }
+        if (s.includes('DEFAULT_VALUE =')) {
+          updated.default_value = p[idx++];
+        }
         if (s.includes('OPTIONS =')) {
-          const opts = params![paramIdx++];
-          updated.options = typeof opts === 'string' ? JSON.parse(opts as string) : opts;
+          const opts = p[idx++];
+          updated.options =
+            typeof opts === 'string' ? JSON.parse(opts as string) : opts;
+        }
+        if (s.includes('UPDATED_AT =')) {
+          updated.updated_at = p[idx++] as Date;
         }
         fakeFields.set(fieldId, updated);
         return { rows: [updated] };
@@ -161,10 +265,12 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
       return { rows: [] };
     }
 
-    // SELECT COUNT(*) AS count FROM records WHERE object_id
-    if (s.includes('SELECT COUNT(*) AS COUNT FROM RECORDS WHERE OBJECT_ID')) {
+    // SELECT count(*) AS count FROM records WHERE object_id
+    if (s.includes('FROM RECORDS') && s.includes('COUNT(*)')) {
       const objectId = params![0] as string;
-      const count = [...fakeRecords.values()].filter((r) => r.object_id === objectId).length;
+      const count = [...fakeRecords.values()].filter(
+        (r) => r.object_id === objectId,
+      ).length;
       return { rows: [{ count: String(count) }] };
     }
 
@@ -184,13 +290,36 @@ const { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, moc
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params);
   });
 
-  return { fakeObjects, fakeFields, fakeRecords, fakeLayouts, fakeLayoutFields, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return {
+    fakeObjects,
+    fakeFields,
+    fakeRecords,
+    fakeLayouts,
+    fakeLayoutFields,
+    mockQuery,
+    mockConnect,
+  };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Test helpers ────────────────────────────────────────────────────────────

--- a/apps/api/src/services/fieldDefinitionService.ts
+++ b/apps/api/src/services/fieldDefinitionService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { sql, type Updateable } from 'kysely';
+import { sql, type Selectable, type Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
 import type { FieldDefinitions } from '../db/kysely.types.js';
@@ -89,21 +89,30 @@ function throwConflictError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToFieldDefinition(row: Record<string, unknown>): FieldDefinition {
+/**
+ * Row shape returned by `selectAll()` / `returningAll()` against
+ * `field_definitions`. Typing the mapper against `Selectable<FieldDefinitions>`
+ * means schema drift (a renamed column, a changed nullability) is a
+ * compile-time error at the call sites, rather than an `unknown` cast
+ * leaking an incorrect runtime shape into the domain model.
+ */
+type FieldDefinitionRow = Selectable<FieldDefinitions>;
+
+function rowToFieldDefinition(row: FieldDefinitionRow): FieldDefinition {
   return {
-    id: row.id as string,
-    objectId: row.object_id as string,
-    apiName: row.api_name as string,
-    label: row.label as string,
-    fieldType: row.field_type as string,
-    description: (row.description as string | null) ?? undefined,
-    required: row.required as boolean,
-    defaultValue: (row.default_value as string | null) ?? undefined,
-    options: (row.options as Record<string, unknown>) ?? {},
-    sortOrder: row.sort_order as number,
-    isSystem: row.is_system as boolean,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    id: row.id,
+    objectId: row.object_id,
+    apiName: row.api_name,
+    label: row.label,
+    fieldType: row.field_type,
+    description: row.description ?? undefined,
+    required: row.required,
+    defaultValue: row.default_value ?? undefined,
+    options: (row.options as Record<string, unknown> | null) ?? {},
+    sortOrder: row.sort_order,
+    isSystem: row.is_system,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   };
 }
 
@@ -387,7 +396,7 @@ export async function createFieldDefinition(
 
   logger.info({ fieldId, objectId, apiName: params.apiName }, 'Field definition created');
 
-  return rowToFieldDefinition(inserted as unknown as Record<string, unknown>);
+  return rowToFieldDefinition(inserted);
 }
 
 /**
@@ -409,7 +418,7 @@ export async function listFieldDefinitions(
     .orderBy('sort_order', 'asc')
     .execute();
 
-  return rows.map((row) => rowToFieldDefinition(row as unknown as Record<string, unknown>));
+  return rows.map((row) => rowToFieldDefinition(row));
 }
 
 /**
@@ -441,11 +450,8 @@ export async function updateFieldDefinition(
     throwNotFoundError('Field definition not found');
   }
 
-  const row = existingRow as unknown as Record<string, unknown>;
-  const isSystem = row.is_system as boolean;
-
   // System fields: cannot change field_type
-  if (isSystem && params.fieldType !== undefined) {
+  if (existingRow.is_system && params.fieldType !== undefined) {
     throwValidationError('Cannot change field_type on system fields');
   }
 
@@ -461,7 +467,7 @@ export async function updateFieldDefinition(
   }
 
   // Determine the effective field type for options validation
-  const effectiveFieldType = params.fieldType?.trim() ?? (row.field_type as string);
+  const effectiveFieldType = params.fieldType?.trim() ?? existingRow.field_type;
 
   if (params.options !== undefined) {
     const optionsError = validateFieldOptions(effectiveFieldType, params.options);
@@ -480,7 +486,7 @@ export async function updateFieldDefinition(
   if (params.options !== undefined) updates.options = JSON.stringify(params.options);
 
   if (Object.keys(updates).length === 0) {
-    return rowToFieldDefinition(row);
+    return rowToFieldDefinition(existingRow);
   }
 
   updates.updated_at = new Date();
@@ -496,11 +502,11 @@ export async function updateFieldDefinition(
 
   logger.info({ fieldId, objectId }, 'Field definition updated');
 
-  const updated = rowToFieldDefinition(updatedRow as unknown as Record<string, unknown>);
+  const updated = rowToFieldDefinition(updatedRow);
 
   // Warn if field_type changed and records exist
   let warning: string | undefined;
-  if (params.fieldType !== undefined && params.fieldType.trim() !== (row.field_type as string)) {
+  if (params.fieldType !== undefined && params.fieldType.trim() !== existingRow.field_type) {
     const recordCountRow = await db
       .selectFrom('records')
       .select(sql<string>`COUNT(*)`.as('count'))
@@ -509,7 +515,7 @@ export async function updateFieldDefinition(
       .executeTakeFirstOrThrow();
     const count = parseInt(recordCountRow.count, 10);
     if (count > 0) {
-      warning = `field_type changed from "${row.field_type}" to "${params.fieldType.trim()}"; ${count} existing record(s) may contain data that does not match the new type`;
+      warning = `field_type changed from "${existingRow.field_type}" to "${params.fieldType.trim()}"; ${count} existing record(s) may contain data that does not match the new type`;
     }
   }
 
@@ -547,7 +553,7 @@ export async function deleteFieldDefinition(
     throwNotFoundError('Field definition not found');
   }
 
-  if ((existingRow as unknown as Record<string, unknown>).is_system === true) {
+  if (existingRow.is_system === true) {
     throwDeleteBlockedError('Cannot delete system fields');
   }
 
@@ -627,5 +633,5 @@ export async function reorderFieldDefinitions(
     .orderBy('sort_order', 'asc')
     .execute();
 
-  return rows.map((row) => rowToFieldDefinition(row as unknown as Record<string, unknown>));
+  return rows.map((row) => rowToFieldDefinition(row));
 }

--- a/apps/api/src/services/fieldDefinitionService.ts
+++ b/apps/api/src/services/fieldDefinitionService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import { sql, type Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { FieldDefinitions } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -259,11 +261,13 @@ export function validateFieldOptions(
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 async function assertObjectExists(tenantId: string, objectId: string): Promise<void> {
-  const result = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (result.rows.length === 0) {
+  const row = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!row) {
     throwNotFoundError('Object definition not found');
   }
 }
@@ -299,75 +303,91 @@ export async function createFieldDefinition(
   if (optionsError) throwValidationError(optionsError);
 
   // Check uniqueness of api_name within this object and tenant
-  const existing = await pool.query(
-    'SELECT id FROM field_definitions WHERE object_id = $1 AND api_name = $2 AND tenant_id = $3',
-    [objectId, params.apiName.trim(), tenantId],
-  );
-  if (existing.rows.length > 0) {
+  const existing = await db
+    .selectFrom('field_definitions')
+    .select('id')
+    .where('object_id', '=', objectId)
+    .where('api_name', '=', params.apiName.trim())
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (existing) {
     throwConflictError(`A field with api_name "${params.apiName.trim()}" already exists on this object`);
   }
 
   // Determine next sort_order
-  const maxSortResult = await pool.query(
-    'SELECT COALESCE(MAX(sort_order), 0) AS max_sort FROM field_definitions WHERE object_id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  const nextSortOrder = (parseInt(maxSortResult.rows[0].max_sort as string, 10) || 0) + 1;
+  const maxSortRow = await db
+    .selectFrom('field_definitions')
+    .select(sql<string>`COALESCE(MAX(sort_order), 0)`.as('max_sort'))
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirstOrThrow();
+  const nextSortOrder = (parseInt(maxSortRow.max_sort, 10) || 0) + 1;
 
   const fieldId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO field_definitions
-       (id, tenant_id, object_id, api_name, label, field_type, description, required, default_value, options, sort_order, is_system, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-     RETURNING *`,
-    [
-      fieldId,
-      tenantId,
-      objectId,
-      params.apiName.trim(),
-      params.label.trim(),
-      params.fieldType.trim(),
-      params.description?.trim() ?? null,
-      params.required ?? false,
-      params.defaultValue ?? null,
-      JSON.stringify(params.options ?? {}),
-      nextSortOrder,
-      false,
-      now,
-      now,
-    ],
-  );
+  const inserted = await db
+    .insertInto('field_definitions')
+    .values({
+      id: fieldId,
+      tenant_id: tenantId,
+      object_id: objectId,
+      api_name: params.apiName.trim(),
+      label: params.label.trim(),
+      field_type: params.fieldType.trim(),
+      description: params.description?.trim() ?? null,
+      required: params.required ?? false,
+      default_value: params.defaultValue ?? null,
+      options: JSON.stringify(params.options ?? {}),
+      sort_order: nextSortOrder,
+      is_system: false,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   // Auto-add to default form layout
-  const defaultFormLayout = await pool.query(
-    `SELECT id FROM layout_definitions
-     WHERE object_id = $1 AND layout_type = 'form' AND is_default = true AND tenant_id = $2
-     LIMIT 1`,
-    [objectId, tenantId],
-  );
+  const defaultFormLayout = await db
+    .selectFrom('layout_definitions')
+    .select('id')
+    .where('object_id', '=', objectId)
+    .where('layout_type', '=', 'form')
+    .where('is_default', '=', true)
+    .where('tenant_id', '=', tenantId)
+    .limit(1)
+    .executeTakeFirst();
 
-  if (defaultFormLayout.rows.length > 0) {
-    const layoutId = defaultFormLayout.rows[0].id as string;
+  if (defaultFormLayout) {
+    const layoutId = defaultFormLayout.id;
 
     // Determine next sort_order within the layout
-    const maxLayoutSort = await pool.query(
-      'SELECT COALESCE(MAX(sort_order), 0) AS max_sort FROM layout_fields WHERE layout_id = $1',
-      [layoutId],
-    );
-    const nextLayoutSortOrder = (parseInt(maxLayoutSort.rows[0].max_sort as string, 10) || 0) + 1;
+    const maxLayoutSortRow = await db
+      .selectFrom('layout_fields')
+      .select(sql<string>`COALESCE(MAX(sort_order), 0)`.as('max_sort'))
+      .where('layout_id', '=', layoutId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirstOrThrow();
+    const nextLayoutSortOrder =
+      (parseInt(maxLayoutSortRow.max_sort, 10) || 0) + 1;
 
-    await pool.query(
-      `INSERT INTO layout_fields (id, layout_id, field_id, section, sort_order, width)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [randomUUID(), layoutId, fieldId, 0, nextLayoutSortOrder, 'full'],
-    );
+    await db
+      .insertInto('layout_fields')
+      .values({
+        id: randomUUID(),
+        tenant_id: tenantId,
+        layout_id: layoutId,
+        field_id: fieldId,
+        section: 0,
+        sort_order: nextLayoutSortOrder,
+        width: 'full',
+      })
+      .execute();
   }
 
   logger.info({ fieldId, objectId, apiName: params.apiName }, 'Field definition created');
 
-  return rowToFieldDefinition(result.rows[0]);
+  return rowToFieldDefinition(inserted as unknown as Record<string, unknown>);
 }
 
 /**
@@ -381,12 +401,15 @@ export async function listFieldDefinitions(
 ): Promise<FieldDefinition[]> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM field_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY sort_order ASC',
-    [objectId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('field_definitions')
+    .selectAll()
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('sort_order', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToFieldDefinition(row));
+  return rows.map((row) => rowToFieldDefinition(row as unknown as Record<string, unknown>));
 }
 
 /**
@@ -406,16 +429,19 @@ export async function updateFieldDefinition(
 ): Promise<FieldDefinition & { warning?: string }> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM field_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [fieldId, objectId, tenantId],
-  );
+  const existingRow = await db
+    .selectFrom('field_definitions')
+    .selectAll()
+    .where('id', '=', fieldId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Field definition not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
+  const row = existingRow as unknown as Record<string, unknown>;
   const isSystem = row.is_system as boolean;
 
   // System fields: cannot change field_type
@@ -442,64 +468,46 @@ export async function updateFieldDefinition(
     if (optionsError) throwValidationError(optionsError);
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
+  // Build a typed update object so Kysely enforces the column/value
+  // contract from the generated schema. Only keys the caller explicitly
+  // provided are emitted — `undefined` means "leave unchanged".
+  const updates: Updateable<FieldDefinitions> = {};
+  if (params.label !== undefined) updates.label = params.label.trim();
+  if (params.fieldType !== undefined) updates.field_type = params.fieldType.trim();
+  if (params.description !== undefined) updates.description = params.description?.trim() ?? null;
+  if (params.required !== undefined) updates.required = params.required;
+  if (params.defaultValue !== undefined) updates.default_value = params.defaultValue ?? null;
+  if (params.options !== undefined) updates.options = JSON.stringify(params.options);
 
-  if ('label' in params) {
-    updates.push(`label = $${paramIndex++}`);
-    values.push(params.label!.trim());
-  }
-  if ('fieldType' in params) {
-    updates.push(`field_type = $${paramIndex++}`);
-    values.push(params.fieldType!.trim());
-  }
-  if ('description' in params) {
-    updates.push(`description = $${paramIndex++}`);
-    values.push(params.description?.trim() ?? null);
-  }
-  if ('required' in params) {
-    updates.push(`required = $${paramIndex++}`);
-    values.push(params.required);
-  }
-  if ('defaultValue' in params) {
-    updates.push(`default_value = $${paramIndex++}`);
-    values.push(params.defaultValue ?? null);
-  }
-  if ('options' in params) {
-    updates.push(`options = $${paramIndex++}`);
-    values.push(JSON.stringify(params.options));
-  }
-
-  if (updates.length === 0) {
+  if (Object.keys(updates).length === 0) {
     return rowToFieldDefinition(row);
   }
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
+  updates.updated_at = new Date();
 
-  values.push(fieldId);
-  values.push(objectId);
-
-  const result = await pool.query(
-    `UPDATE field_definitions SET ${updates.join(', ')} WHERE id = $${paramIndex++} AND object_id = $${paramIndex} RETURNING *`,
-    values,
-  );
+  const updatedRow = await db
+    .updateTable('field_definitions')
+    .set(updates)
+    .where('id', '=', fieldId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ fieldId, objectId }, 'Field definition updated');
 
-  const updated = rowToFieldDefinition(result.rows[0]);
+  const updated = rowToFieldDefinition(updatedRow as unknown as Record<string, unknown>);
 
   // Warn if field_type changed and records exist
   let warning: string | undefined;
   if (params.fieldType !== undefined && params.fieldType.trim() !== (row.field_type as string)) {
-    const recordCount = await pool.query(
-      'SELECT COUNT(*) AS count FROM records WHERE object_id = $1 AND tenant_id = $2',
-      [objectId, tenantId],
-    );
-    const count = parseInt(recordCount.rows[0].count as string, 10);
+    const recordCountRow = await db
+      .selectFrom('records')
+      .select(sql<string>`COUNT(*)`.as('count'))
+      .where('object_id', '=', objectId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirstOrThrow();
+    const count = parseInt(recordCountRow.count, 10);
     if (count > 0) {
       warning = `field_type changed from "${row.field_type}" to "${params.fieldType.trim()}"; ${count} existing record(s) may contain data that does not match the new type`;
     }
@@ -527,27 +535,30 @@ export async function deleteFieldDefinition(
 ): Promise<void> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM field_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [fieldId, objectId, tenantId],
-  );
+  const existingRow = await db
+    .selectFrom('field_definitions')
+    .selectAll()
+    .where('id', '=', fieldId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Field definition not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
-  if (row.is_system === true) {
+  if ((existingRow as unknown as Record<string, unknown>).is_system === true) {
     throwDeleteBlockedError('Cannot delete system fields');
   }
 
   // layout_fields has ON DELETE CASCADE from field_definitions, so deleting
   // the field definition will automatically remove it from all layouts.
-  await pool.query(
-    'DELETE FROM field_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [fieldId, objectId, tenantId],
-  );
+  await db
+    .deleteFrom('field_definitions')
+    .where('id', '=', fieldId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ fieldId, objectId }, 'Field definition deleted');
 }
@@ -579,14 +590,16 @@ export async function reorderFieldDefinitions(
   const fieldCount = sanitizedFieldIds.length;
 
   // Verify all field IDs belong to this object
-  const existingFields = await pool.query(
-    'SELECT id FROM field_definitions WHERE object_id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  const existingIds = new Set(existingFields.rows.map((r: Record<string, unknown>) => r.id as string));
+  const existingFields = await db
+    .selectFrom('field_definitions')
+    .select('id')
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
+  const existingIds = new Set(existingFields.map((r) => r.id));
 
   for (let i = 0; i < fieldCount; i++) {
-    if (!existingIds.has(sanitizedFieldIds[i])) {
+    if (!existingIds.has(sanitizedFieldIds[i]!)) {
       throwValidationError(`Field ID "${sanitizedFieldIds[i]}" does not belong to this object`);
     }
   }
@@ -594,19 +607,25 @@ export async function reorderFieldDefinitions(
   // Update sort_order for each field
   const now = new Date();
   for (let i = 0; i < fieldCount; i++) {
-    await pool.query(
-      'UPDATE field_definitions SET sort_order = $1, updated_at = $2 WHERE id = $3 AND object_id = $4',
-      [i + 1, now, sanitizedFieldIds[i], objectId],
-    );
+    await db
+      .updateTable('field_definitions')
+      .set({ sort_order: i + 1, updated_at: now })
+      .where('id', '=', sanitizedFieldIds[i]!)
+      .where('object_id', '=', objectId)
+      .where('tenant_id', '=', tenantId)
+      .execute();
   }
 
   logger.info({ objectId, fieldCount }, 'Field definitions reordered');
 
   // Return the updated list
-  const result = await pool.query(
-    'SELECT * FROM field_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY sort_order ASC',
-    [objectId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('field_definitions')
+    .selectAll()
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('sort_order', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToFieldDefinition(row));
+  return rows.map((row) => rowToFieldDefinition(row as unknown as Record<string, unknown>));
 }


### PR DESCRIPTION
## Summary

First PR in Group B (schema-critical services) of #445. Replaces every raw `pool.query` call in `fieldDefinitionService` with typed Kysely query builders, using `sql` templates only for aggregate expressions that need them (`COALESCE(MAX(sort_order), 0)`, `COUNT(*)`).

### Latent bug fix

The raw-pg implementation inserted into `layout_fields` without a `tenant_id` value, which would have violated the NOT NULL constraint added in migration 017 on a real database. Kysely's generated types force the column to be set, so the default-form-layout auto-add now correctly threads the tenant through the insert. A regression test pins this behaviour.

### Hardening

- `Updateable<FieldDefinitions>` on the update path so SET-clause drift is caught at compile time.
- Every update check switched from `'key' in params` → `params.key !== undefined`, matching the "absent vs explicit undefined" convention used by the other migrated services.
- Every tenant-scoped query now carries an explicit `tenant_id` predicate as defence-in-depth (ADR-006).

## Test plan

- [x] `fieldDefinitionService.test.ts` — 75 existing behavioural tests pass unchanged (mock updated with quote-stripping normaliser + `mockConnect` for the RLS proxy path)
- [x] `fieldDefinitionService.kysely-sql.test.ts` — new 15-test regression suite:
  - tenant_id defence-in-depth on every data query of all 5 exported functions
  - INSERT column shape pinned for both `field_definitions` (14 cols) and `layout_fields` (7 cols, including `tenant_id`)
  - UPDATE shape pinned: only provided columns set, RETURNING used to avoid a follow-up SELECT
  - No explicit BEGIN/COMMIT
- [x] Full api workspace test suite: 814/814 passing
- [x] `tsc --noEmit` clean

Refs #445

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf