### PR TITLE
Migrate relationshipDefinitionService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/relationshipDefinitionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/relationshipDefinitionService.kysely-sql.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Kysely SQL regression suite for relationshipDefinitionService.
+ *
+ * Complements `relationshipDefinitionService.test.ts` (behavioural
+ * assertions) by asserting directly on the SQL Kysely emits for each
+ * exported service function. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query — including each branch of
+ *      the `relationship_definitions ⋈ object_definitions` join — carries
+ *      a `tenant_id` filter as defence-in-depth against an RLS
+ *      misconfiguration (ADR-006).
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const SOURCE_OBJECT_ID = 'obj-source-001';
+const TARGET_OBJECT_ID = 'obj-target-001';
+const RELATIONSHIP_ID = 'rel-test-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      // Transaction control statements
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+
+      // RLS preamble
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // Source/target object existence check:
+      // SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2
+      if (
+        s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+        s.includes('WHERE ID =') &&
+        s.includes('TENANT_ID')
+      ) {
+        return { rows: [{ id: params?.[0] ?? SOURCE_OBJECT_ID }] };
+      }
+
+      // Uniqueness check: SELECT id FROM relationship_definitions WHERE ... api_name ...
+      if (
+        s.startsWith('SELECT ID FROM RELATIONSHIP_DEFINITIONS') &&
+        s.includes('API_NAME')
+      ) {
+        return { rows: [] };
+      }
+
+      // INSERT INTO relationship_definitions RETURNING *
+      if (s.startsWith('INSERT INTO RELATIONSHIP_DEFINITIONS')) {
+        return {
+          rows: [
+            {
+              id: RELATIONSHIP_ID,
+              tenant_id: TENANT_ID,
+              source_object_id: SOURCE_OBJECT_ID,
+              target_object_id: TARGET_OBJECT_ID,
+              relationship_type: 'lookup',
+              api_name: 'opportunity_account',
+              label: 'Opportunity',
+              reverse_label: null,
+              required: false,
+              created_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // listRelationshipDefinitions — SELECT ... FROM relationship_definitions AS rd
+      // INNER JOIN object_definitions AS src / tgt
+      // (no WHERE RD.ID = — distinguishes list from delete lookup)
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+        !s.includes('WHERE RD.ID =') &&
+        !s.includes('RD.ID = ')
+      ) {
+        return { rows: [] };
+      }
+
+      // deleteRelationshipDefinition lookup — SELECT with join AND WHERE rd.id = $1
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+        (s.includes('WHERE RD.ID =') || s.includes('RD.ID ='))
+      ) {
+        return {
+          rows: [
+            {
+              id: RELATIONSHIP_ID,
+              source_is_system: false,
+              target_is_system: false,
+            },
+          ],
+        };
+      }
+
+      // DELETE FROM relationship_definitions
+      if (s.startsWith('DELETE FROM RELATIONSHIP_DEFINITIONS')) {
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createRelationshipDefinition,
+  listRelationshipDefinitions,
+  deleteRelationshipDefinition,
+} = await import('../relationshipDefinitionService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const baseCreateParams = {
+  sourceObjectId: SOURCE_OBJECT_ID,
+  targetObjectId: TARGET_OBJECT_ID,
+  relationshipType: 'lookup',
+  apiName: 'opportunity_account',
+  label: 'Account',
+  reverseLabel: 'Opportunities',
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('relationshipDefinitionService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on createRelationshipDefinition references tenant_id', async () => {
+    await createRelationshipDefinition(TENANT_ID, baseCreateParams);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on listRelationshipDefinitions references tenant_id', async () => {
+    await listRelationshipDefinitions(TENANT_ID, SOURCE_OBJECT_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on deleteRelationshipDefinition references tenant_id', async () => {
+    await deleteRelationshipDefinition(TENANT_ID, RELATIONSHIP_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('listRelationshipDefinitions binds tenant_id in both JOIN ON clauses and the outer WHERE', async () => {
+    await listRelationshipDefinitions(TENANT_ID, SOURCE_OBJECT_ID);
+
+    const selects = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') && s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD')
+      );
+    });
+    expect(selects.length).toBe(1);
+
+    // src join, tgt join, and outer WHERE each bind tenant_id — 3 copies.
+    const tenantBindCount = selects[0]!.params.filter(
+      (p) => p === TENANT_ID,
+    ).length;
+    expect(tenantBindCount).toBe(3);
+  });
+
+  it('deleteRelationshipDefinition lookup binds tenant_id in both JOIN ON clauses and the outer WHERE', async () => {
+    await deleteRelationshipDefinition(TENANT_ID, RELATIONSHIP_ID);
+
+    const lookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+        (s.includes('WHERE RD.ID =') || s.includes('RD.ID ='))
+      );
+    });
+    expect(lookups.length).toBe(1);
+
+    const tenantBindCount = lookups[0]!.params.filter(
+      (p) => p === TENANT_ID,
+    ).length;
+    expect(tenantBindCount).toBe(3);
+  });
+});
+
+describe('relationshipDefinitionService Kysely SQL — generated SQL shape', () => {
+  it('createRelationshipDefinition INSERT carries all 10 columns with tenant_id as second bind', async () => {
+    await createRelationshipDefinition(TENANT_ID, baseCreateParams);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RELATIONSHIP_DEFINITIONS'),
+    );
+    expect(inserts.length).toBe(1);
+    // id, tenant_id, source_object_id, target_object_id, relationship_type,
+    // api_name, label, reverse_label, required, created_at
+    expect(inserts[0]!.params.length).toBe(10);
+    expect(inserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(inserts[0]!.params[2]).toBe(SOURCE_OBJECT_ID);
+    expect(inserts[0]!.params[3]).toBe(TARGET_OBJECT_ID);
+    expect(inserts[0]!.params[4]).toBe('lookup');
+    expect(inserts[0]!.params[5]).toBe('opportunity_account');
+    expect(inserts[0]!.params[6]).toBe('Account');
+  });
+
+  it('createRelationshipDefinition validates source and target object existence before the INSERT', async () => {
+    await createRelationshipDefinition(TENANT_ID, baseCreateParams);
+
+    const objectLookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+        s.includes('WHERE ID =')
+      );
+    });
+    // One lookup for source, one for target.
+    expect(objectLookups.length).toBe(2);
+    for (const q of objectLookups) {
+      const s = normalise(q.sql);
+      expect(s).toContain('TENANT_ID');
+    }
+  });
+
+  it('createRelationshipDefinition checks api_name uniqueness scoped by source_object_id + tenant_id', async () => {
+    await createRelationshipDefinition(TENANT_ID, baseCreateParams);
+
+    const uniqueChecks = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT ID FROM RELATIONSHIP_DEFINITIONS') &&
+        s.includes('API_NAME')
+      );
+    });
+    expect(uniqueChecks.length).toBe(1);
+
+    const s = normalise(uniqueChecks[0]!.sql);
+    expect(s).toContain('SOURCE_OBJECT_ID =');
+    expect(s).toContain('API_NAME =');
+    expect(s).toContain('TENANT_ID =');
+  });
+
+  it('listRelationshipDefinitions uses aliased INNER JOINs on object_definitions for source and target', async () => {
+    await listRelationshipDefinitions(TENANT_ID, SOURCE_OBJECT_ID);
+
+    const selects = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') && s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD')
+      );
+    });
+    expect(selects.length).toBe(1);
+
+    const s = normalise(selects[0]!.sql);
+    expect(s).toContain('FROM RELATIONSHIP_DEFINITIONS AS RD');
+    expect(s).toContain('INNER JOIN OBJECT_DEFINITIONS AS SRC');
+    expect(s).toContain('INNER JOIN OBJECT_DEFINITIONS AS TGT');
+    // Aliased label/plural_label columns surface to UI
+    expect(s).toContain('SOURCE_OBJECT_API_NAME');
+    expect(s).toContain('SOURCE_OBJECT_LABEL');
+    expect(s).toContain('SOURCE_OBJECT_PLURAL_LABEL');
+    expect(s).toContain('TARGET_OBJECT_API_NAME');
+    expect(s).toContain('TARGET_OBJECT_LABEL');
+    expect(s).toContain('TARGET_OBJECT_PLURAL_LABEL');
+    // Bidirectional match: object appears as either source or target
+    expect(s).toContain('RD.SOURCE_OBJECT_ID =');
+    expect(s).toContain('RD.TARGET_OBJECT_ID =');
+    expect(s).toContain('ORDER BY RD.CREATED_AT ASC');
+  });
+
+  it('listRelationshipDefinitions performs the caller-object existence check against object_definitions', async () => {
+    await listRelationshipDefinitions(TENANT_ID, SOURCE_OBJECT_ID);
+
+    const existenceCheck = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+        s.includes('WHERE ID =')
+      );
+    });
+    expect(existenceCheck.length).toBe(1);
+    const s = normalise(existenceCheck[0]!.sql);
+    expect(s).toContain('TENANT_ID');
+  });
+
+  it('deleteRelationshipDefinition lookup selects is_system flags from both joined objects', async () => {
+    await deleteRelationshipDefinition(TENANT_ID, RELATIONSHIP_ID);
+
+    const lookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+        (s.includes('WHERE RD.ID =') || s.includes('RD.ID ='))
+      );
+    });
+    expect(lookups.length).toBe(1);
+
+    const s = normalise(lookups[0]!.sql);
+    expect(s).toContain('INNER JOIN OBJECT_DEFINITIONS AS SRC');
+    expect(s).toContain('INNER JOIN OBJECT_DEFINITIONS AS TGT');
+    expect(s).toContain('SOURCE_IS_SYSTEM');
+    expect(s).toContain('TARGET_IS_SYSTEM');
+  });
+
+  it('deleteRelationshipDefinition issues exactly one DELETE scoped by id + tenant_id', async () => {
+    await deleteRelationshipDefinition(TENANT_ID, RELATIONSHIP_ID);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM RELATIONSHIP_DEFINITIONS'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const s = normalise(deletes[0]!.sql);
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+  });
+});
+
+describe('relationshipDefinitionService Kysely SQL — non-transactional paths', () => {
+  it('createRelationshipDefinition runs without opening an explicit transaction', async () => {
+    await createRelationshipDefinition(TENANT_ID, baseCreateParams);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('listRelationshipDefinitions runs without opening an explicit transaction', async () => {
+    await listRelationshipDefinitions(TENANT_ID, SOURCE_OBJECT_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('deleteRelationshipDefinition runs without opening an explicit transaction', async () => {
+    await deleteRelationshipDefinition(TENANT_ID, RELATIONSHIP_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/relationshipDefinitionService.test.ts
+++ b/apps/api/src/services/__tests__/relationshipDefinitionService.test.ts
@@ -16,23 +16,41 @@ vi.mock('../../lib/logger.js', () => ({
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
 
-const { fakeObjects, fakeRelationships, mockQuery } = vi.hoisted(() => {
+const { fakeObjects, fakeRelationships, mockQuery, mockConnect } = vi.hoisted(() => {
   const fakeObjects = new Map<string, Record<string, unknown>>();
   const fakeRelationships = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(rawSql: string, params?: unknown[]) {
+    // Strip identifier quoting so matching is quote-agnostic.
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
-    // SELECT id FROM object_definitions WHERE id = $1
-    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
+    // Transaction control statements — no-ops in the fake.
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+
+    // RLS preamble
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2
+    if (
+      s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS') &&
+      s.includes('WHERE ID =')
+    ) {
       const id = params![0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
       return { rows: [] };
     }
 
-    // SELECT id FROM relationship_definitions WHERE source_object_id = $1 AND api_name = $2
-    if (s.startsWith('SELECT ID FROM RELATIONSHIP_DEFINITIONS WHERE SOURCE_OBJECT_ID') && s.includes('API_NAME')) {
+    // SELECT id FROM relationship_definitions WHERE source_object_id AND api_name AND tenant_id
+    if (
+      s.startsWith('SELECT ID FROM RELATIONSHIP_DEFINITIONS') &&
+      s.includes('SOURCE_OBJECT_ID') &&
+      s.includes('API_NAME')
+    ) {
       const sourceObjectId = params![0] as string;
       const apiName = params![1] as string;
       const match = [...fakeRelationships.values()].find(
@@ -42,21 +60,63 @@ const { fakeObjects, fakeRelationships, mockQuery } = vi.hoisted(() => {
       return { rows: [] };
     }
 
-    // INSERT INTO relationship_definitions
+    // INSERT INTO relationship_definitions — Kysely binds values in
+    // the column order declared in the service's `.values({...})`
+    // call. Column order: id, tenant_id, source_object_id,
+    // target_object_id, relationship_type, api_name, label,
+    // reverse_label, required, created_at (10 columns).
     if (s.startsWith('INSERT INTO RELATIONSHIP_DEFINITIONS')) {
-      const [id, _tenant_id, source_object_id, target_object_id, relationship_type, api_name, label, reverse_label, required, created_at] = params as unknown[];
+      const [
+        id,
+        tenant_id,
+        source_object_id,
+        target_object_id,
+        relationship_type,
+        api_name,
+        label,
+        reverse_label,
+        required,
+        created_at,
+      ] = params as unknown[];
       const row: Record<string, unknown> = {
-        id, source_object_id, target_object_id, relationship_type, api_name, label, reverse_label, required, created_at,
+        id,
+        tenant_id,
+        source_object_id,
+        target_object_id,
+        relationship_type,
+        api_name,
+        label,
+        reverse_label,
+        required,
+        created_at,
       };
       fakeRelationships.set(id as string, row);
       return { rows: [row] };
     }
 
-    // SELECT rd.*, src.label ... (list relationships with joins)
-    if (s.includes('FROM RELATIONSHIP_DEFINITIONS RD') && s.includes('JOIN OBJECT_DEFINITIONS SRC') && s.includes('JOIN OBJECT_DEFINITIONS TGT') && s.includes('SOURCE_OBJECT_ID = $1 OR RD.TARGET_OBJECT_ID = $1')) {
-      const objectId = params![0] as string;
+    // listRelationshipDefinitions — joined SELECT. Kysely emits
+    //   from "relationship_definitions" as "rd"
+    //   inner join "object_definitions" as "src" on "src"."id" = "rd"."source_object_id" and "src"."tenant_id" = $1
+    //   inner join "object_definitions" as "tgt" on ...
+    //   where ("rd"."source_object_id" = $N or "rd"."target_object_id" = $N+1) and "rd"."tenant_id" = $N+2
+    // After quote-strip + upper-case the FROM clause is
+    // "FROM RELATIONSHIP_DEFINITIONS AS RD".
+    if (
+      s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+      s.includes('INNER JOIN OBJECT_DEFINITIONS AS SRC') &&
+      s.includes('INNER JOIN OBJECT_DEFINITIONS AS TGT') &&
+      s.includes('SOURCE_OBJECT_ID') &&
+      s.includes('TARGET_OBJECT_ID') &&
+      !s.includes('WHERE RD.ID =')
+    ) {
+      // Param layout: [tenantId, tenantId, objectId, objectId, tenantId]
+      // The last bind is always the outer rd.tenant_id filter. The
+      // object id binds are the 3rd/4th (the OR clause in the WHERE).
+      const objectId = params![2] as string;
       const rows = [...fakeRelationships.values()]
-        .filter((r) => r.source_object_id === objectId || r.target_object_id === objectId)
+        .filter(
+          (r) => r.source_object_id === objectId || r.target_object_id === objectId,
+        )
         .map((r) => {
           const src = fakeObjects.get(r.source_object_id as string);
           const tgt = fakeObjects.get(r.target_object_id as string);
@@ -73,24 +133,33 @@ const { fakeObjects, fakeRelationships, mockQuery } = vi.hoisted(() => {
       return { rows };
     }
 
-    // SELECT rd.*, src.is_system ... (delete check with system flag)
-    if (s.includes('FROM RELATIONSHIP_DEFINITIONS RD') && s.includes('JOIN OBJECT_DEFINITIONS SRC') && s.includes('JOIN OBJECT_DEFINITIONS TGT') && s.includes('WHERE RD.ID = $1')) {
-      const id = params![0] as string;
+    // deleteRelationshipDefinition lookup — joined SELECT with
+    //   where "rd"."id" = $N and "rd"."tenant_id" = $N+1
+    if (
+      s.includes('FROM RELATIONSHIP_DEFINITIONS AS RD') &&
+      s.includes('INNER JOIN OBJECT_DEFINITIONS AS SRC') &&
+      s.includes('INNER JOIN OBJECT_DEFINITIONS AS TGT') &&
+      s.includes('WHERE RD.ID =')
+    ) {
+      // Param layout: [tenantId, tenantId, id, tenantId]
+      const id = params![2] as string;
       const rel = fakeRelationships.get(id);
       if (!rel) return { rows: [] };
       const src = fakeObjects.get(rel.source_object_id as string);
       const tgt = fakeObjects.get(rel.target_object_id as string);
       return {
-        rows: [{
-          ...rel,
-          source_is_system: src?.is_system ?? false,
-          target_is_system: tgt?.is_system ?? false,
-        }],
+        rows: [
+          {
+            id: rel.id,
+            source_is_system: src?.is_system ?? false,
+            target_is_system: tgt?.is_system ?? false,
+          },
+        ],
       };
     }
 
-    // DELETE FROM relationship_definitions WHERE id = $1
-    if (s.startsWith('DELETE FROM RELATIONSHIP_DEFINITIONS WHERE ID')) {
+    // DELETE FROM relationship_definitions WHERE id = $1 AND tenant_id = $2
+    if (s.startsWith('DELETE FROM RELATIONSHIP_DEFINITIONS')) {
       const id = params![0] as string;
       const existed = fakeRelationships.has(id);
       fakeRelationships.delete(id);
@@ -98,13 +167,28 @@ const { fakeObjects, fakeRelationships, mockQuery } = vi.hoisted(() => {
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params);
   });
 
-  return { fakeObjects, fakeRelationships, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeObjects, fakeRelationships, mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Test helpers ────────────────────────────────────────────────────────────

--- a/apps/api/src/services/relationshipDefinitionService.ts
+++ b/apps/api/src/services/relationshipDefinitionService.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'crypto';
+import type { Selectable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type {
+  ObjectDefinitions,
+  RelationshipDefinitions,
+} from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -69,29 +74,57 @@ function throwDeleteBlockedError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToRelationshipDefinition(row: Record<string, unknown>): RelationshipDefinition {
+/**
+ * Typing the row mapper against `Selectable<RelationshipDefinitions>`
+ * (rather than `Record<string, unknown>`) means a column rename or
+ * nullability change on the generated schema becomes a compile-time
+ * error at this service, rather than an `unknown` cast leaking an
+ * incorrect runtime shape into the domain model.
+ */
+type RelationshipDefinitionSelectable = Selectable<RelationshipDefinitions>;
+
+function rowToRelationshipDefinition(
+  row: RelationshipDefinitionSelectable,
+): RelationshipDefinition {
   return {
-    id: row.id as string,
-    sourceObjectId: row.source_object_id as string,
-    targetObjectId: row.target_object_id as string,
-    relationshipType: row.relationship_type as string,
-    apiName: row.api_name as string,
-    label: row.label as string,
-    reverseLabel: (row.reverse_label as string | null) ?? undefined,
-    required: row.required as boolean,
-    createdAt: new Date(row.created_at as string),
+    id: row.id,
+    sourceObjectId: row.source_object_id,
+    targetObjectId: row.target_object_id,
+    relationshipType: row.relationship_type,
+    apiName: row.api_name,
+    label: row.label,
+    reverseLabel: row.reverse_label ?? undefined,
+    required: row.required,
+    createdAt: row.created_at,
   };
 }
 
-function rowToRelationshipDefinitionWithObjects(row: Record<string, unknown>): RelationshipDefinitionWithObjects {
+/**
+ * The list query projects relationship_definitions columns plus six
+ * aliased object_definitions columns (three for the source, three for
+ * the target). We type that composite row explicitly so the mapper
+ * stays fully type-checked against the generated schema.
+ */
+type RelationshipDefinitionWithObjectsRow = RelationshipDefinitionSelectable & {
+  source_object_api_name: Selectable<ObjectDefinitions>['api_name'];
+  source_object_label: Selectable<ObjectDefinitions>['label'];
+  source_object_plural_label: Selectable<ObjectDefinitions>['plural_label'];
+  target_object_api_name: Selectable<ObjectDefinitions>['api_name'];
+  target_object_label: Selectable<ObjectDefinitions>['label'];
+  target_object_plural_label: Selectable<ObjectDefinitions>['plural_label'];
+};
+
+function rowToRelationshipDefinitionWithObjects(
+  row: RelationshipDefinitionWithObjectsRow,
+): RelationshipDefinitionWithObjects {
   return {
     ...rowToRelationshipDefinition(row),
-    sourceObjectApiName: row.source_object_api_name as string,
-    sourceObjectLabel: row.source_object_label as string,
-    sourceObjectPluralLabel: row.source_object_plural_label as string,
-    targetObjectApiName: row.target_object_api_name as string,
-    targetObjectLabel: row.target_object_label as string,
-    targetObjectPluralLabel: row.target_object_plural_label as string,
+    sourceObjectApiName: row.source_object_api_name,
+    sourceObjectLabel: row.source_object_label,
+    sourceObjectPluralLabel: row.source_object_plural_label,
+    targetObjectApiName: row.target_object_api_name,
+    targetObjectLabel: row.target_object_label,
+    targetObjectPluralLabel: row.target_object_plural_label,
   };
 }
 
@@ -171,28 +204,35 @@ export async function createRelationshipDefinition(
   }
 
   // Validate both objects exist within tenant
-  const sourceResult = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [params.sourceObjectId, tenantId],
-  );
-  if (sourceResult.rows.length === 0) {
+  const sourceRow = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', params.sourceObjectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!sourceRow) {
     throwNotFoundError('Source object definition not found');
   }
 
-  const targetResult = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [params.targetObjectId, tenantId],
-  );
-  if (targetResult.rows.length === 0) {
+  const targetRow = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', params.targetObjectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!targetRow) {
     throwNotFoundError('Target object definition not found');
   }
 
   // Check uniqueness of api_name on the source object within tenant
-  const existing = await pool.query(
-    'SELECT id FROM relationship_definitions WHERE source_object_id = $1 AND api_name = $2 AND tenant_id = $3',
-    [params.sourceObjectId, params.apiName.trim(), tenantId],
-  );
-  if (existing.rows.length > 0) {
+  const existing = await db
+    .selectFrom('relationship_definitions')
+    .select('id')
+    .where('source_object_id', '=', params.sourceObjectId)
+    .where('api_name', '=', params.apiName.trim())
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (existing) {
     throwConflictError(
       `A relationship with api_name "${params.apiName.trim()}" already exists on this source object`,
     );
@@ -201,31 +241,34 @@ export async function createRelationshipDefinition(
   const relationshipId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO relationship_definitions
-       (id, tenant_id, source_object_id, target_object_id, relationship_type, api_name, label, reverse_label, required, created_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-     RETURNING *`,
-    [
-      relationshipId,
-      tenantId,
-      params.sourceObjectId,
-      params.targetObjectId,
-      params.relationshipType.trim(),
-      params.apiName.trim(),
-      params.label.trim(),
-      params.reverseLabel?.trim() ?? null,
-      params.required ?? false,
-      now,
-    ],
-  );
+  const inserted = await db
+    .insertInto('relationship_definitions')
+    .values({
+      id: relationshipId,
+      tenant_id: tenantId,
+      source_object_id: params.sourceObjectId,
+      target_object_id: params.targetObjectId,
+      relationship_type: params.relationshipType.trim(),
+      api_name: params.apiName.trim(),
+      label: params.label.trim(),
+      reverse_label: params.reverseLabel?.trim() ?? null,
+      required: params.required ?? false,
+      created_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info(
-    { relationshipId, sourceObjectId: params.sourceObjectId, targetObjectId: params.targetObjectId, apiName: params.apiName },
+    {
+      relationshipId,
+      sourceObjectId: params.sourceObjectId,
+      targetObjectId: params.targetObjectId,
+      apiName: params.apiName,
+    },
     'Relationship definition created',
   );
 
-  return rowToRelationshipDefinition(result.rows[0]);
+  return rowToRelationshipDefinition(inserted);
 }
 
 /**
@@ -239,33 +282,52 @@ export async function listRelationshipDefinitions(
   objectId: string,
 ): Promise<RelationshipDefinitionWithObjects[]> {
   // Validate object exists within tenant
-  const objectResult = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (objectResult.rows.length === 0) {
+  const objectRow = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!objectRow) {
     throwNotFoundError('Object definition not found');
   }
 
-  const result = await pool.query(
-    `SELECT rd.*,
-            src.api_name AS source_object_api_name,
-            src.label AS source_object_label,
-            src.plural_label AS source_object_plural_label,
-            tgt.api_name AS target_object_api_name,
-            tgt.label AS target_object_label,
-            tgt.plural_label AS target_object_plural_label
-     FROM relationship_definitions rd
-     JOIN object_definitions src ON src.id = rd.source_object_id
-     JOIN object_definitions tgt ON tgt.id = rd.target_object_id
-     WHERE (rd.source_object_id = $1 OR rd.target_object_id = $1) AND rd.tenant_id = $2
-     ORDER BY rd.created_at ASC`,
-    [objectId, tenantId],
-  );
+  // Join to both src and tgt object_definitions rows to surface label
+  // metadata alongside each relationship. Every joined table is also
+  // scoped by tenant_id as defence-in-depth against an RLS
+  // misconfiguration (ADR-006).
+  const rows = await db
+    .selectFrom('relationship_definitions as rd')
+    .innerJoin('object_definitions as src', (join) =>
+      join
+        .onRef('src.id', '=', 'rd.source_object_id')
+        .on('src.tenant_id', '=', tenantId),
+    )
+    .innerJoin('object_definitions as tgt', (join) =>
+      join
+        .onRef('tgt.id', '=', 'rd.target_object_id')
+        .on('tgt.tenant_id', '=', tenantId),
+    )
+    .selectAll('rd')
+    .select([
+      'src.api_name as source_object_api_name',
+      'src.label as source_object_label',
+      'src.plural_label as source_object_plural_label',
+      'tgt.api_name as target_object_api_name',
+      'tgt.label as target_object_label',
+      'tgt.plural_label as target_object_plural_label',
+    ])
+    .where((eb) =>
+      eb.or([
+        eb('rd.source_object_id', '=', objectId),
+        eb('rd.target_object_id', '=', objectId),
+      ]),
+    )
+    .where('rd.tenant_id', '=', tenantId)
+    .orderBy('rd.created_at', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) =>
-    rowToRelationshipDefinitionWithObjects(row),
-  );
+  return rows.map(rowToRelationshipDefinitionWithObjects);
 }
 
 /**
@@ -276,30 +338,48 @@ export async function listRelationshipDefinitions(
  * @throws {Error} NOT_FOUND — relationship does not exist
  * @throws {Error} DELETE_BLOCKED — system relationship
  */
-export async function deleteRelationshipDefinition(tenantId: string, id: string): Promise<void> {
-  const existing = await pool.query(
-    `SELECT rd.*,
-            src.is_system AS source_is_system,
-            tgt.is_system AS target_is_system
-     FROM relationship_definitions rd
-     JOIN object_definitions src ON src.id = rd.source_object_id
-     JOIN object_definitions tgt ON tgt.id = rd.target_object_id
-     WHERE rd.id = $1 AND rd.tenant_id = $2`,
-    [id, tenantId],
-  );
+export async function deleteRelationshipDefinition(
+  tenantId: string,
+  id: string,
+): Promise<void> {
+  const existingRow = await db
+    .selectFrom('relationship_definitions as rd')
+    .innerJoin('object_definitions as src', (join) =>
+      join
+        .onRef('src.id', '=', 'rd.source_object_id')
+        .on('src.tenant_id', '=', tenantId),
+    )
+    .innerJoin('object_definitions as tgt', (join) =>
+      join
+        .onRef('tgt.id', '=', 'rd.target_object_id')
+        .on('tgt.tenant_id', '=', tenantId),
+    )
+    .select([
+      'rd.id',
+      'src.is_system as source_is_system',
+      'tgt.is_system as target_is_system',
+    ])
+    .where('rd.id', '=', id)
+    .where('rd.tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Relationship definition not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
   // System relationships (both source and target are system objects) cannot be deleted
-  if (row.source_is_system === true && row.target_is_system === true) {
+  if (
+    existingRow.source_is_system === true &&
+    existingRow.target_is_system === true
+  ) {
     throwDeleteBlockedError('Cannot delete system relationships');
   }
 
-  await pool.query('DELETE FROM relationship_definitions WHERE id = $1 AND tenant_id = $2', [id, tenantId]);
+  await db
+    .deleteFrom('relationship_definitions')
+    .where('id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ relationshipId: id }, 'Relationship definition deleted');
 }


### PR DESCRIPTION
## Summary

Continues Phase 3b of the Kysely migration (#445). Replaces raw pg text queries in `relationshipDefinitionService.ts` with Kysely query builder for all three exported functions (`createRelationshipDefinition`, `listRelationshipDefinitions`, `deleteRelationshipDefinition`).

- Row mappers are typed against `Selectable<RelationshipDefinitions>` and `Selectable<ObjectDefinitions>` — a column rename on the generated schema becomes a compile-time error at this service rather than leaking an `unknown` cast into the domain model.
- `listRelationshipDefinitions` and the delete-lookup query use aliased `INNER JOIN object_definitions` twice (source + target), with `tenant_id` pinned inside each JOIN ON clause as defence-in-depth per ADR-006.
- `createRelationshipDefinition` keeps the same uniqueness and existence checks, now as Kysely `selectFrom(...).executeTakeFirst()` calls.
- Tests rewritten to drive Kysely: quote-stripping pg mock, `mockConnect` routing for Kysely's per-query `pool.connect()` pattern, matchers for `FROM RELATIONSHIP_DEFINITIONS AS RD` + `INNER JOIN OBJECT_DEFINITIONS AS SRC/TGT`, and updated param indexes that account for tenant_id binds coming first from the JOIN ON clauses.
- New companion `relationshipDefinitionService.kysely-sql.test.ts` regression suite (15 tests) asserts the compiled SQL shape: tenant_id defence-in-depth on every data query, both JOIN ON bindings + the outer WHERE, 10-column INSERT layout, JOIN aliases, and non-transactional execution paths.

## Test plan

- [x] `npx vitest run apps/api/src/services/__tests__/relationshipDefinitionService.test.ts` — 32/32 pass
- [x] `npx vitest run apps/api/src/services/__tests__/relationshipDefinitionService.kysely-sql.test.ts` — 15/15 pass
- [x] `npx vitest run apps/api/src/services/__tests__/` — 850/850 pass
- [x] `tsc --noEmit` — clean

After this merges the remaining Group B service is `recordRelationshipService.ts`.

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf