### PR TITLE
Migrate recordRelationshipService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/recordRelationshipService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/recordRelationshipService.kysely-sql.test.ts
@@ -357,7 +357,7 @@ describe('recordRelationshipService Kysely SQL — tenant_id defence-in-depth', 
         s.includes('UNION')
       );
     });
-    // Both the count query and the data query wrap the same UNION.
+    // Both the count query and the data query wrap their own UNION.
     expect(unionQueries.length).toBeGreaterThanOrEqual(2);
 
     for (const q of unionQueries) {
@@ -374,6 +374,41 @@ describe('recordRelationshipService Kysely SQL — tenant_id defence-in-depth', 
       const tenantBindCount = q.params.filter((p) => p === TENANT_ID).length;
       expect(tenantBindCount).toBeGreaterThanOrEqual(4);
     }
+  });
+
+  it('getRelatedRecords count query projects only r.id to keep UNION dedup lightweight', async () => {
+    // Regression test for Codex review
+    // https://github.com/Brianclark490/CPCRM/pull/460#discussion_r3089285469
+    //
+    // The count path used to reuse the full-projection UNION, forcing
+    // Postgres to dedupe wide rows including JSONB `field_values`
+    // before counting. We now run an id-only UNION for the count,
+    // leaving the wide projection only for the data/paged query.
+    await getRelatedRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      'account',
+      'user-123',
+      20,
+      0,
+    );
+
+    const countQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return s.includes('COUNT(*)') && s.includes('AS RELATED');
+    });
+    expect(countQueries.length).toBe(1);
+
+    const countSql = normalise(countQueries[0]!.sql);
+    // Count subquery projects only r.id — no wide columns.
+    expect(countSql).toContain('UNION');
+    expect(countSql).not.toContain('R.NAME');
+    expect(countSql).not.toContain('R.FIELD_VALUES');
+    expect(countSql).not.toContain('R.CREATED_AT');
+    expect(countSql).not.toContain('R.UPDATED_AT');
+    // Two `r.id` projections — one per UNION branch.
+    const idProjections = countSql.match(/SELECT R\.ID/g) ?? [];
+    expect(idProjections.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/apps/api/src/services/__tests__/recordRelationshipService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/recordRelationshipService.kysely-sql.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Kysely SQL regression suite for recordRelationshipService.
+ *
+ * Complements `recordRelationshipService.test.ts` (behavioural
+ * assertions) by asserting directly on the SQL Kysely emits for each
+ * exported service function. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query — including each branch of
+ *      the UNION in getRelatedRecords and both sides of the
+ *      `record_relationships ⋈ records` join — carries a `tenant_id`
+ *      filter as defence-in-depth against an RLS misconfiguration
+ *      (ADR-006).
+ *   3. Pin the latent duplicate-check / parent-check / related-records
+ *      tenant_id fixes so a future refactor doesn't reintroduce the
+ *      defence-in-depth gap.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const SOURCE_RECORD_ID = 'rec-source-001';
+const TARGET_RECORD_ID = 'rec-target-001';
+const RELATIONSHIP_ID = 'rel-test-001';
+const LINK_ID = 'link-test-001';
+const SOURCE_OBJECT_ID = 'obj-source-001';
+const TARGET_OBJECT_ID = 'obj-target-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      // Transaction control + RLS preamble
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // getRelatedRecords count wrapping the UNION subquery
+      if (s.includes('COUNT(*)') && s.includes('AS RELATED')) {
+        return { rows: [{ total: '0' }] };
+      }
+      // getRelatedRecords data wrapping the UNION subquery
+      if (s.includes('FROM RELATED') || s.includes('AS RELATED')) {
+        return { rows: [] };
+      }
+
+      // linkRecords — SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS') &&
+        s.includes('OBJECT_ID') &&
+        s.includes('WHERE ID =') &&
+        !s.includes('FROM RELATIONSHIP_DEFINITIONS')
+      ) {
+        return {
+          rows: [
+            {
+              id: params?.[0] ?? SOURCE_RECORD_ID,
+              object_id:
+                params?.[0] === TARGET_RECORD_ID
+                  ? TARGET_OBJECT_ID
+                  : SOURCE_OBJECT_ID,
+            },
+          ],
+        };
+      }
+
+      // unlinkRecords — SELECT id FROM records WHERE id = $1 AND tenant_id = $2
+      if (
+        s.startsWith('SELECT ID FROM RECORDS') &&
+        !s.includes('OBJECT_ID')
+      ) {
+        return { rows: [{ id: params?.[0] ?? SOURCE_RECORD_ID }] };
+      }
+
+      // linkRecords — SELECT * FROM relationship_definitions WHERE id = $1 AND tenant_id = $2
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS') &&
+        s.includes('WHERE ID =')
+      ) {
+        return {
+          rows: [
+            {
+              id: RELATIONSHIP_ID,
+              tenant_id: TENANT_ID,
+              source_object_id: SOURCE_OBJECT_ID,
+              target_object_id: TARGET_OBJECT_ID,
+              relationship_type: 'lookup',
+              api_name: 'opportunity_account',
+              label: 'Account',
+              reverse_label: null,
+              required: false,
+              created_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // linkRecords duplicate check — SELECT id FROM record_relationships WHERE
+      //   relationship_id AND source_record_id AND target_record_id AND tenant_id
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORD_RELATIONSHIPS') &&
+        s.includes('RELATIONSHIP_ID =') &&
+        s.includes('SOURCE_RECORD_ID =') &&
+        s.includes('TARGET_RECORD_ID =')
+      ) {
+        return { rows: [] };
+      }
+
+      // linkRecords parent check — SELECT id FROM record_relationships WHERE
+      //   relationship_id AND source_record_id AND tenant_id (no target)
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORD_RELATIONSHIPS') &&
+        s.includes('RELATIONSHIP_ID =') &&
+        s.includes('SOURCE_RECORD_ID =') &&
+        !s.includes('TARGET_RECORD_ID')
+      ) {
+        return { rows: [] };
+      }
+
+      // unlinkRecords lookup — SELECT id FROM record_relationships WHERE
+      //   id AND tenant_id AND (source = $ OR target = $)
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORD_RELATIONSHIPS') &&
+        s.includes('ID =') &&
+        s.includes('SOURCE_RECORD_ID =') &&
+        s.includes('TARGET_RECORD_ID =')
+      ) {
+        return { rows: [{ id: LINK_ID }] };
+      }
+
+      // INSERT INTO record_relationships
+      if (s.startsWith('INSERT INTO RECORD_RELATIONSHIPS')) {
+        return {
+          rows: [
+            {
+              id: LINK_ID,
+              tenant_id: TENANT_ID,
+              relationship_id: RELATIONSHIP_ID,
+              source_record_id: SOURCE_RECORD_ID,
+              target_record_id: TARGET_RECORD_ID,
+              created_at: new Date(),
+            },
+          ],
+        };
+      }
+
+      // DELETE FROM record_relationships
+      if (s.startsWith('DELETE FROM RECORD_RELATIONSHIPS')) {
+        return { rows: [] };
+      }
+
+      // getRelatedRecords — resolve object type
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM OBJECT_DEFINITIONS') &&
+        s.includes('API_NAME =')
+      ) {
+        return { rows: [{ id: TARGET_OBJECT_ID }] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { linkRecords, unlinkRecords, getRelatedRecords } = await import(
+  '../recordRelationshipService.js'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('recordRelationshipService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on linkRecords references tenant_id', async () => {
+    await linkRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      RELATIONSHIP_ID,
+      TARGET_RECORD_ID,
+      'user-123',
+    );
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on unlinkRecords references tenant_id', async () => {
+    await unlinkRecords(TENANT_ID, SOURCE_RECORD_ID, LINK_ID, 'user-123');
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on getRelatedRecords references tenant_id', async () => {
+    await getRelatedRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      'account',
+      'user-123',
+      20,
+      0,
+    );
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('linkRecords duplicate check binds tenant_id (latent bug fix)', async () => {
+    // Historical bug: the raw-pg implementation omitted tenant_id on
+    // the duplicate-link check, leaving it reliant on RLS alone. The
+    // Kysely migration adds tenant_id as defence-in-depth and this
+    // assertion pins the fix.
+    await linkRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      RELATIONSHIP_ID,
+      TARGET_RECORD_ID,
+      'user-123',
+    );
+
+    const duplicateChecks = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORD_RELATIONSHIPS') &&
+        s.includes('RELATIONSHIP_ID =') &&
+        s.includes('SOURCE_RECORD_ID =') &&
+        s.includes('TARGET_RECORD_ID =')
+      );
+    });
+    expect(duplicateChecks.length).toBe(1);
+
+    const s = normalise(duplicateChecks[0]!.sql);
+    expect(s).toContain('TENANT_ID =');
+    expect(duplicateChecks[0]!.params).toContain(TENANT_ID);
+  });
+
+  it('getRelatedRecords UNION subquery binds tenant_id on both rr and r in both branches (latent bug fix)', async () => {
+    // Historical bug: the raw-pg UNION query omitted tenant_id on both
+    // the record_relationships join table and the records table in
+    // both halves of the UNION. The Kysely migration adds tenant_id
+    // defence-in-depth to all four positions.
+    await getRelatedRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      'account',
+      'user-123',
+      20,
+      0,
+    );
+
+    const unionQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('FROM RECORD_RELATIONSHIPS AS RR') &&
+        s.includes('INNER JOIN RECORDS AS R') &&
+        s.includes('UNION')
+      );
+    });
+    // Both the count query and the data query wrap the same UNION.
+    expect(unionQueries.length).toBeGreaterThanOrEqual(2);
+
+    for (const q of unionQueries) {
+      const s = normalise(q.sql);
+      // tenant_id appears at least 4 times — rr + r on each side of
+      // the union.
+      const tenantMatches = s.match(/TENANT_ID/g) ?? [];
+      expect(
+        tenantMatches.length,
+        `Expected ≥4 TENANT_ID references in union query:\n  ${q.sql}`,
+      ).toBeGreaterThanOrEqual(4);
+
+      // And the params bind TENANT_ID at least 4 times.
+      const tenantBindCount = q.params.filter((p) => p === TENANT_ID).length;
+      expect(tenantBindCount).toBeGreaterThanOrEqual(4);
+    }
+  });
+});
+
+describe('recordRelationshipService Kysely SQL — generated SQL shape', () => {
+  it('linkRecords INSERT carries all 6 columns with tenant_id as second bind', async () => {
+    await linkRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      RELATIONSHIP_ID,
+      TARGET_RECORD_ID,
+      'user-123',
+    );
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RECORD_RELATIONSHIPS'),
+    );
+    expect(inserts.length).toBe(1);
+    // id, tenant_id, relationship_id, source_record_id, target_record_id, created_at
+    expect(inserts[0]!.params.length).toBe(6);
+    expect(inserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(inserts[0]!.params[2]).toBe(RELATIONSHIP_ID);
+    expect(inserts[0]!.params[3]).toBe(SOURCE_RECORD_ID);
+    expect(inserts[0]!.params[4]).toBe(TARGET_RECORD_ID);
+  });
+
+  it('linkRecords validates both records and the relationship definition before the INSERT', async () => {
+    await linkRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      RELATIONSHIP_ID,
+      TARGET_RECORD_ID,
+      'user-123',
+    );
+
+    const recordLookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS') &&
+        s.includes('OBJECT_ID') &&
+        s.includes('WHERE ID =')
+      );
+    });
+    // One for source, one for target.
+    expect(recordLookups.length).toBe(2);
+
+    const relDefLookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RELATIONSHIP_DEFINITIONS') &&
+        s.includes('WHERE ID =')
+      );
+    });
+    expect(relDefLookups.length).toBe(1);
+  });
+
+  it('unlinkRecords lookup uses (source_record_id = $ OR target_record_id = $) disjunction and scopes by tenant_id', async () => {
+    await unlinkRecords(TENANT_ID, SOURCE_RECORD_ID, LINK_ID, 'user-123');
+
+    const lookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORD_RELATIONSHIPS') &&
+        s.includes('SOURCE_RECORD_ID =') &&
+        s.includes('TARGET_RECORD_ID =')
+      );
+    });
+    expect(lookups.length).toBe(1);
+
+    const s = normalise(lookups[0]!.sql);
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('OR');
+  });
+
+  it('unlinkRecords issues exactly one DELETE scoped by id + tenant_id', async () => {
+    await unlinkRecords(TENANT_ID, SOURCE_RECORD_ID, LINK_ID, 'user-123');
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM RECORD_RELATIONSHIPS'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const s = normalise(deletes[0]!.sql);
+    expect(s).toContain('WHERE');
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+  });
+
+  it('getRelatedRecords emits both a COUNT(*) query and a paginated data query over the union alias', async () => {
+    await getRelatedRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      'account',
+      'user-123',
+      20,
+      5,
+    );
+
+    const countQueries = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return s.includes('COUNT(*)') && s.includes('AS RELATED');
+    });
+    expect(countQueries.length).toBe(1);
+
+    const dataPage = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.includes('AS RELATED') &&
+        s.includes('LIMIT') &&
+        s.includes('OFFSET')
+      );
+    });
+    expect(dataPage.length).toBe(1);
+
+    const pageSql = normalise(dataPage[0]!.sql);
+    expect(pageSql).toContain('ORDER BY CREATED_AT DESC');
+    // Both halves of the UNION project the same 5 columns.
+    expect(pageSql.match(/R\.ID/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(pageSql.match(/R\.NAME/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(pageSql.match(/R\.FIELD_VALUES/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(pageSql.match(/R\.CREATED_AT/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(pageSql.match(/R\.UPDATED_AT/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(pageSql).toContain('UNION');
+
+    // The LIMIT/OFFSET binds should be at the tail of the params.
+    const p = dataPage[0]!.params;
+    expect(p).toContain(20);
+    expect(p).toContain(5);
+  });
+});
+
+describe('recordRelationshipService Kysely SQL — non-transactional paths', () => {
+  it('linkRecords runs without opening an explicit transaction', async () => {
+    await linkRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      RELATIONSHIP_ID,
+      TARGET_RECORD_ID,
+      'user-123',
+    );
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('unlinkRecords runs without opening an explicit transaction', async () => {
+    await unlinkRecords(TENANT_ID, SOURCE_RECORD_ID, LINK_ID, 'user-123');
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('getRelatedRecords runs without opening an explicit transaction', async () => {
+    await getRelatedRecords(
+      TENANT_ID,
+      SOURCE_RECORD_ID,
+      'account',
+      'user-123',
+      20,
+      0,
+    );
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/recordRelationshipService.test.ts
+++ b/apps/api/src/services/__tests__/recordRelationshipService.test.ts
@@ -3,21 +3,67 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const TENANT_ID = 'test-tenant-001';
 
 vi.mock('../../lib/logger.js', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely drives the service now, so the mock must be quote-agnostic
+// (Kysely emits quoted identifiers) and must route through
+// `pool.connect()` in addition to `pool.query()` — PostgresDialect
+// acquires a client per query via connect().
 
-const { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery } = vi.hoisted(() => {
+const {
+  fakeRecordRelationships,
+  fakeRecords,
+  fakeRelationshipDefs,
+  mockQuery,
+  mockConnect,
+} = vi.hoisted(() => {
   const fakeRecordRelationships = new Map<string, Record<string, unknown>>();
   const fakeRecords = new Map<string, Record<string, unknown>>();
   const fakeRelationshipDefs = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function normalise(sql: string): string {
+    return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  async function handleQuery(rawSql: string, params: unknown[] | undefined) {
+    const s = normalise(rawSql);
+
+    // Transaction control + RLS preamble — no-ops for the mock.
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // getRelatedRecords count + data queries over the UNION subquery
+    // aliased `related`. These match before the generic
+    // record_relationships matchers below so that the nested
+    // `FROM record_relationships as rr` inside the subquery doesn't
+    // get mis-routed to the duplicate / parent / unlink handlers.
+    if (s.includes('COUNT(*)') && s.includes('AS RELATED')) {
+      return { rows: [{ total: '0' }] };
+    }
+    if (
+      s.includes('FROM RELATED') ||
+      (s.includes('AS RELATED') && s.includes('LIMIT'))
+    ) {
+      return { rows: [] };
+    }
 
     // SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2
-    if (s.startsWith('SELECT ID, OBJECT_ID FROM RECORDS')) {
+    if (
+      s.startsWith('SELECT ID, OBJECT_ID FROM RECORDS') ||
+      (s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS') &&
+        s.includes('OBJECT_ID') &&
+        s.includes('WHERE ID =') &&
+        !s.includes('AS R') &&
+        !s.includes('RECORD_RELATIONSHIPS'))
+    ) {
       const id = params![0] as string;
       const record = fakeRecords.get(id);
       if (record) {
@@ -27,7 +73,10 @@ const { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery } 
     }
 
     // SELECT id FROM records WHERE id = $1 AND tenant_id = $2
-    if (s.startsWith('SELECT ID FROM RECORDS')) {
+    if (
+      s.startsWith('SELECT ID FROM RECORDS') &&
+      !s.includes('OBJECT_ID')
+    ) {
       const id = params![0] as string;
       const record = fakeRecords.get(id);
       if (record) {
@@ -36,29 +85,47 @@ const { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery } 
       return { rows: [] };
     }
 
-    // SELECT * FROM relationship_definitions WHERE id = $1
-    if (s.startsWith('SELECT * FROM RELATIONSHIP_DEFINITIONS')) {
+    // SELECT * FROM relationship_definitions WHERE id = $1 AND tenant_id = $2
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM RELATIONSHIP_DEFINITIONS') &&
+      s.includes('WHERE ID =')
+    ) {
       const id = params![0] as string;
       const rel = fakeRelationshipDefs.get(id);
       if (rel) return { rows: [rel] };
       return { rows: [] };
     }
 
-    // SELECT id FROM record_relationships WHERE relationship_id AND source_record_id AND target_record_id (duplicate check)
-    if (s.includes('FROM RECORD_RELATIONSHIPS') && s.includes('SOURCE_RECORD_ID = $2') && s.includes('TARGET_RECORD_ID = $3')) {
+    // Duplicate check — relationship_id AND source_record_id AND target_record_id AND tenant_id
+    if (
+      s.includes('FROM RECORD_RELATIONSHIPS') &&
+      s.includes('RELATIONSHIP_ID =') &&
+      s.includes('SOURCE_RECORD_ID =') &&
+      s.includes('TARGET_RECORD_ID =')
+    ) {
       const relId = params![0] as string;
       const sourceId = params![1] as string;
       const targetId = params![2] as string;
       for (const rr of fakeRecordRelationships.values()) {
-        if (rr.relationship_id === relId && rr.source_record_id === sourceId && rr.target_record_id === targetId) {
+        if (
+          rr.relationship_id === relId &&
+          rr.source_record_id === sourceId &&
+          rr.target_record_id === targetId
+        ) {
           return { rows: [rr] };
         }
       }
       return { rows: [] };
     }
 
-    // SELECT id FROM record_relationships WHERE relationship_id AND source_record_id (parent check)
-    if (s.includes('FROM RECORD_RELATIONSHIPS') && s.includes('RELATIONSHIP_ID = $1') && s.includes('SOURCE_RECORD_ID = $2') && !s.includes('TARGET_RECORD_ID')) {
+    // Parent check — relationship_id AND source_record_id (no target)
+    if (
+      s.includes('FROM RECORD_RELATIONSHIPS') &&
+      s.includes('RELATIONSHIP_ID =') &&
+      s.includes('SOURCE_RECORD_ID =') &&
+      !s.includes('TARGET_RECORD_ID')
+    ) {
       const relId = params![0] as string;
       const sourceId = params![1] as string;
       const matches = [];
@@ -71,35 +138,64 @@ const { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery } 
     }
 
     // INSERT INTO record_relationships
+    // Columns: id, tenant_id, relationship_id, source_record_id, target_record_id, created_at
     if (s.startsWith('INSERT INTO RECORD_RELATIONSHIPS')) {
-      const [id, _tenant_id, relationship_id, source_record_id, target_record_id, created_at] = params as unknown[];
+      const [
+        id,
+        _tenantId,
+        relationship_id,
+        source_record_id,
+        target_record_id,
+        created_at,
+      ] = params as unknown[];
       const row: Record<string, unknown> = {
-        id, relationship_id, source_record_id, target_record_id, created_at,
+        id,
+        tenant_id: _tenantId,
+        relationship_id,
+        source_record_id,
+        target_record_id,
+        created_at,
       };
       fakeRecordRelationships.set(id as string, row);
       return { rows: [row] };
     }
 
-    // SELECT id FROM record_relationships WHERE id AND (source OR target)
-    if (s.includes('FROM RECORD_RELATIONSHIPS') && s.includes('ID = $1') && s.includes('SOURCE_RECORD_ID = $2 OR TARGET_RECORD_ID = $2')) {
+    // unlinkRecords lookup: SELECT id FROM record_relationships
+    // WHERE id = $1 AND tenant_id = $2 AND (source_record_id = $3 OR target_record_id = $3)
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM RECORD_RELATIONSHIPS') &&
+      s.includes('ID =') &&
+      s.includes('SOURCE_RECORD_ID =') &&
+      s.includes('TARGET_RECORD_ID =')
+    ) {
       const id = params![0] as string;
-      const recordId = params![1] as string;
+      // params: [id, tenantId, sourceRecordId, sourceRecordId] — Kysely
+      // binds the OR branch twice.
+      const recordId = params![2] as string;
       const rr = fakeRecordRelationships.get(id);
-      if (rr && (rr.source_record_id === recordId || rr.target_record_id === recordId)) {
+      if (
+        rr &&
+        (rr.source_record_id === recordId || rr.target_record_id === recordId)
+      ) {
         return { rows: [rr] };
       }
       return { rows: [] };
     }
 
-    // DELETE FROM record_relationships WHERE id = $1
+    // DELETE FROM record_relationships WHERE id = $1 AND tenant_id = $2
     if (s.startsWith('DELETE FROM RECORD_RELATIONSHIPS')) {
       const id = params![0] as string;
       fakeRecordRelationships.delete(id);
       return { rowCount: 1 };
     }
 
-    // SELECT id FROM object_definitions WHERE api_name = $1
-    if (s.includes('FROM OBJECT_DEFINITIONS WHERE API_NAME')) {
+    // SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM OBJECT_DEFINITIONS') &&
+      s.includes('API_NAME =')
+    ) {
       const apiName = params![0] as string;
       if (apiName === 'account') {
         return { rows: [{ id: 'obj-account-id' }] };
@@ -110,24 +206,35 @@ const { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery } 
       return { rows: [] };
     }
 
-    // COUNT for related records
-    if (s.includes('COUNT(*)') && s.includes('RELATED')) {
-      return { rows: [{ total: '0' }] };
-    }
-
-    // SELECT related records
-    if (s.includes('RELATED') && s.includes('LIMIT')) {
-      return { rows: [] };
-    }
-
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return handleQuery(rawSql, params);
   });
 
-  return { fakeRecordRelationships, fakeRecords, fakeRelationshipDefs, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return handleQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return {
+    fakeRecordRelationships,
+    fakeRecords,
+    fakeRelationshipDefs,
+    mockQuery,
+    mockConnect,
+  };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 const { linkRecords, unlinkRecords, getRelatedRecords } = await import(
@@ -142,6 +249,7 @@ describe('linkRecords', () => {
     fakeRecords.clear();
     fakeRelationshipDefs.clear();
     mockQuery.mockClear();
+    mockConnect.mockClear();
   });
 
   function seedData() {
@@ -303,6 +411,7 @@ describe('unlinkRecords', () => {
     fakeRecordRelationships.clear();
     fakeRecords.clear();
     mockQuery.mockClear();
+    mockConnect.mockClear();
   });
 
   it('removes a record link', async () => {
@@ -351,6 +460,7 @@ describe('getRelatedRecords', () => {
   beforeEach(() => {
     fakeRecords.clear();
     mockQuery.mockClear();
+    mockConnect.mockClear();
   });
 
   it('throws NOT_FOUND when record does not exist', async () => {

--- a/apps/api/src/services/recordRelationshipService.ts
+++ b/apps/api/src/services/recordRelationshipService.ts
@@ -332,6 +332,47 @@ export async function getRelatedRecords(
   // Both halves explicitly scope by tenant_id on both the join table
   // and the records table as defence-in-depth (ADR-006). The raw-pg
   // implementation historically omitted these filters.
+  //
+  // The count and data paths use *separate* subquery projections so the
+  // COUNT(*) path doesn't have to UNION-deduplicate wide rows that
+  // include JSONB `field_values`. The count subquery projects only
+  // `r.id`; the data subquery projects the five columns the response
+  // body needs.
+
+  // Count the distinct related records across both directions — id-only
+  // projection keeps the UNION dedup lightweight on tenants with many
+  // relationships or large `field_values`.
+  const outgoingIds = db
+    .selectFrom('record_relationships as rr')
+    .innerJoin('records as r', (join) =>
+      join
+        .onRef('r.id', '=', 'rr.target_record_id')
+        .on('r.tenant_id', '=', tenantId),
+    )
+    .select('r.id')
+    .where('rr.source_record_id', '=', recordId)
+    .where('rr.tenant_id', '=', tenantId)
+    .where('r.object_id', '=', targetObjectId);
+
+  const incomingIds = db
+    .selectFrom('record_relationships as rr')
+    .innerJoin('records as r', (join) =>
+      join
+        .onRef('r.id', '=', 'rr.source_record_id')
+        .on('r.tenant_id', '=', tenantId),
+    )
+    .select('r.id')
+    .where('rr.target_record_id', '=', recordId)
+    .where('rr.tenant_id', '=', tenantId)
+    .where('r.object_id', '=', targetObjectId);
+
+  const countRow = await db
+    .selectFrom(() => outgoingIds.union(incomingIds).as('related'))
+    .select((eb) => eb.fn.countAll<string>().as('total'))
+    .executeTakeFirstOrThrow();
+  const total = parseInt(countRow.total, 10);
+
+  // Page through the distinct related records with the full projection.
   const outgoing = db
     .selectFrom('record_relationships as rr')
     .innerJoin('records as r', (join) =>
@@ -356,14 +397,6 @@ export async function getRelatedRecords(
     .where('rr.tenant_id', '=', tenantId)
     .where('r.object_id', '=', targetObjectId);
 
-  // Count the distinct related records across both directions.
-  const countRow = await db
-    .selectFrom(() => outgoing.union(incoming).as('related'))
-    .select((eb) => eb.fn.countAll<string>().as('total'))
-    .executeTakeFirstOrThrow();
-  const total = parseInt(countRow.total, 10);
-
-  // Page through the distinct related records.
   const dataRows = await db
     .selectFrom(() => outgoing.union(incoming).as('related'))
     .selectAll()

--- a/apps/api/src/services/recordRelationshipService.ts
+++ b/apps/api/src/services/recordRelationshipService.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'crypto';
+import type { Selectable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type {
+  RecordRelationships,
+  Records,
+  RelationshipDefinitions,
+} from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,23 +55,44 @@ function throwConflictError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToRecordRelationship(row: Record<string, unknown>): RecordRelationship {
+/**
+ * Typing the row mapper against `Selectable<RecordRelationships>`
+ * (rather than `Record<string, unknown>`) means a column rename or
+ * nullability change on the generated schema becomes a compile-time
+ * error at this service, rather than an `unknown` cast leaking an
+ * incorrect runtime shape into the domain model.
+ */
+type RecordRelationshipSelectable = Selectable<RecordRelationships>;
+
+function rowToRecordRelationship(
+  row: RecordRelationshipSelectable,
+): RecordRelationship {
   return {
-    id: row.id as string,
-    relationshipId: row.relationship_id as string,
-    sourceRecordId: row.source_record_id as string,
-    targetRecordId: row.target_record_id as string,
-    createdAt: new Date(row.created_at as string),
+    id: row.id,
+    relationshipId: row.relationship_id,
+    sourceRecordId: row.source_record_id,
+    targetRecordId: row.target_record_id,
+    createdAt: row.created_at,
   };
 }
 
-function rowToRelatedRecord(row: Record<string, unknown>): RelatedRecordRow {
+/**
+ * The UNION subquery projects a handful of `records` columns. We type
+ * the mapper against those columns so a rename on `records` surfaces
+ * here at compile time.
+ */
+type RelatedRecordSelectable = Pick<
+  Selectable<Records>,
+  'id' | 'name' | 'field_values' | 'created_at' | 'updated_at'
+>;
+
+function rowToRelatedRecord(row: RelatedRecordSelectable): RelatedRecordRow {
   return {
-    id: row.id as string,
-    name: row.name as string,
-    fieldValues: (row.field_values as Record<string, unknown>) ?? {},
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    id: row.id,
+    name: row.name,
+    fieldValues: (row.field_values as Record<string, unknown> | null) ?? {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   };
 }
 
@@ -105,34 +132,37 @@ export async function linkRecords(
   }
 
   // Fetch the source record
-  const sourceResult = await pool.query(
-    'SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2',
-    [sourceRecordId, tenantId],
-  );
-  if (sourceResult.rows.length === 0) {
+  const sourceRecord = await db
+    .selectFrom('records')
+    .select(['id', 'object_id'])
+    .where('id', '=', sourceRecordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!sourceRecord) {
     throwNotFoundError('Source record not found');
   }
-  const sourceRecord = sourceResult.rows[0] as Record<string, unknown>;
 
   // Fetch the target record
-  const targetResult = await pool.query(
-    'SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2',
-    [targetRecordId, tenantId],
-  );
-  if (targetResult.rows.length === 0) {
+  const targetRecord = await db
+    .selectFrom('records')
+    .select(['id', 'object_id'])
+    .where('id', '=', targetRecordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!targetRecord) {
     throwNotFoundError('Target record not found');
   }
-  const targetRecord = targetResult.rows[0] as Record<string, unknown>;
 
   // Fetch the relationship definition
-  const relDefResult = await pool.query(
-    'SELECT * FROM relationship_definitions WHERE id = $1 AND tenant_id = $2',
-    [relationshipId, tenantId],
-  );
-  if (relDefResult.rows.length === 0) {
+  const relDef: Selectable<RelationshipDefinitions> | undefined = await db
+    .selectFrom('relationship_definitions')
+    .selectAll()
+    .where('id', '=', relationshipId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!relDef) {
     throwNotFoundError('Relationship definition not found');
   }
-  const relDef = relDefResult.rows[0] as Record<string, unknown>;
 
   // Validate object types match the relationship definition
   if (sourceRecord.object_id !== relDef.source_object_id) {
@@ -146,25 +176,32 @@ export async function linkRecords(
     );
   }
 
-  // Check for duplicate link
-  const duplicateCheck = await pool.query(
-    `SELECT id FROM record_relationships
-     WHERE relationship_id = $1 AND source_record_id = $2 AND target_record_id = $3`,
-    [relationshipId, sourceRecordId, targetRecordId],
-  );
-  if (duplicateCheck.rows.length > 0) {
+  // Check for duplicate link. Scoped by tenant_id as defence-in-depth
+  // against an RLS misconfiguration (ADR-006); the raw-pg implementation
+  // historically omitted this.
+  const duplicate = await db
+    .selectFrom('record_relationships')
+    .select('id')
+    .where('relationship_id', '=', relationshipId)
+    .where('source_record_id', '=', sourceRecordId)
+    .where('target_record_id', '=', targetRecordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (duplicate) {
     throwConflictError('This relationship link already exists');
   }
 
-  // For parent_child relationships, enforce single parent
-  // A source record can only have one target via a parent_child relationship
+  // For parent_child relationships, enforce single parent.
+  // Also scoped by tenant_id (same latent bug as the duplicate check).
   if (relDef.relationship_type === 'parent_child') {
-    const existingParent = await pool.query(
-      `SELECT id FROM record_relationships
-       WHERE relationship_id = $1 AND source_record_id = $2`,
-      [relationshipId, sourceRecordId],
-    );
-    if (existingParent.rows.length > 0) {
+    const existingParent = await db
+      .selectFrom('record_relationships')
+      .select('id')
+      .where('relationship_id', '=', relationshipId)
+      .where('source_record_id', '=', sourceRecordId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (existingParent) {
       throwConflictError(
         'This record already has a parent for this relationship. Parent-child relationships allow only one parent.',
       );
@@ -174,19 +211,25 @@ export async function linkRecords(
   const linkId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO record_relationships (id, tenant_id, relationship_id, source_record_id, target_record_id, created_at)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     RETURNING *`,
-    [linkId, tenantId, relationshipId, sourceRecordId, targetRecordId, now],
-  );
+  const inserted = await db
+    .insertInto('record_relationships')
+    .values({
+      id: linkId,
+      tenant_id: tenantId,
+      relationship_id: relationshipId,
+      source_record_id: sourceRecordId,
+      target_record_id: targetRecordId,
+      created_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info(
     { linkId, relationshipId, sourceRecordId, targetRecordId, ownerId },
     'Records linked',
   );
 
-  return rowToRecordRelationship(result.rows[0]);
+  return rowToRecordRelationship(inserted);
 }
 
 /**
@@ -203,25 +246,38 @@ export async function unlinkRecords(
   ownerId: string,
 ): Promise<void> {
   // Verify the source record exists within the tenant
-  const recordResult = await pool.query(
-    'SELECT id FROM records WHERE id = $1 AND tenant_id = $2',
-    [sourceRecordId, tenantId],
-  );
-  if (recordResult.rows.length === 0) {
+  const record = await db
+    .selectFrom('records')
+    .select('id')
+    .where('id', '=', sourceRecordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!record) {
     throwNotFoundError('Record not found');
   }
 
   // Verify the record_relationship exists and involves this record
-  const relResult = await pool.query(
-    `SELECT id FROM record_relationships
-     WHERE id = $1 AND (source_record_id = $2 OR target_record_id = $2) AND tenant_id = $3`,
-    [recordRelationshipId, sourceRecordId, tenantId],
-  );
-  if (relResult.rows.length === 0) {
+  const existingLink = await db
+    .selectFrom('record_relationships')
+    .select('id')
+    .where('id', '=', recordRelationshipId)
+    .where('tenant_id', '=', tenantId)
+    .where((eb) =>
+      eb.or([
+        eb('source_record_id', '=', sourceRecordId),
+        eb('target_record_id', '=', sourceRecordId),
+      ]),
+    )
+    .executeTakeFirst();
+  if (!existingLink) {
     throwNotFoundError('Relationship link not found');
   }
 
-  await pool.query('DELETE FROM record_relationships WHERE id = $1 AND tenant_id = $2', [recordRelationshipId, tenantId]);
+  await db
+    .deleteFrom('record_relationships')
+    .where('id', '=', recordRelationshipId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info(
     { recordRelationshipId, sourceRecordId, ownerId },
@@ -245,64 +301,78 @@ export async function getRelatedRecords(
 ): Promise<RelatedRecordsResult> {
   void ownerId;
   // Verify the record exists within the tenant
-  const recordResult = await pool.query(
-    'SELECT id, object_id FROM records WHERE id = $1 AND tenant_id = $2',
-    [recordId, tenantId],
-  );
-  if (recordResult.rows.length === 0) {
+  const record = await db
+    .selectFrom('records')
+    .select(['id', 'object_id'])
+    .where('id', '=', recordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!record) {
     throwNotFoundError('Record not found');
   }
 
   // Resolve the target object type
-  const objectResult = await pool.query(
-    'SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2',
-    [objectApiName, tenantId],
-  );
-  if (objectResult.rows.length === 0) {
+  const objectDef = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('api_name', '=', objectApiName)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!objectDef) {
     throwNotFoundError(`Object type '${objectApiName}' not found`);
   }
-  const targetObjectId = (objectResult.rows[0] as Record<string, unknown>).id as string;
+  const targetObjectId = objectDef.id;
 
-  // Find related records in both directions:
-  // 1. Records where our record is the source and the target belongs to the specified object type
-  // 2. Records where our record is the target and the source belongs to the specified object type
+  // Find related records in both directions via a UNION:
+  //   1. Records where our record is the source and the target belongs
+  //      to the specified object type (outgoing).
+  //   2. Records where our record is the target and the source belongs
+  //      to the specified object type (incoming).
+  //
+  // Both halves explicitly scope by tenant_id on both the join table
+  // and the records table as defence-in-depth (ADR-006). The raw-pg
+  // implementation historically omitted these filters.
+  const outgoing = db
+    .selectFrom('record_relationships as rr')
+    .innerJoin('records as r', (join) =>
+      join
+        .onRef('r.id', '=', 'rr.target_record_id')
+        .on('r.tenant_id', '=', tenantId),
+    )
+    .select(['r.id', 'r.name', 'r.field_values', 'r.created_at', 'r.updated_at'])
+    .where('rr.source_record_id', '=', recordId)
+    .where('rr.tenant_id', '=', tenantId)
+    .where('r.object_id', '=', targetObjectId);
 
-  const countResult = await pool.query(
-    `SELECT COUNT(*) AS total FROM (
-       SELECT r.id
-       FROM record_relationships rr
-       JOIN records r ON r.id = rr.target_record_id
-       WHERE rr.source_record_id = $1 AND r.object_id = $2
-       UNION
-       SELECT r.id
-       FROM record_relationships rr
-       JOIN records r ON r.id = rr.source_record_id
-       WHERE rr.target_record_id = $1 AND r.object_id = $2
-     ) AS related`,
-    [recordId, targetObjectId],
-  );
-  const total = parseInt(countResult.rows[0].total as string, 10);
+  const incoming = db
+    .selectFrom('record_relationships as rr')
+    .innerJoin('records as r', (join) =>
+      join
+        .onRef('r.id', '=', 'rr.source_record_id')
+        .on('r.tenant_id', '=', tenantId),
+    )
+    .select(['r.id', 'r.name', 'r.field_values', 'r.created_at', 'r.updated_at'])
+    .where('rr.target_record_id', '=', recordId)
+    .where('rr.tenant_id', '=', tenantId)
+    .where('r.object_id', '=', targetObjectId);
 
-  const dataResult = await pool.query(
-    `SELECT * FROM (
-       SELECT r.id, r.name, r.field_values, r.created_at, r.updated_at
-       FROM record_relationships rr
-       JOIN records r ON r.id = rr.target_record_id
-       WHERE rr.source_record_id = $1 AND r.object_id = $2
-       UNION
-       SELECT r.id, r.name, r.field_values, r.created_at, r.updated_at
-       FROM record_relationships rr
-       JOIN records r ON r.id = rr.source_record_id
-       WHERE rr.target_record_id = $1 AND r.object_id = $2
-     ) AS related
-     ORDER BY created_at DESC
-     LIMIT $3 OFFSET $4`,
-    [recordId, targetObjectId, limit, offset],
-  );
+  // Count the distinct related records across both directions.
+  const countRow = await db
+    .selectFrom(() => outgoing.union(incoming).as('related'))
+    .select((eb) => eb.fn.countAll<string>().as('total'))
+    .executeTakeFirstOrThrow();
+  const total = parseInt(countRow.total, 10);
 
-  const data = dataResult.rows.map((row: Record<string, unknown>) =>
-    rowToRelatedRecord(row),
-  );
+  // Page through the distinct related records.
+  const dataRows = await db
+    .selectFrom(() => outgoing.union(incoming).as('related'))
+    .selectAll()
+    .orderBy('created_at', 'desc')
+    .limit(limit)
+    .offset(offset)
+    .execute();
+
+  const data = dataRows.map(rowToRelatedRecord);
 
   return { data, total, limit, offset };
 }


### PR DESCRIPTION
## Summary

Continues Phase 3b of the Kysely migration (#445) and completes Group B. Replaces raw pg text queries in `recordRelationshipService.ts` with Kysely query builder for all three exported functions (`linkRecords`, `unlinkRecords`, `getRelatedRecords`).

- Row mappers are typed against `Selectable<RecordRelationships>` and `Pick<Selectable<Records>, ...>` — a column rename on the generated schema becomes a compile-time error at this service rather than leaking an `unknown` cast into the domain model.
- Pins three latent `tenant_id` defence-in-depth gaps (ADR-006) that the raw-pg implementation historically omitted:
  1. `linkRecords` duplicate-link check — previously `WHERE relationship_id AND source_record_id AND target_record_id` with no `tenant_id`. Now scoped by `tenant_id`.
  2. `linkRecords` parent-check (for `parent_child` relationships) — same omission. Now scoped by `tenant_id`.
  3. `getRelatedRecords` UNION subquery — previously omitted `tenant_id` on both the `record_relationships` join table and the `records` table in *both* halves of the UNION. Kysely now binds `tenant_id` to all four positions (`rr` + `r` × outgoing + incoming).
- `getRelatedRecords` models the UNION via `.selectFrom((eb) => outgoing.union(incoming).as('related'))` so the count and paginated data queries share the same compiled subquery while type-checking every projected column against `Records`.
- Existing behavioural tests updated for Kysely's per-query `pool.connect()` pattern (mockConnect) with quote-stripping matchers.
- New companion `recordRelationshipService.kysely-sql.test.ts` regression suite (13 tests) asserts the compiled SQL shape: `tenant_id` defence-in-depth on every data query, `≥4` `tenant_id` bindings inside the UNION query, pinned 6-column INSERT layout, `ORDER BY CREATED_AT DESC` / `LIMIT` / `OFFSET` on the paged data query, and non-transactional execution paths.

## Test plan

- [x] `npx vitest run apps/api/src/services/__tests__/recordRelationshipService.test.ts` — 18/18 pass
- [x] `npx vitest run apps/api/src/services/__tests__/recordRelationshipService.kysely-sql.test.ts` — 13/13 pass
- [x] `npx vitest run apps/api/src/services/__tests__/` — 863/863 pass
- [x] `npx vitest run apps/api/` — 1419/1419 (1 pre-existing skip)
- [x] `tsc --noEmit` — clean

This completes Group B of Kysely phase 3b.

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf