### PR TITLE
Migrate organisation/profile/userSync services to Kysely (Phase 3b, Group C PR 1)

### DIFF
--- a/apps/api/src/services/__tests__/organisationService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/organisationService.kysely-sql.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Kysely SQL regression suite for organisationService.
+ *
+ * Complements `organisationService.test.ts` (behavioural assertions) by
+ * asserting directly on the SQL Kysely emits for `provisionOrganisation`.
+ * It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query carries a `tenant_id` bind
+ *      as defence-in-depth against an RLS misconfiguration (ADR-006).
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const USER_ID = 'user-sql-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // INSERT INTO organisations RETURNING *
+      if (s.startsWith('INSERT INTO ORGANISATIONS')) {
+        const [id, tenant_id, name, description, created_at, updated_at] =
+          params as unknown[];
+        return {
+          rows: [
+            {
+              id,
+              tenant_id,
+              name,
+              description: description ?? null,
+              created_at,
+              updated_at,
+            },
+          ],
+        };
+      }
+
+      // INSERT INTO tenant_memberships RETURNING *
+      if (s.startsWith('INSERT INTO TENANT_MEMBERSHIPS')) {
+        const [id, tenant_id, user_id, organisation_id, role, created_at, updated_at] =
+          params as unknown[];
+        return {
+          rows: [
+            {
+              id,
+              tenant_id,
+              user_id,
+              organisation_id,
+              role,
+              created_at,
+              updated_at,
+            },
+          ],
+        };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { provisionOrganisation } = await import('../organisationService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const baseParams = {
+  name: 'Acme Corp',
+  description: 'Primary organisation',
+  tenantId: TENANT_ID,
+  requestingUserId: USER_ID,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('organisationService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on provisionOrganisation references tenant_id', async () => {
+    await provisionOrganisation(baseParams);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('both INSERT statements bind the tenant_id from the authenticated session', async () => {
+    await provisionOrganisation(baseParams);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO'),
+    );
+    expect(inserts.length).toBe(2);
+    for (const q of inserts) {
+      expect(q.params).toContain(TENANT_ID);
+    }
+  });
+});
+
+describe('organisationService Kysely SQL — generated SQL shape', () => {
+  it('provisionOrganisation emits INSERT INTO organisations with 6 bound columns', async () => {
+    await provisionOrganisation(baseParams);
+
+    const orgInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO ORGANISATIONS'),
+    );
+    expect(orgInserts.length).toBe(1);
+
+    // Column order: id, tenant_id, name, description, created_at, updated_at.
+    expect(orgInserts[0]!.params.length).toBe(6);
+    expect(orgInserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(orgInserts[0]!.params[2]).toBe('Acme Corp');
+    expect(orgInserts[0]!.params[3]).toBe('Primary organisation');
+
+    const s = normalise(orgInserts[0]!.sql);
+    expect(s).toContain('RETURNING');
+  });
+
+  it('provisionOrganisation emits INSERT INTO tenant_memberships with role="owner"', async () => {
+    await provisionOrganisation(baseParams);
+
+    const memberInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO TENANT_MEMBERSHIPS'),
+    );
+    expect(memberInserts.length).toBe(1);
+
+    // Column order: id, tenant_id, user_id, organisation_id, role, created_at, updated_at.
+    expect(memberInserts[0]!.params.length).toBe(7);
+    expect(memberInserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(memberInserts[0]!.params[2]).toBe(USER_ID);
+    expect(memberInserts[0]!.params[4]).toBe('owner');
+
+    const s = normalise(memberInserts[0]!.sql);
+    expect(s).toContain('RETURNING');
+  });
+
+  it('membership insert points at the freshly-created organisation id', async () => {
+    const result = await provisionOrganisation(baseParams);
+
+    const memberInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO TENANT_MEMBERSHIPS'),
+    );
+    expect(memberInserts[0]!.params[3]).toBe(result.organisation.id);
+  });
+
+  it('persists description=null when not provided (not empty string or "undefined")', async () => {
+    await provisionOrganisation({
+      name: 'No Desc Org',
+      tenantId: TENANT_ID,
+      requestingUserId: USER_ID,
+    });
+
+    const orgInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO ORGANISATIONS'),
+    );
+    expect(orgInserts[0]!.params[3]).toBeNull();
+  });
+});
+
+describe('organisationService Kysely SQL — non-transactional path', () => {
+  it('provisionOrganisation runs without opening an explicit transaction', async () => {
+    await provisionOrganisation(baseParams);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/organisationService.test.ts
+++ b/apps/api/src/services/__tests__/organisationService.test.ts
@@ -6,41 +6,89 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely's PostgresDialect acquires a client per query via `pool.connect()`,
+// so the mock routes both `pool.query` (legacy) and `pool.connect().query`
+// (Kysely) through the same `runQuery` dispatcher.
 
-const { mockQuery } = vi.hoisted(() => {
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+const { mockQuery, mockConnect } = vi.hoisted(() => {
+  function runQuery(rawSql: string, params?: unknown[]) {
+    // Strip identifier quoting so matching is quote-agnostic.
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
+    // Transaction control statements — no-ops in the fake.
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+
+    // RLS preamble from the Kysely pool proxy.
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO organisations — Kysely binds values in the column order
+    // declared in the service's `.values({...})` call:
+    //   id, tenant_id, name, description, created_at, updated_at.
     if (s.startsWith('INSERT INTO ORGANISATIONS')) {
-      const [id, tenant_id, name, description, created_at, updated_at] = params as unknown[];
+      const [id, tenant_id, name, description, created_at, updated_at] =
+        params as unknown[];
       return {
-        rows: [{
-          id, tenant_id, name,
-          description: description ?? null,
-          created_at, updated_at,
-        }],
+        rows: [
+          {
+            id,
+            tenant_id,
+            name,
+            description: description ?? null,
+            created_at,
+            updated_at,
+          },
+        ],
       };
     }
 
+    // INSERT INTO tenant_memberships — column order:
+    //   id, tenant_id, user_id, organisation_id, role, created_at, updated_at.
     if (s.startsWith('INSERT INTO TENANT_MEMBERSHIPS')) {
-      const [id, tenant_id, user_id, organisation_id, , created_at, updated_at] = params as unknown[];
+      const [id, tenant_id, user_id, organisation_id, role, created_at, updated_at] =
+        params as unknown[];
       return {
-        rows: [{
-          id, tenant_id, user_id, organisation_id,
-          role: 'owner',
-          created_at, updated_at,
-        }],
+        rows: [
+          {
+            id,
+            tenant_id,
+            user_id,
+            organisation_id,
+            role,
+            created_at,
+            updated_at,
+          },
+        ],
       };
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params);
   });
 
-  return { mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 describe('validateName', () => {

--- a/apps/api/src/services/__tests__/profileService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/profileService.kysely-sql.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Kysely SQL regression suite for profileService.
+ *
+ * Complements `profileService.test.ts` (behavioural assertions) by
+ * asserting directly on the SQL Kysely emits for `getOrCreateProfile`,
+ * `getProfile`, and `updateProfile`.
+ *
+ * Note: `user_profiles` is a global table (no `tenant_id` column) —
+ * profiles follow the Descope user across tenants — so this suite does
+ * not assert tenant_id defence-in-depth.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const USER_ID = 'user-sql-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture, setExistingProfile } =
+  vi.hoisted(() => {
+    const capturedQueries: CapturedQuery[] = [];
+    let existingProfileRow: Record<string, unknown> | null = null;
+
+    function makeRow(overrides: Record<string, unknown> = {}) {
+      const now = new Date();
+      return {
+        id: 'profile-uuid',
+        user_id: 'user-sql-001',
+        display_name: null,
+        job_title: null,
+        updated_by: 'user-sql-001',
+        created_at: now,
+        updated_at: now,
+        ...overrides,
+      };
+    }
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // SELECT * FROM user_profiles WHERE user_id = $1
+      if (s.startsWith('SELECT') && s.includes('FROM USER_PROFILES')) {
+        if (existingProfileRow) {
+          return { rows: [existingProfileRow] };
+        }
+        return { rows: [] };
+      }
+
+      // INSERT INTO user_profiles ... RETURNING *
+      if (s.startsWith('INSERT INTO USER_PROFILES')) {
+        const [id, user_id, display_name, job_title, updated_by, created_at, updated_at] =
+          params as unknown[];
+        return {
+          rows: [
+            {
+              id,
+              user_id,
+              display_name: display_name ?? null,
+              job_title: job_title ?? null,
+              updated_by,
+              created_at,
+              updated_at,
+            },
+          ],
+        };
+      }
+
+      // UPDATE user_profiles SET ... WHERE user_id = $N RETURNING *
+      if (s.startsWith('UPDATE USER_PROFILES')) {
+        return { rows: [makeRow({ display_name: 'Alice' })] };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+      existingProfileRow = null;
+    }
+
+    function setExistingProfile(row: Record<string, unknown> | null) {
+      existingProfileRow = row === null ? null : makeRow(row);
+    }
+
+    return {
+      capturedQueries,
+      mockQuery,
+      mockConnect,
+      resetCapture,
+      setExistingProfile,
+    };
+  });
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { getOrCreateProfile, getProfile, updateProfile } = await import(
+  '../profileService.js'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('profileService Kysely SQL — getOrCreateProfile', () => {
+  it('returns the existing profile with a single SELECT when one is found', async () => {
+    setExistingProfile({});
+    await getOrCreateProfile(USER_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBe(1);
+    const s = normalise(queries[0]!.sql);
+    expect(s).toContain('SELECT');
+    expect(s).toContain('FROM USER_PROFILES');
+    expect(s).toContain('USER_ID =');
+    expect(queries[0]!.params).toContain(USER_ID);
+  });
+
+  it('creates a new profile via INSERT ... RETURNING * when none exists', async () => {
+    await getOrCreateProfile(USER_ID);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO USER_PROFILES'),
+    );
+    expect(inserts.length).toBe(1);
+
+    // Column order: id, user_id, display_name, job_title, updated_by, created_at, updated_at.
+    expect(inserts[0]!.params.length).toBe(7);
+    expect(inserts[0]!.params[1]).toBe(USER_ID);
+    expect(inserts[0]!.params[2]).toBeNull();
+    expect(inserts[0]!.params[3]).toBeNull();
+    expect(inserts[0]!.params[4]).toBe(USER_ID);
+
+    const s = normalise(inserts[0]!.sql);
+    expect(s).toContain('RETURNING');
+  });
+});
+
+describe('profileService Kysely SQL — getProfile', () => {
+  it('issues exactly one SELECT scoped by user_id', async () => {
+    setExistingProfile({ display_name: 'Bob' });
+    const result = await getProfile(USER_ID);
+
+    expect(result).not.toBeNull();
+    const queries = dataQueries();
+    expect(queries.length).toBe(1);
+
+    const s = normalise(queries[0]!.sql);
+    expect(s).toContain('SELECT');
+    expect(s).toContain('FROM USER_PROFILES');
+    expect(s).toContain('USER_ID =');
+  });
+});
+
+describe('profileService Kysely SQL — updateProfile', () => {
+  it('emits a SELECT existence check followed by UPDATE ... RETURNING *', async () => {
+    setExistingProfile({});
+    await updateProfile(USER_ID, { displayName: 'Alice' }, USER_ID);
+
+    const queries = dataQueries();
+    // One SELECT (existence check) + one UPDATE
+    expect(queries.length).toBe(2);
+
+    expect(normalise(queries[0]!.sql)).toContain('SELECT');
+    expect(normalise(queries[0]!.sql)).toContain('FROM USER_PROFILES');
+
+    const updateSql = normalise(queries[1]!.sql);
+    expect(updateSql).toContain('UPDATE USER_PROFILES');
+    expect(updateSql).toContain('DISPLAY_NAME =');
+    expect(updateSql).toContain('UPDATED_BY =');
+    expect(updateSql).toContain('UPDATED_AT =');
+    expect(updateSql).toContain('USER_ID =');
+    expect(updateSql).toContain('RETURNING');
+  });
+
+  it('only sets columns the caller provided (no hidden over-writes)', async () => {
+    setExistingProfile({});
+    await updateProfile(USER_ID, { displayName: 'Alice' }, USER_ID);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE USER_PROFILES'),
+    );
+    expect(updates.length).toBe(1);
+
+    const s = normalise(updates[0]!.sql);
+    expect(s).toContain('DISPLAY_NAME =');
+    // job_title was NOT in the params — it should not appear in the SET list
+    expect(s).not.toContain('JOB_TITLE =');
+  });
+
+  it('updating only jobTitle does not clobber display_name', async () => {
+    setExistingProfile({});
+    await updateProfile(USER_ID, { jobTitle: 'Engineer' }, USER_ID);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE USER_PROFILES'),
+    );
+    expect(updates.length).toBe(1);
+
+    const s = normalise(updates[0]!.sql);
+    expect(s).toContain('JOB_TITLE =');
+    expect(s).not.toContain('DISPLAY_NAME =');
+  });
+});
+
+describe('profileService Kysely SQL — non-transactional paths', () => {
+  it('getOrCreateProfile runs without opening an explicit transaction', async () => {
+    await getOrCreateProfile(USER_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('updateProfile runs without opening an explicit transaction', async () => {
+    setExistingProfile({});
+    await updateProfile(USER_ID, { displayName: 'Alice' }, USER_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/profileService.test.ts
+++ b/apps/api/src/services/__tests__/profileService.test.ts
@@ -11,14 +11,42 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely's PostgresDialect acquires a client per query via `pool.connect()`,
+// so we route both `pool.query` and `pool.connect().query` through the same
+// underlying `mockQuery`. Callers can keep using `mockResolvedValueOnce` on
+// `mockQuery` to queue up responses in query order — the RLS preamble
+// `SELECT set_config(...)` and transaction control statements are intercepted
+// in the client wrapper so they don't consume a queued response.
 
-const { mockQuery } = vi.hoisted(() => {
+const { mockQuery, mockConnect } = vi.hoisted(() => {
   const mockQuery = vi.fn();
-  return { mockQuery };
+
+  const isPassthrough = (rawSql: string) => {
+    const s = rawSql.replace(/\s+/g, ' ').trim().toUpperCase();
+    return (
+      s === 'BEGIN' ||
+      s === 'COMMIT' ||
+      s === 'ROLLBACK' ||
+      s.startsWith('SELECT SET_CONFIG')
+    );
+  };
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      if (isPassthrough(rawSql)) return { rows: [] };
+      return mockQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -31,8 +59,8 @@ function makeProfileRow(overrides: Record<string, unknown> = {}) {
     display_name: null,
     job_title: null,
     updated_by: 'user-123',
-    created_at: now.toISOString(),
-    updated_at: now.toISOString(),
+    created_at: now,
+    updated_at: now,
     ...overrides,
   };
 }

--- a/apps/api/src/services/__tests__/userSyncService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/userSyncService.kysely-sql.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Kysely SQL regression suite for userSyncService.
+ *
+ * Complements `userSyncService.test.ts` (behavioural assertions) by
+ * asserting directly on the SQL Kysely emits for `syncUserRecord`. It
+ * exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query on `records` and
+ *      `object_definitions` carries a `tenant_id` filter as
+ *      defence-in-depth against an RLS misconfiguration (ADR-006).
+ *   3. Verify the JSONB `field_values->>'descope_user_id'` lookup is
+ *      emitted with a parameter bind (not string interpolation).
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const DESCOPE_USER_ID = 'descope-sql-001';
+const OBJECT_ID = 'obj-user-sql';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const {
+  capturedQueries,
+  mockQuery,
+  mockConnect,
+  resetCapture,
+  setExistingUser,
+} = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+  let existingUserRow:
+    | { id: string; field_values: Record<string, unknown> }
+    | null = null;
+
+  function runQuery(
+    rawSql: string,
+    params: unknown[] | undefined,
+    via: 'pool' | 'client',
+  ) {
+    capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // SELECT id FROM object_definitions WHERE api_name = 'user' AND tenant_id = $1
+    if (s.startsWith('SELECT') && s.includes('FROM OBJECT_DEFINITIONS')) {
+      return { rows: [{ id: 'obj-user-sql' }] };
+    }
+
+    // SELECT id, field_values FROM records WHERE ... field_values->>'descope_user_id'
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM RECORDS') &&
+      s.includes("FIELD_VALUES->>'DESCOPE_USER_ID'")
+    ) {
+      if (existingUserRow) return { rows: [existingUserRow] };
+      return { rows: [] };
+    }
+
+    // INSERT INTO records (user record create)
+    if (s.startsWith('INSERT INTO RECORDS')) {
+      return { rows: [] };
+    }
+
+    // UPDATE records (either the user record update or the backfill UPDATEs)
+    if (s.startsWith('UPDATE RECORDS')) {
+      return { rowCount: 0 };
+    }
+
+    return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return runQuery(rawSql, params, 'pool');
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'client');
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+    existingUserRow = null;
+  }
+
+  function setExistingUser(
+    row: { id: string; field_values: Record<string, unknown> } | null,
+  ) {
+    existingUserRow = row;
+  }
+
+  return {
+    capturedQueries,
+    mockQuery,
+    mockConnect,
+    resetCapture,
+    setExistingUser,
+  };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { syncUserRecord } = await import('../userSyncService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const baseInput = {
+  tenantId: TENANT_ID,
+  descopeUserId: DESCOPE_USER_ID,
+  email: 'sql@example.com',
+  displayName: 'SQL User',
+  role: 'member',
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('userSyncService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every data query on a create path references tenant_id', async () => {
+    await syncUserRecord(baseInput);
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+
+  it('every data query on an update path references tenant_id', async () => {
+    setExistingUser({
+      id: 'rec-existing',
+      field_values: {
+        email: 'sql@example.com',
+        display_name: 'Old Name',
+        role: 'member',
+        descope_user_id: DESCOPE_USER_ID,
+        is_active: true,
+      },
+    });
+    await syncUserRecord({ ...baseInput, displayName: 'New Name' });
+
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+    for (const q of queries) {
+      const s = normalise(q.sql);
+      expect(
+        s.includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('userSyncService Kysely SQL — JSONB key access', () => {
+  it('descope_user_id lookup binds the user id as a parameter, not an interpolated string', async () => {
+    await syncUserRecord(baseInput);
+
+    const lookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS') &&
+        s.includes("FIELD_VALUES->>'DESCOPE_USER_ID'")
+      );
+    });
+    expect(lookups.length).toBe(1);
+
+    const params = lookups[0]!.params;
+    expect(params).toContain(DESCOPE_USER_ID);
+
+    // The raw literal should NOT appear twice in the SQL text (no interpolation).
+    const sql = lookups[0]!.sql;
+    // The literal 'descope_user_id' (quoted) is present once as the JSONB key;
+    // the user id itself (DESCOPE_USER_ID) must NOT appear in the SQL text.
+    expect(sql.includes(DESCOPE_USER_ID)).toBe(false);
+  });
+
+  it('the SELECT projects only id and field_values — not the full row', async () => {
+    await syncUserRecord(baseInput);
+
+    const lookups = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS') &&
+        s.includes("FIELD_VALUES->>'DESCOPE_USER_ID'")
+      );
+    });
+    expect(lookups.length).toBe(1);
+
+    const s = normalise(lookups[0]!.sql);
+    expect(s).toContain('ID');
+    expect(s).toContain('FIELD_VALUES');
+    // Columns that should NOT be in the projection
+    expect(s).not.toContain('OWNER_NAME');
+    expect(s).not.toContain('UPDATED_BY_NAME');
+    expect(s).not.toContain('PIPELINE_ID');
+  });
+});
+
+describe('userSyncService Kysely SQL — create path', () => {
+  it('creates the records row with INSERT binding 8 columns', async () => {
+    await syncUserRecord(baseInput);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RECORDS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    // Column order: id, object_id, name, field_values, owner_id, tenant_id, created_at, updated_at.
+    expect(inserts[0]!.params.length).toBe(8);
+    expect(inserts[0]!.params[1]).toBe(OBJECT_ID);
+    expect(inserts[0]!.params[2]).toBe('SQL User'); // name
+    expect(inserts[0]!.params[4]).toBe(DESCOPE_USER_ID); // owner_id
+    expect(inserts[0]!.params[5]).toBe(TENANT_ID);
+
+    // field_values is a JSON-stringified payload
+    const fieldValues = JSON.parse(inserts[0]!.params[3] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(fieldValues['descope_user_id']).toBe(DESCOPE_USER_ID);
+    expect(fieldValues['display_name']).toBe('SQL User');
+    expect(fieldValues['role']).toBe('member');
+  });
+
+  it('runs the owner_record_id and updated_by_record_id backfill UPDATEs after creation', async () => {
+    await syncUserRecord(baseInput);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE RECORDS'),
+    );
+    // Two backfill UPDATEs (owner_record_id + updated_by_record_id)
+    expect(updates.length).toBe(2);
+
+    const ownerBackfill = normalise(updates[0]!.sql);
+    expect(ownerBackfill).toContain('OWNER_RECORD_ID');
+    expect(ownerBackfill).toContain('OWNER_ID =');
+    expect(ownerBackfill).toContain('TENANT_ID =');
+    // The OR branch guarding re-writes
+    expect(ownerBackfill).toContain('IS NULL');
+
+    const updatedByBackfill = normalise(updates[1]!.sql);
+    expect(updatedByBackfill).toContain('UPDATED_BY_RECORD_ID');
+    expect(updatedByBackfill).toContain('UPDATED_BY =');
+    expect(updatedByBackfill).toContain('TENANT_ID =');
+    expect(updatedByBackfill).toContain('IS NULL');
+  });
+});
+
+describe('userSyncService Kysely SQL — update path', () => {
+  it('emits the user-record UPDATE scoped by id + tenant_id', async () => {
+    setExistingUser({
+      id: 'rec-existing',
+      field_values: {
+        email: 'sql@example.com',
+        display_name: 'Old Name',
+        role: 'member',
+        descope_user_id: DESCOPE_USER_ID,
+        is_active: true,
+      },
+    });
+    await syncUserRecord({ ...baseInput, displayName: 'New Name' });
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE RECORDS'),
+    );
+    // 1 user-record UPDATE + 2 backfill UPDATEs = 3
+    expect(updates.length).toBe(3);
+
+    const userUpdate = normalise(updates[0]!.sql);
+    expect(userUpdate).toContain('FIELD_VALUES =');
+    expect(userUpdate).toContain('NAME =');
+    expect(userUpdate).toContain('UPDATED_AT =');
+    expect(userUpdate).toContain('ID =');
+    expect(userUpdate).toContain('TENANT_ID =');
+  });
+
+  it('skips the user-record UPDATE when display_name and role are unchanged', async () => {
+    setExistingUser({
+      id: 'rec-existing',
+      field_values: {
+        email: 'sql@example.com',
+        display_name: 'SQL User',
+        role: 'member',
+        descope_user_id: DESCOPE_USER_ID,
+        is_active: true,
+      },
+    });
+    await syncUserRecord(baseInput);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE RECORDS'),
+    );
+    // Only the 2 backfill UPDATEs, no user-record UPDATE.
+    expect(updates.length).toBe(2);
+    for (const q of updates) {
+      const s = normalise(q.sql);
+      // The backfill UPDATEs set owner_record_id / updated_by_record_id, not field_values.
+      expect(s).not.toContain('FIELD_VALUES =');
+    }
+  });
+});
+
+describe('userSyncService Kysely SQL — non-transactional paths', () => {
+  it('syncUserRecord runs without opening an explicit transaction', async () => {
+    await syncUserRecord(baseInput);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/userSyncService.test.ts
+++ b/apps/api/src/services/__tests__/userSyncService.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Kysely's PostgresDialect acquires a client per query via `pool.connect()`,
+// so we route both `pool.query` and `pool.connect().query` through the same
+// underlying `mockQuery`. Callers use `mockResolvedValueOnce` on `mockQuery`
+// to queue responses in query order.
 const mockQuery = vi.fn();
 
+const mockConnect = vi.fn(async () => ({
+  query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    return mockQuery(rawSql, params);
+  }),
+  release: vi.fn(),
+}));
+
 vi.mock('../../db/client.js', () => ({
-  pool: {
-    query: (...args: unknown[]) => mockQuery(...args),
-  },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 vi.mock('../../lib/logger.js', () => ({
@@ -40,7 +51,7 @@ describe('syncUserRecord', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: objectId }] }) // object_definitions SELECT
       .mockResolvedValueOnce({ rows: [] }) // records SELECT (no existing user)
-      .mockResolvedValueOnce({ rows: [{ id: 'new-record-id' }] }) // records INSERT
+      .mockResolvedValueOnce({ rows: [] }) // records INSERT
       .mockResolvedValueOnce({ rowCount: 0 }) // backfill owner_record_id
       .mockResolvedValueOnce({ rowCount: 0 }); // backfill updated_by_record_id
 
@@ -56,10 +67,13 @@ describe('syncUserRecord', () => {
     expect(result.userRecordId).toBeDefined();
     expect(result.userRecordId).not.toBe('');
 
-    // Verify the INSERT was called with correct field_values
+    // Verify the INSERT was called with correct field_values.
+    // Kysely binds values in the order declared in `.values({...})`:
+    //   id, object_id, name, field_values, owner_id, tenant_id, created_at, updated_at.
     const insertCall = mockQuery.mock.calls[2];
-    const insertSql = insertCall[0] as string;
-    expect(insertSql).toContain('INSERT INTO records');
+    const insertSql = (insertCall[0] as string).toLowerCase();
+    expect(insertSql).toContain('insert into');
+    expect(insertSql).toContain('records');
 
     const insertParams = insertCall[1] as unknown[];
     expect(insertParams[2]).toBe('Test User'); // name
@@ -104,10 +118,12 @@ describe('syncUserRecord', () => {
     expect(result.created).toBe(false);
     expect(result.userRecordId).toBe(existingId);
 
-    // Verify UPDATE was called
+    // Verify UPDATE was called — Kysely's `.set({ field_values, name, updated_at })`
+    // binds those three values first, so `updateParams[0]` is the field_values JSON.
     const updateCall = mockQuery.mock.calls[2];
-    const updateSql = updateCall[0] as string;
-    expect(updateSql).toContain('UPDATE records');
+    const updateSql = (updateCall[0] as string).toLowerCase();
+    expect(updateSql).toContain('update');
+    expect(updateSql).toContain('records');
 
     const updateParams = updateCall[1] as unknown[];
     const updatedFieldValues = JSON.parse(updateParams[0] as string) as Record<string, unknown>;
@@ -194,7 +210,7 @@ describe('syncUserRecord', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: objectId }] }) // object_definitions SELECT
       .mockResolvedValueOnce({ rows: [] }) // records SELECT (no existing user)
-      .mockResolvedValueOnce({ rows: [{ id: 'new-record-id' }] }) // records INSERT
+      .mockResolvedValueOnce({ rows: [] }) // records INSERT
       .mockResolvedValueOnce({ rowCount: 0 }) // backfill owner_record_id
       .mockResolvedValueOnce({ rowCount: 0 }); // backfill updated_by_record_id
 
@@ -218,7 +234,7 @@ describe('syncUserRecord', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: objectId }] }) // object_definitions SELECT
       .mockResolvedValueOnce({ rows: [] }) // records SELECT (no existing user)
-      .mockResolvedValueOnce({ rows: [{ id: 'new-record-id' }] }) // records INSERT
+      .mockResolvedValueOnce({ rows: [] }) // records INSERT
       .mockResolvedValueOnce({ rowCount: 2 }) // backfill owner_record_id
       .mockResolvedValueOnce({ rowCount: 1 }); // backfill updated_by_record_id
 
@@ -231,13 +247,13 @@ describe('syncUserRecord', () => {
 
     // Verify backfill UPDATE for owner_record_id
     const backfillOwnerCall = mockQuery.mock.calls[3];
-    const backfillOwnerSql = backfillOwnerCall[0] as string;
+    const backfillOwnerSql = (backfillOwnerCall[0] as string).toLowerCase();
     expect(backfillOwnerSql).toContain('owner_record_id');
     expect(backfillOwnerSql).toContain('owner_id');
 
     // Verify backfill UPDATE for updated_by_record_id
     const backfillUpdatedByCall = mockQuery.mock.calls[4];
-    const backfillUpdatedBySql = backfillUpdatedByCall[0] as string;
+    const backfillUpdatedBySql = (backfillUpdatedByCall[0] as string).toLowerCase();
     expect(backfillUpdatedBySql).toContain('updated_by_record_id');
     expect(backfillUpdatedBySql).toContain('updated_by');
   });

--- a/apps/api/src/services/organisationService.ts
+++ b/apps/api/src/services/organisationService.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'crypto';
+import type { Selectable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type {
+  Organisations,
+  TenantMemberships,
+} from '../db/kysely.types.js';
 
 // ─── Local type aliases (mirror packages/types) ───────────────────────────────
 
@@ -69,6 +74,42 @@ function validateName(name: unknown): string | null {
   return null;
 }
 
+// ─── Row → domain model ─────────────────────────────────────────────────────
+
+/**
+ * Typing the row mappers against `Selectable<Organisations>` /
+ * `Selectable<TenantMemberships>` (rather than `Record<string, unknown>`)
+ * means a column rename or nullability change on the generated schema
+ * becomes a compile-time error at this service, rather than an `unknown`
+ * cast leaking an incorrect runtime shape into the domain model.
+ */
+function rowToOrganisation(
+  row: Selectable<Organisations>,
+): Organisation {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    name: row.name,
+    description: row.description ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToMembership(
+  row: Selectable<TenantMemberships>,
+): TenantMembership {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    userId: row.user_id,
+    organisationId: row.organisation_id ?? undefined,
+    role: row.role as 'owner' | 'admin' | 'member',
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 /**
  * Provisions a new organisation within a tenant.
  *
@@ -103,57 +144,38 @@ export async function provisionOrganisation(
   logger.info({ tenantId, organisationId, requestingUserId }, 'Provisioning new organisation');
 
   // Step 2 — persist organisation record
-  const orgResult = await pool.query(
-    `INSERT INTO organisations (id, tenant_id, name, description, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6)
-     RETURNING *`,
-    [
-      organisationId,
-      tenantId,
-      name.trim(),
-      description?.trim() ?? null,
-      now,
-      now,
-    ],
-  );
+  const orgRow = await db
+    .insertInto('organisations')
+    .values({
+      id: organisationId,
+      tenant_id: tenantId,
+      name: name.trim(),
+      description: description?.trim() ?? null,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
-  const orgRow = orgResult.rows[0];
-  const organisation: Organisation = {
-    id: orgRow.id as string,
-    tenantId: orgRow.tenant_id as string,
-    name: orgRow.name as string,
-    description: (orgRow.description as string | null) ?? undefined,
-    createdAt: new Date(orgRow.created_at as string),
-    updatedAt: new Date(orgRow.updated_at as string),
-  };
+  const organisation = rowToOrganisation(orgRow);
 
   // Step 3 — persist membership for the requesting user as owner
   const membershipId = randomUUID();
-  const memberResult = await pool.query(
-    `INSERT INTO tenant_memberships
-       (id, tenant_id, user_id, organisation_id, role, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, 'owner', $5, $6)
-     RETURNING *`,
-    [
-      membershipId,
-      tenantId,
-      requestingUserId,
-      organisationId,
-      now,
-      now,
-    ],
-  );
+  const memberRow = await db
+    .insertInto('tenant_memberships')
+    .values({
+      id: membershipId,
+      tenant_id: tenantId,
+      user_id: requestingUserId,
+      organisation_id: organisationId,
+      role: 'owner',
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
-  const memberRow = memberResult.rows[0];
-  const membership: TenantMembership = {
-    id: memberRow.id as string,
-    tenantId: memberRow.tenant_id as string,
-    userId: memberRow.user_id as string,
-    organisationId: (memberRow.organisation_id as string | null) ?? undefined,
-    role: memberRow.role as 'owner' | 'admin' | 'member',
-    createdAt: new Date(memberRow.created_at as string),
-    updatedAt: new Date(memberRow.updated_at as string),
-  };
+  const membership = rowToMembership(memberRow);
 
   logger.info(
     { tenantId, organisationId, membershipId: membership.id },

--- a/apps/api/src/services/profileService.ts
+++ b/apps/api/src/services/profileService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { UserProfiles } from '../db/kysely.types.js';
 
 export interface UserProfile {
   id: string;
@@ -31,15 +33,22 @@ function validateTextField(value: unknown, fieldLabel: string): string | null {
   return null;
 }
 
-function rowToProfile(row: Record<string, unknown>): UserProfile {
+/**
+ * Typing the row mapper against `Selectable<UserProfiles>` (rather than
+ * `Record<string, unknown>`) means a column rename or nullability change
+ * on the generated schema becomes a compile-time error at this service,
+ * rather than an `unknown` cast leaking an incorrect runtime shape into
+ * the domain model.
+ */
+function rowToProfile(row: Selectable<UserProfiles>): UserProfile {
   return {
-    id: row.id as string,
-    userId: row.user_id as string,
-    displayName: (row.display_name as string | null) ?? undefined,
-    jobTitle: (row.job_title as string | null) ?? undefined,
-    updatedBy: row.updated_by as string,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    id: row.id,
+    userId: row.user_id,
+    displayName: row.display_name ?? undefined,
+    jobTitle: row.job_title ?? undefined,
+    updatedBy: row.updated_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   };
 }
 
@@ -49,15 +58,20 @@ function rowToProfile(row: Record<string, unknown>): UserProfile {
  *
  * The profile is automatically seeded with no optional fields on first creation.
  * This implements the "profile on first access" requirement.
+ *
+ * Note: `user_profiles` is a global table (no `tenant_id` column) because
+ * a single Descope user may belong to multiple tenants and shares one
+ * profile across all of them.
  */
 export async function getOrCreateProfile(userId: string): Promise<UserProfile> {
-  const existing = await pool.query(
-    'SELECT * FROM user_profiles WHERE user_id = $1',
-    [userId],
-  );
+  const existing = await db
+    .selectFrom('user_profiles')
+    .selectAll()
+    .where('user_id', '=', userId)
+    .executeTakeFirst();
 
-  if (existing.rows.length > 0) {
-    return rowToProfile(existing.rows[0] as Record<string, unknown>);
+  if (existing) {
+    return rowToProfile(existing);
   }
 
   const now = new Date();
@@ -65,27 +79,35 @@ export async function getOrCreateProfile(userId: string): Promise<UserProfile> {
 
   logger.info({ userId }, 'Creating user profile for first-time user');
 
-  const result = await pool.query(
-    `INSERT INTO user_profiles (id, user_id, display_name, job_title, updated_by, created_at, updated_at)
-     VALUES ($1, $2, NULL, NULL, $3, $4, $5)
-     RETURNING *`,
-    [id, userId, userId, now, now],
-  );
+  const inserted = await db
+    .insertInto('user_profiles')
+    .values({
+      id,
+      user_id: userId,
+      display_name: null,
+      job_title: null,
+      updated_by: userId,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
-  return rowToProfile(result.rows[0] as Record<string, unknown>);
+  return rowToProfile(inserted);
 }
 
 /**
  * Returns the user profile for the given Descope user ID, or null if not found.
  */
 export async function getProfile(userId: string): Promise<UserProfile | null> {
-  const result = await pool.query(
-    'SELECT * FROM user_profiles WHERE user_id = $1',
-    [userId],
-  );
+  const row = await db
+    .selectFrom('user_profiles')
+    .selectAll()
+    .where('user_id', '=', userId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) return null;
-  return rowToProfile(result.rows[0] as Record<string, unknown>);
+  if (!row) return null;
+  return rowToProfile(row);
 }
 
 /**
@@ -118,47 +140,48 @@ export async function updateProfile(
     }
   }
 
-  const existing = await pool.query(
-    'SELECT * FROM user_profiles WHERE user_id = $1',
-    [userId],
-  );
+  const existing = await db
+    .selectFrom('user_profiles')
+    .select('id')
+    .where('user_id', '=', userId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     const e = new Error('Profile not found') as Error & { code: string };
     e.code = 'NOT_FOUND';
     throw e;
   }
 
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
+  // Build the partial update — only include fields the caller provided,
+  // preserving the original "UPDATE only-what-you-set" semantics.
+  const patch: {
+    display_name?: string | null;
+    job_title?: string | null;
+    updated_by: string;
+    updated_at: Date;
+  } = {
+    updated_by: updatedBy,
+    updated_at: new Date(),
+  };
 
   if ('displayName' in params) {
-    updates.push(`display_name = $${paramIndex++}`);
-    values.push(params.displayName?.trim() ?? null);
+    patch.display_name = params.displayName?.trim() ?? null;
   }
 
   if ('jobTitle' in params) {
-    updates.push(`job_title = $${paramIndex++}`);
-    values.push(params.jobTitle?.trim() ?? null);
+    patch.job_title = params.jobTitle?.trim() ?? null;
   }
 
-  updates.push(`updated_by = $${paramIndex++}`);
-  values.push(updatedBy);
-
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(new Date());
-
-  values.push(userId);
-
-  const result = await pool.query(
-    `UPDATE user_profiles SET ${updates.join(', ')} WHERE user_id = $${paramIndex} RETURNING *`,
-    values,
-  );
+  const updated = await db
+    .updateTable('user_profiles')
+    .set(patch)
+    .where('user_id', '=', userId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ userId, updatedBy }, 'User profile updated');
 
-  return rowToProfile(result.rows[0] as Record<string, unknown>);
+  return rowToProfile(updated);
 }
 
 export { validateTextField };

--- a/apps/api/src/services/userSyncService.ts
+++ b/apps/api/src/services/userSyncService.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
-import { pool } from '../db/client.js';
+import { sql } from 'kysely';
+import { db } from '../db/kysely.js';
 import { logger } from '../lib/logger.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -33,30 +34,35 @@ export async function syncUserRecord(input: SyncUserInput): Promise<SyncUserResu
   const { tenantId, descopeUserId, email, displayName, role } = input;
 
   // Find the User object definition for this tenant
-  const objResult = await pool.query(
-    `SELECT id FROM object_definitions WHERE api_name = 'user' AND tenant_id = $1`,
-    [tenantId],
-  );
+  const objDef = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('api_name', '=', 'user')
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (objResult.rows.length === 0) {
+  if (!objDef) {
     logger.debug({ tenantId }, 'User object definition not found; skipping user sync');
     return { userRecordId: '', created: false };
   }
 
-  const objectId = objResult.rows[0].id as string;
+  const objectId = objDef.id;
 
-  // Check if a User record exists for this descope_user_id
-  const existingResult = await pool.query(
-    `SELECT id, field_values FROM records
-     WHERE object_id = $1 AND tenant_id = $2
-       AND field_values->>'descope_user_id' = $3`,
-    [objectId, tenantId, descopeUserId],
-  );
+  // Check if a User record exists for this descope_user_id.
+  //
+  // The JSONB key access `field_values->>'descope_user_id'` is written via
+  // `sql` so the column reference is SQL-level while `descopeUserId` is
+  // bound as a parameter (see ADR-006 Appendix A on JSONB path expressions).
+  const existing = await db
+    .selectFrom('records')
+    .select(['id', 'field_values'])
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .where(sql<string>`field_values->>'descope_user_id'`, '=', descopeUserId)
+    .executeTakeFirst();
 
-  if (existingResult.rows.length > 0) {
-    // User record exists — check if we need to update
-    const existing = existingResult.rows[0] as { id: string; field_values: Record<string, unknown> };
-    const existingFieldValues = existing.field_values;
+  if (existing) {
+    const existingFieldValues = (existing.field_values ?? {}) as Record<string, unknown>;
 
     const needsUpdate =
       (displayName !== undefined && existingFieldValues['display_name'] !== displayName) ||
@@ -67,14 +73,22 @@ export async function syncUserRecord(input: SyncUserInput): Promise<SyncUserResu
       if (displayName !== undefined) updatedFieldValues['display_name'] = displayName;
       if (role !== undefined) updatedFieldValues['role'] = role;
 
-      const name = displayName ?? (existingFieldValues['display_name'] as string) ?? email ?? descopeUserId;
+      const name =
+        displayName ??
+        (existingFieldValues['display_name'] as string) ??
+        email ??
+        descopeUserId;
 
-      await pool.query(
-        `UPDATE records
-         SET field_values = $1, name = $2, updated_at = NOW()
-         WHERE id = $3 AND tenant_id = $4`,
-        [JSON.stringify(updatedFieldValues), name, existing.id, tenantId],
-      );
+      await db
+        .updateTable('records')
+        .set({
+          field_values: JSON.stringify(updatedFieldValues),
+          name,
+          updated_at: new Date(),
+        })
+        .where('id', '=', existing.id)
+        .where('tenant_id', '=', tenantId)
+        .execute();
 
       logger.debug({ tenantId, descopeUserId }, 'Updated User record from Descope');
     }
@@ -96,11 +110,21 @@ export async function syncUserRecord(input: SyncUserInput): Promise<SyncUserResu
     is_active: true,
   };
 
-  await pool.query(
-    `INSERT INTO records (id, object_id, name, field_values, owner_id, tenant_id, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())`,
-    [id, objectId, name, JSON.stringify(fieldValues), descopeUserId, tenantId],
-  );
+  const now = new Date();
+
+  await db
+    .insertInto('records')
+    .values({
+      id,
+      object_id: objectId,
+      name,
+      field_values: JSON.stringify(fieldValues),
+      owner_id: descopeUserId,
+      tenant_id: tenantId,
+      created_at: now,
+      updated_at: now,
+    })
+    .execute();
 
   logger.info({ tenantId, descopeUserId, userRecordId: id }, 'Created User record from Descope');
 
@@ -121,23 +145,31 @@ async function backfillOwnerRecordId(
   userRecordId: string,
 ): Promise<void> {
   try {
-    await pool.query(
-      `UPDATE records
-       SET owner_record_id = $1
-       WHERE tenant_id = $2
-         AND owner_id = $3
-         AND (owner_record_id IS NULL OR owner_record_id != $1)`,
-      [userRecordId, tenantId, descopeUserId],
-    );
+    await db
+      .updateTable('records')
+      .set({ owner_record_id: userRecordId })
+      .where('tenant_id', '=', tenantId)
+      .where('owner_id', '=', descopeUserId)
+      .where((eb) =>
+        eb.or([
+          eb('owner_record_id', 'is', null),
+          eb('owner_record_id', '!=', userRecordId),
+        ]),
+      )
+      .execute();
 
-    await pool.query(
-      `UPDATE records
-       SET updated_by_record_id = $1
-       WHERE tenant_id = $2
-         AND updated_by = $3
-         AND (updated_by_record_id IS NULL OR updated_by_record_id != $1)`,
-      [userRecordId, tenantId, descopeUserId],
-    );
+    await db
+      .updateTable('records')
+      .set({ updated_by_record_id: userRecordId })
+      .where('tenant_id', '=', tenantId)
+      .where('updated_by', '=', descopeUserId)
+      .where((eb) =>
+        eb.or([
+          eb('updated_by_record_id', 'is', null),
+          eb('updated_by_record_id', '!=', userRecordId),
+        ]),
+      )
+      .execute();
   } catch (err) {
     // Backfill is best-effort — don't fail the login
     logger.warn({ err, tenantId, descopeUserId }, 'Failed to backfill owner_record_id');


### PR DESCRIPTION
## Summary

Phase 3b, Group C — PR 1 of 3. Migrates the low-risk trio of
`organisationService`, `profileService`, and `userSyncService` from
raw `pg` `pool.query` calls to the tenant-aware Kysely client
(`apps/api/src/db/kysely.ts`).

Row mappers are typed against `Selectable<OrganisationTable>` /
`Selectable<UserProfiles>` etc. so a future column rename or
nullability change on the generated schema surfaces at compile time
instead of as an `unknown` cast leaking an incorrect runtime shape
into the domain model.

### Per-service notes

- **organisationService.ts** — `provisionOrganisation` now issues two
  Kysely INSERTs with `.returningAll().executeTakeFirstOrThrow()`,
  preserving the original non-transactional behaviour.
- **profileService.ts** — `getOrCreateProfile` / `getProfile` /
  `updateProfile` use Kysely builders. `updateProfile` retains its
  *"only SET the columns the caller provided"* semantics via a
  conditionally-built patch object (no hidden over-writes). Note that
  `user_profiles` has **no** `tenant_id` column — profiles are global
  across tenants — so there is no defence-in-depth work here.
- **userSyncService.ts** — the `descope_user_id` JSONB lookup uses
  ``sql<string>`field_values->>'descope_user_id'`` so the user id is
  bound as a parameter (ADR-006 Appendix A). Backfill UPDATEs preserve
  the "IS NULL OR != new value" guard via `eb.or([...])`.

### Tests

- Existing behavioural suites are now Kysely-aware: they route
  `pool.connect().query` through the same `mockQuery` so the
  `mockResolvedValueOnce` pattern keeps working.
- New `.kysely-sql.test.ts` regression suites (one per service)
  assert directly on the SQL Kysely emits:
  - every data query carries `tenant_id` (where applicable)
  - INSERT/UPDATE column counts + position of `tenant_id` bind
  - `descope_user_id` JSONB lookup binds the value as a parameter —
    the raw user id must **not** appear in the SQL text
  - `getOrCreateProfile` / `getProfile` issue exactly one SELECT each
  - `updateProfile` only `SET`s the columns the caller provided
  - non-transactional paths (no `BEGIN`/`COMMIT`)

### Test plan

- [x] `npx vitest run` (apps/api) — **1444 passed / 1 skipped**
- [x] `npx tsc --noEmit -p apps/api` — clean
- [x] Targeted run of the 6 new/updated test files — **65 passed**

Tracker: #445 (Phase 3b, Group C).
Follow-ups: PR 2 (`accountService`), PR 3 (`tenantProvisioning`).

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf