### PR TITLE
Migrate accountService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/accountService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/accountService.kysely-sql.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Kysely SQL regression suite for accountService.
+ *
+ * Complements `accountService.test.ts` (behavioural assertions) by
+ * asserting directly on the SQL Kysely emits for every public entry
+ * point. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every tenant-scoped query on `accounts` and
+ *      `opportunities` carries a `tenant_id` filter as defence-in-depth
+ *      against an RLS misconfiguration (ADR-006) — including inside the
+ *      correlated `opportunity_count` scalar subquery.
+ *   3. Verify the list-path emits a lightweight `SELECT count(*)` for
+ *      pagination rather than dedupe'ing the wide joined projection.
+ *   4. Verify updateAccount only writes the columns the caller supplied
+ *      (no hidden over-writes of unrelated fields).
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const OWNER_ID = 'user-sql-001';
+const ACCOUNT_ID = 'account-sql-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture, setFixtureRow } =
+  vi.hoisted(() => {
+    const capturedQueries: CapturedQuery[] = [];
+    let fixtureRow: Record<string, unknown> | null = null;
+
+    function makeAccountRow(overrides: Record<string, unknown> = {}) {
+      const now = new Date();
+      return {
+        id: 'account-sql-001',
+        tenant_id: 'sql-tenant-001',
+        name: 'SQL Corp',
+        industry: null,
+        website: null,
+        phone: null,
+        email: null,
+        address_line1: null,
+        address_line2: null,
+        city: null,
+        region: null,
+        postal_code: null,
+        country: null,
+        notes: null,
+        owner_id: 'user-sql-001',
+        created_by: 'user-sql-001',
+        created_at: now,
+        updated_at: now,
+        ...overrides,
+      };
+    }
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql
+        .replace(/\s+/g, ' ')
+        .replace(/"/g, '')
+        .trim()
+        .toUpperCase();
+
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // INSERT INTO accounts ... RETURNING *
+      if (s.startsWith('INSERT INTO ACCOUNTS')) {
+        // Echo the bound params back so createAccount sees a populated row.
+        const [
+          id,
+          tenant_id,
+          name,
+          industry,
+          website,
+          phone,
+          email,
+          address_line1,
+          address_line2,
+          city,
+          region,
+          postal_code,
+          country,
+          notes,
+          owner_id,
+          created_by,
+          created_at,
+          updated_at,
+        ] = (params ?? []) as unknown[];
+        return {
+          rows: [
+            {
+              id,
+              tenant_id,
+              name,
+              industry,
+              website,
+              phone,
+              email,
+              address_line1,
+              address_line2,
+              city,
+              region,
+              postal_code,
+              country,
+              notes,
+              owner_id,
+              created_by,
+              created_at,
+              updated_at,
+            },
+          ],
+          rowCount: 1,
+          command: 'INSERT',
+        };
+      }
+
+      // listAccounts count path: SELECT count(*) as total FROM accounts as a
+      if (s.startsWith('SELECT COUNT(*)') && s.includes('FROM ACCOUNTS')) {
+        return { rows: [{ total: '1' }] };
+      }
+
+      // listAccounts data path: SELECT a.*, (SELECT count(*) ...) as opportunity_count
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM ACCOUNTS AS A') &&
+        s.includes('LIMIT') &&
+        s.includes('OFFSET')
+      ) {
+        return { rows: [{ ...makeAccountRow(), opportunity_count: '0' }] };
+      }
+
+      // getAccountWithOpportunities / updateAccount existence check:
+      //   SELECT * FROM accounts WHERE id = ... AND tenant_id = ... AND owner_id = ...
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM ACCOUNTS') &&
+        !s.includes('FROM ACCOUNTS AS A')
+      ) {
+        if (fixtureRow) return { rows: [fixtureRow] };
+        return { rows: [] };
+      }
+
+      // getAccountWithOpportunities opportunities projection
+      if (s.startsWith('SELECT') && s.includes('FROM OPPORTUNITIES')) {
+        return { rows: [] };
+      }
+
+      // UPDATE accounts ... RETURNING *
+      if (s.startsWith('UPDATE ACCOUNTS')) {
+        return { rows: [makeAccountRow()], rowCount: 1, command: 'UPDATE' };
+      }
+
+      // DELETE FROM accounts
+      if (s.startsWith('DELETE FROM ACCOUNTS')) {
+        return { rows: [], rowCount: 1, command: 'DELETE' };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: unknown, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+      fixtureRow = null;
+    }
+
+    function setFixtureRow(row: Record<string, unknown> | null) {
+      fixtureRow = row === null ? null : makeAccountRow(row);
+    }
+
+    return {
+      capturedQueries,
+      mockQuery,
+      mockConnect,
+      resetCapture,
+      setFixtureRow,
+    };
+  });
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createAccount,
+  listAccounts,
+  getAccountWithOpportunities,
+  updateAccount,
+  deleteAccount,
+} = await import('../accountService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const baseCreate = {
+  name: 'SQL Corp',
+  tenantId: TENANT_ID,
+  requestingUserId: OWNER_ID,
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('accountService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('createAccount binds tenant_id on the INSERT', async () => {
+    await createAccount(baseCreate);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO ACCOUNTS'),
+    );
+    expect(inserts.length).toBe(1);
+    expect(inserts[0]!.params).toContain(TENANT_ID);
+    expect(normalise(inserts[0]!.sql)).toContain('TENANT_ID');
+  });
+
+  it('listAccounts references tenant_id on every data query (count + list)', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 20, offset: 0 });
+
+    const queries = dataQueries();
+    expect(queries.length).toBe(2); // count + data
+    for (const q of queries) {
+      expect(
+        normalise(q.sql).includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+      expect(q.params).toContain(TENANT_ID);
+    }
+  });
+
+  it('listAccounts search path references tenant_id on every data query', async () => {
+    await listAccounts({
+      tenantId: TENANT_ID,
+      ownerId: OWNER_ID,
+      search: 'acme',
+      limit: 20,
+      offset: 0,
+    });
+
+    const queries = dataQueries();
+    expect(queries.length).toBe(2);
+    for (const q of queries) {
+      expect(
+        normalise(q.sql).includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+      expect(q.params).toContain(TENANT_ID);
+    }
+  });
+
+  it('the opportunity_count scalar subquery carries tenant_id on BOTH the outer and inner halves', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 20, offset: 0 });
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM ACCOUNTS AS A') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    const s = normalise(dataPath!.sql);
+    // Outer (a.tenant_id)
+    expect(s).toContain('A.TENANT_ID =');
+    // Inner (o.tenant_id) referenced inside the scalar subquery
+    expect(s).toContain('O.TENANT_ID =');
+    // And it's a ref-equality against a.tenant_id, not a bind
+    expect(s).toContain('O.TENANT_ID = A.TENANT_ID');
+  });
+
+  it('getAccountWithOpportunities references tenant_id on both the account SELECT and the opportunities SELECT', async () => {
+    setFixtureRow({});
+    await getAccountWithOpportunities(ACCOUNT_ID, TENANT_ID, OWNER_ID);
+
+    const queries = dataQueries();
+    expect(queries.length).toBe(2); // account + opportunities
+    for (const q of queries) {
+      expect(
+        normalise(q.sql).includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+      expect(q.params).toContain(TENANT_ID);
+    }
+  });
+
+  it('updateAccount references tenant_id on both the existence check and the UPDATE', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { name: 'Updated' });
+
+    const queries = dataQueries();
+    // SELECT existence check + UPDATE ... RETURNING *
+    expect(queries.length).toBe(2);
+    for (const q of queries) {
+      expect(
+        normalise(q.sql).includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+      expect(q.params).toContain(TENANT_ID);
+    }
+  });
+
+  it('deleteAccount binds tenant_id on the DELETE', async () => {
+    await deleteAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM ACCOUNTS'),
+    );
+    expect(deletes.length).toBe(1);
+    expect(deletes[0]!.params).toContain(TENANT_ID);
+    expect(normalise(deletes[0]!.sql)).toContain('TENANT_ID =');
+  });
+});
+
+describe('accountService Kysely SQL — create path', () => {
+  it('INSERT INTO accounts binds exactly 18 columns in the expected order', async () => {
+    await createAccount(baseCreate);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO ACCOUNTS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    // Column order (as written in the service .values({...})):
+    //   id, tenant_id, name, industry, website, phone, email,
+    //   address_line1, address_line2, city, region, postal_code, country,
+    //   notes, owner_id, created_by, created_at, updated_at.
+    expect(inserts[0]!.params.length).toBe(18);
+    expect(inserts[0]!.params[1]).toBe(TENANT_ID);
+    expect(inserts[0]!.params[2]).toBe('SQL Corp');
+    expect(inserts[0]!.params[14]).toBe(OWNER_ID); // owner_id
+    expect(inserts[0]!.params[15]).toBe(OWNER_ID); // created_by
+
+    const s = normalise(inserts[0]!.sql);
+    expect(s).toContain('RETURNING');
+  });
+
+  it('persists optional fields as null when not supplied (not empty string or "undefined")', async () => {
+    await createAccount(baseCreate);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO ACCOUNTS'),
+    );
+    const p = inserts[0]!.params;
+    // industry..notes — every optional column coerced to null
+    for (let i = 3; i <= 13; i++) {
+      expect(p[i], `column index ${i} should be null`).toBeNull();
+    }
+  });
+});
+
+describe('accountService Kysely SQL — list path', () => {
+  it('count query is a separate lightweight SELECT COUNT(*) — not the wide data projection', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 20, offset: 0 });
+
+    const countQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('SELECT COUNT(*)'),
+    );
+    expect(countQuery).toBeDefined();
+
+    const s = normalise(countQuery!.sql);
+    // The count query should NOT project the full accounts row or the
+    // opportunity_count scalar — that's the data query's job.
+    expect(s).not.toContain('A.*');
+    expect(s).not.toContain('OPPORTUNITY_COUNT');
+    // And no LIMIT/OFFSET on the count path
+    expect(s).not.toContain('LIMIT');
+    expect(s).not.toContain('OFFSET');
+  });
+
+  it('data query emits the correlated opportunity_count subquery', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 20, offset: 0 });
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM ACCOUNTS AS A') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    const s = normalise(dataPath!.sql);
+    expect(s).toContain('A.*');
+    expect(s).toContain('OPPORTUNITY_COUNT');
+    // The subquery joins on account_id + tenant_id via whereRef
+    expect(s).toContain('O.ACCOUNT_ID = A.ID');
+    expect(s).toContain('FROM OPPORTUNITIES AS O');
+  });
+
+  it('search path binds the escaped ilike pattern, not a raw string', async () => {
+    await listAccounts({
+      tenantId: TENANT_ID,
+      ownerId: OWNER_ID,
+      search: '50%_off',
+      limit: 20,
+      offset: 0,
+    });
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM ACCOUNTS AS A') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    // The bound value should carry escaped LIKE metacharacters.
+    const escapedBind = '%50\\%\\_off%';
+    expect(dataPath!.params).toContain(escapedBind);
+
+    const s = normalise(dataPath!.sql);
+    // ILIKE, not LIKE, and bound as a parameter
+    expect(s).toContain('A.NAME ILIKE');
+    expect(s).toContain('A.EMAIL ILIKE');
+    // The raw user input itself must NOT appear in the SQL text
+    expect(dataPath!.sql.includes('50%_off')).toBe(false);
+  });
+
+  it('list query orders by a.created_at DESC with LIMIT / OFFSET applied', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 5, offset: 10 });
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM ACCOUNTS AS A') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    const s = normalise(dataPath!.sql);
+    expect(s).toContain('ORDER BY A.CREATED_AT DESC');
+    expect(s).toContain('LIMIT');
+    expect(s).toContain('OFFSET');
+    expect(dataPath!.params).toContain(5);
+    expect(dataPath!.params).toContain(10);
+  });
+});
+
+describe('accountService Kysely SQL — getAccountWithOpportunities', () => {
+  it('projects only the 8 columns needed for the API response (not *)', async () => {
+    setFixtureRow({});
+    await getAccountWithOpportunities(ACCOUNT_ID, TENANT_ID, OWNER_ID);
+
+    const oppQuery = dataQueries().find((q) =>
+      normalise(q.sql).includes('FROM OPPORTUNITIES'),
+    );
+    expect(oppQuery).toBeDefined();
+
+    const s = normalise(oppQuery!.sql);
+    // Must list the exact columns, and must NOT be SELECT *
+    expect(s).toContain('ID');
+    expect(s).toContain('TITLE');
+    expect(s).toContain('STAGE');
+    expect(s).toContain('VALUE');
+    expect(s).toContain('CURRENCY');
+    expect(s).toContain('EXPECTED_CLOSE_DATE');
+    // Columns the product does not need should NOT be projected
+    expect(s).not.toContain('DESCRIPTION');
+    expect(s).not.toContain('OWNER_ID');
+    expect(s).toContain('ORDER BY CREATED_AT DESC');
+  });
+});
+
+describe('accountService Kysely SQL — updateAccount', () => {
+  it('emits an existence-check SELECT followed by UPDATE ... RETURNING *', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { name: 'Renamed' });
+
+    const queries = dataQueries();
+    expect(queries.length).toBe(2);
+
+    const selectSql = normalise(queries[0]!.sql);
+    expect(selectSql).toContain('SELECT');
+    expect(selectSql).toContain('FROM ACCOUNTS');
+    expect(selectSql).toContain('ID =');
+    expect(selectSql).toContain('TENANT_ID =');
+    expect(selectSql).toContain('OWNER_ID =');
+
+    const updateSql = normalise(queries[1]!.sql);
+    expect(updateSql).toContain('UPDATE ACCOUNTS');
+    expect(updateSql).toContain('RETURNING');
+  });
+
+  it('only sets columns the caller provided (no hidden over-writes)', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { name: 'Renamed' });
+
+    const updateQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE ACCOUNTS'),
+    );
+    expect(updateQuery).toBeDefined();
+
+    const s = normalise(updateQuery!.sql);
+    // updated_at is always touched
+    expect(s).toContain('UPDATED_AT =');
+    // name was in the patch
+    expect(s).toContain('NAME =');
+    // Nothing else
+    expect(s).not.toContain('INDUSTRY =');
+    expect(s).not.toContain('WEBSITE =');
+    expect(s).not.toContain('PHONE =');
+    expect(s).not.toContain('EMAIL =');
+    expect(s).not.toContain('ADDRESS_LINE1 =');
+    expect(s).not.toContain('CITY =');
+    expect(s).not.toContain('NOTES =');
+  });
+
+  it('updating only email does not clobber name or other fields', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { email: 'new@example.com' });
+
+    const updateQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE ACCOUNTS'),
+    );
+    const s = normalise(updateQuery!.sql);
+    expect(s).toContain('EMAIL =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).not.toContain('NAME =');
+    expect(s).not.toContain('INDUSTRY =');
+  });
+
+  it('explicit-null clears the column (distinguished from "key not present")', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { industry: null });
+
+    const updateQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE ACCOUNTS'),
+    );
+    expect(updateQuery).toBeDefined();
+
+    const s = normalise(updateQuery!.sql);
+    expect(s).toContain('INDUSTRY =');
+    expect(updateQuery!.params).toContain(null);
+  });
+});
+
+describe('accountService Kysely SQL — deleteAccount', () => {
+  it('binds id + tenant_id + owner_id on the DELETE', async () => {
+    await deleteAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM ACCOUNTS'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const s = normalise(deletes[0]!.sql);
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('OWNER_ID =');
+
+    expect(deletes[0]!.params).toContain(ACCOUNT_ID);
+    expect(deletes[0]!.params).toContain(TENANT_ID);
+    expect(deletes[0]!.params).toContain(OWNER_ID);
+  });
+});
+
+describe('accountService Kysely SQL — non-transactional paths', () => {
+  it('createAccount runs without opening an explicit transaction', async () => {
+    await createAccount(baseCreate);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('listAccounts runs without opening an explicit transaction', async () => {
+    await listAccounts({ tenantId: TENANT_ID, ownerId: OWNER_ID, limit: 20, offset: 0 });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('updateAccount runs without opening an explicit transaction', async () => {
+    setFixtureRow({});
+    await updateAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID, { name: 'Renamed' });
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+
+  it('deleteAccount runs without opening an explicit transaction', async () => {
+    await deleteAccount(ACCOUNT_ID, TENANT_ID, OWNER_ID);
+    const sqls = capturedQueries.map((q) => normalise(q.sql));
+    expect(sqls).not.toContain('BEGIN');
+    expect(sqls).not.toContain('COMMIT');
+  });
+});

--- a/apps/api/src/services/__tests__/accountService.test.ts
+++ b/apps/api/src/services/__tests__/accountService.test.ts
@@ -16,85 +16,178 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely's PostgresDialect acquires a client per query via `pool.connect()`,
+// so the mock routes both `pool.query` and `pool.connect().query` through the
+// same `runQuery` dispatcher. SQL identifier quotes are stripped so the
+// matchers are quote-agnostic.
 
-const { fakeRows, mockQuery } = vi.hoisted(() => {
+const { fakeRows, mockQuery, mockConnect } = vi.hoisted(() => {
   const fakeRows = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(rawSql: string, params: unknown[] | undefined) {
+    const s = rawSql
+      .replace(/\s+/g, ' ')
+      .replace(/"/g, '')
+      .trim()
+      .toUpperCase();
 
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO accounts (... 18 columns ...) VALUES ($1, ..., $18) RETURNING *
     if (s.startsWith('INSERT INTO ACCOUNTS')) {
-      const [id, tenant_id, name, industry, website, phone, email,
-        address_line1, address_line2, city, region, postal_code, country, notes,
-        owner_id, created_by, created_at, updated_at] = params as unknown[];
+      const [
+        id,
+        tenant_id,
+        name,
+        industry,
+        website,
+        phone,
+        email,
+        address_line1,
+        address_line2,
+        city,
+        region,
+        postal_code,
+        country,
+        notes,
+        owner_id,
+        created_by,
+        created_at,
+        updated_at,
+      ] = params as unknown[];
       const row: Record<string, unknown> = {
-        id, tenant_id, name, industry, website, phone, email,
-        address_line1, address_line2, city, region, postal_code, country, notes,
-        owner_id, created_by, created_at, updated_at,
+        id,
+        tenant_id,
+        name,
+        industry,
+        website,
+        phone,
+        email,
+        address_line1,
+        address_line2,
+        city,
+        region,
+        postal_code,
+        country,
+        notes,
+        owner_id,
+        created_by,
+        created_at,
+        updated_at,
       };
       fakeRows.set(id as string, row);
       return { rows: [row] };
     }
 
-    if (s.startsWith('SELECT COUNT(*)')) {
+    // listAccounts count path:
+    //   SELECT count(*) as total FROM accounts as a
+    //     WHERE a.tenant_id = $1 AND a.owner_id = $2
+    //     [AND (a.name ilike $3 OR a.email ilike $4)]
+    //
+    // Note: the data query also contains COUNT(*) (inside its scalar
+    // subquery), so we anchor on `SELECT COUNT(*)` at the start of the
+    // compiled SQL — not just `includes('COUNT(*)')` — to disambiguate.
+    if (s.startsWith('SELECT COUNT(*)') && s.includes('FROM ACCOUNTS')) {
       const [tenant_id, owner_id] = params as string[];
-      const matching = [...fakeRows.values()].filter(
+      let matching = [...fakeRows.values()].filter(
         (r) => r.tenant_id === tenant_id && r.owner_id === owner_id,
       );
-
-      // Handle search filter if present
-      if (params && params.length > 2) {
-        const searchTerm = (params[2] as string).replace(/%/g, '').toLowerCase();
-        const filtered = matching.filter(
+      if (params && params.length > 2 && typeof params[2] === 'string') {
+        const term = (params[2] as string).replace(/%/g, '').toLowerCase();
+        matching = matching.filter(
           (r) =>
-            (r.name as string).toLowerCase().includes(searchTerm) ||
-            ((r.email as string | null) ?? '').toLowerCase().includes(searchTerm),
+            (r.name as string).toLowerCase().includes(term) ||
+            ((r.email as string | null) ?? '').toLowerCase().includes(term),
         );
-        return { rows: [{ total: String(filtered.length) }] };
       }
-
       return { rows: [{ total: String(matching.length) }] };
     }
 
-    if (s.includes('FROM ACCOUNTS') && s.includes('LIMIT') && s.includes('OFFSET')) {
+    // listAccounts data path:
+    //   SELECT a.*, (select count(*) ... opportunities ...) as opportunity_count
+    //     FROM accounts as a
+    //     WHERE a.tenant_id = $1 AND a.owner_id = $2
+    //     [AND (a.name ilike $3 OR a.email ilike $4)]
+    //     ORDER BY a.created_at DESC LIMIT $N OFFSET $N+1
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM ACCOUNTS AS A') &&
+      s.includes('LIMIT') &&
+      s.includes('OFFSET')
+    ) {
       const [tenant_id, owner_id] = params as string[];
       let matching = [...fakeRows.values()].filter(
         (r) => r.tenant_id === tenant_id && r.owner_id === owner_id,
       );
 
-      // Handle search filter
-      if (params && params.length > 2 && typeof params[2] === 'string' && (params[2] as string).startsWith('%')) {
-        const searchTerm = (params[2] as string).replace(/%/g, '').toLowerCase();
+      // With search: params = [tenantId, ownerId, searchTerm, searchTerm, limit, offset]
+      // Without:     params = [tenantId, ownerId, limit, offset]
+      const hasSearch =
+        params &&
+        params.length > 4 &&
+        typeof params[2] === 'string' &&
+        (params[2] as string).includes('%');
+
+      if (hasSearch) {
+        const term = (params![2] as string).replace(/%/g, '').toLowerCase();
         matching = matching.filter(
           (r) =>
-            (r.name as string).toLowerCase().includes(searchTerm) ||
-            ((r.email as string | null) ?? '').toLowerCase().includes(searchTerm),
+            (r.name as string).toLowerCase().includes(term) ||
+            ((r.email as string | null) ?? '').toLowerCase().includes(term),
         );
-        const limit = params[3] as number;
-        const offset = params[4] as number;
-        return { rows: matching.slice(offset, offset + limit).map((r) => ({ ...r, opportunity_count: '0' })) };
       }
 
-      // No search — params: [tenant_id, owner_id, limit, offset]
-      const limit = params![2] as number;
-      const offset = params![3] as number;
-      return { rows: matching.slice(offset, offset + limit).map((r) => ({ ...r, opportunity_count: '0' })) };
+      const limit = (hasSearch ? params![4] : params![2]) as number;
+      const offset = (hasSearch ? params![5] : params![3]) as number;
+
+      return {
+        rows: matching
+          .slice(offset, offset + limit)
+          .map((r) => ({ ...r, opportunity_count: '0' })),
+      };
     }
 
-    if (s.startsWith('SELECT * FROM ACCOUNTS WHERE ID = $1 AND TENANT_ID = $2 AND OWNER_ID = $3')) {
+    // getAccountWithOpportunities account lookup:
+    //   SELECT * FROM accounts WHERE id = $1 AND tenant_id = $2 AND owner_id = $3
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM ACCOUNTS') &&
+      !s.includes('FROM ACCOUNTS AS A') &&
+      s.includes('ID =') &&
+      s.includes('TENANT_ID =') &&
+      s.includes('OWNER_ID =')
+    ) {
       const [id, tenant_id, owner_id] = params as string[];
       const row = fakeRows.get(id);
-      if (row && row.tenant_id === tenant_id && row.owner_id === owner_id) return { rows: [row] };
+      if (row && row.tenant_id === tenant_id && row.owner_id === owner_id) {
+        // If the projection is only `id` (updateAccount existence check),
+        // the same row still passes the match — Kysely narrows the fields
+        // server-side so we can return the full row object.
+        return { rows: [row] };
+      }
       return { rows: [] };
     }
 
-    if (s.startsWith('SELECT ID, TITLE, STAGE')) {
-      // Opportunities lookup for getAccountWithOpportunities
+    // getAccountWithOpportunities opportunities lookup:
+    //   SELECT id, title, stage, value, currency, expected_close_date,
+    //          created_at, updated_at
+    //     FROM opportunities
+    //     WHERE account_id = $1 AND tenant_id = $2
+    //     ORDER BY created_at DESC
+    if (s.startsWith('SELECT') && s.includes('FROM OPPORTUNITIES')) {
       return { rows: [] };
     }
 
+    // updateAccount UPDATE ... RETURNING *
     if (s.startsWith('UPDATE ACCOUNTS')) {
-      // Find the account to update
+      // The WHERE clause binds [id, tenant_id, owner_id] at the tail, so
+      // the id is at params.length - 3.
       const idIdx = params!.length - 3;
       const id = params![idIdx] as string;
       const existing = fakeRows.get(id);
@@ -104,24 +197,53 @@ const { fakeRows, mockQuery } = vi.hoisted(() => {
       return { rows: [updated] };
     }
 
+    // deleteAccount: Kysely's PostgresDriver reads `rowCount` into
+    // `numAffectedRows` ONLY when `command` is 'INSERT' | 'UPDATE' |
+    // 'DELETE' | 'MERGE' on the pg result, so the mock must emit the
+    // command marker or `numDeletedRows` comes back as 0n.
     if (s.startsWith('DELETE FROM ACCOUNTS')) {
       const [id, tenant_id, owner_id] = params as string[];
       const row = fakeRows.get(id);
       if (row && row.tenant_id === tenant_id && row.owner_id === owner_id) {
         fakeRows.delete(id);
-        return { rowCount: 1 };
+        return { rows: [], rowCount: 1, command: 'DELETE' };
       }
-      return { rowCount: 0 };
+      return { rows: [], rowCount: 0, command: 'DELETE' };
     }
 
     return { rows: [] };
+  }
+
+  // Kysely's pg driver calls `client.query({ text, values })` with a single
+  // query-config object. The shim unwraps both the string- and object-form
+  // call shapes so the dispatcher sees consistent (sql, params) tuples.
+  function unwrap(
+    sql: unknown,
+    params: unknown[] | undefined,
+  ): { rawSql: string; rawParams: unknown[] | undefined } {
+    if (typeof sql === 'string') return { rawSql: sql, rawParams: params };
+    const obj = sql as { text: string; values?: unknown[] };
+    return { rawSql: obj.text, rawParams: obj.values ?? params };
+  }
+
+  const mockQuery = vi.fn(async (sql: unknown, params?: unknown[]) => {
+    const { rawSql, rawParams } = unwrap(sql, params);
+    return runQuery(rawSql, rawParams);
   });
 
-  return { fakeRows, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+      const { rawSql, rawParams } = unwrap(sql, params);
+      return runQuery(rawSql, rawParams);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeRows, mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Validation tests ─────────────────────────────────────────────────────────
@@ -420,7 +542,7 @@ describe('listAccounts', () => {
     });
 
     expect(result.data).toHaveLength(1);
-    expect(result.data[0].name).toBe('My Account');
+    expect(result.data[0]!.name).toBe('My Account');
   });
 });
 

--- a/apps/api/src/services/accountService.ts
+++ b/apps/api/src/services/accountService.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { Selectable } from 'kysely';
+import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
 import type { Accounts, Opportunities } from '../db/kysely.types.js';
@@ -455,7 +455,16 @@ export async function getAccountWithOpportunities(
     stage: row.stage as string,
     value: row.value != null ? Number(row.value) : undefined,
     currency: row.currency ?? undefined,
-    expectedCloseDate: row.expected_close_date ?? undefined,
+    // Postgres DATE columns are returned as strings by `pg` without a
+    // custom type parser (OID 1082 has no default in node-postgres), so
+    // we normalise to `Date` here to preserve the documented
+    // `expectedCloseDate: Date` contract on AccountWithOpportunities.
+    // TIMESTAMP columns (created_at/updated_at) are handled by pg's
+    // default parser and arrive as Date objects already.
+    expectedCloseDate:
+      row.expected_close_date != null
+        ? new Date(row.expected_close_date as unknown as string)
+        : undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }));
@@ -512,11 +521,20 @@ export async function updateAccount(
 
   // Build the partial update — only include fields the caller provided,
   // preserving the original "UPDATE only-what-you-set" semantics.
-  const patch: Record<string, unknown> = {
+  //
+  // Typed against `Updateable<Accounts>` so Kysely still enforces
+  // column names and value shapes at compile time (a column rename
+  // on the generated schema becomes an error here, not a silent
+  // runtime SQL mismatch).
+  //
+  // `name` is non-nullable so we guard on `!== undefined` — the
+  // `'key' in params` pattern is reserved for nullable columns where
+  // `null` (explicit clear) vs missing (leave alone) is meaningful.
+  const patch: Updateable<Accounts> = {
     updated_at: new Date(),
   };
 
-  if ('name' in params) patch.name = params.name!.trim();
+  if (params.name !== undefined) patch.name = params.name.trim();
   if ('industry' in params) patch.industry = params.industry?.trim() ?? null;
   if ('website' in params) patch.website = params.website?.trim() ?? null;
   if ('phone' in params) patch.phone = params.phone?.trim() ?? null;

--- a/apps/api/src/services/accountService.ts
+++ b/apps/api/src/services/accountService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { Accounts, Opportunities } from '../db/kysely.types.js';
 
 // ─── Local type aliases ───────────────────────────────────────────────────────
 
@@ -175,35 +177,64 @@ export function validateWebsite(website: unknown): string | null {
 
 // ─── Row → domain model ───────────────────────────────────────────────────────
 
-function rowToAccount(row: Record<string, unknown>): Account {
+/**
+ * Typing the row mapper against `Selectable<Accounts>` (rather than
+ * `Record<string, unknown>`) means a column rename or nullability change
+ * on the generated schema becomes a compile-time error at this service,
+ * rather than an `unknown` cast leaking an incorrect runtime shape into
+ * the domain model.
+ */
+function rowToAccount(row: Selectable<Accounts>): Account {
   return {
-    id: row.id as string,
-    tenantId: row.tenant_id as string,
-    name: row.name as string,
-    industry: (row.industry as string | null) ?? undefined,
-    website: (row.website as string | null) ?? undefined,
-    phone: (row.phone as string | null) ?? undefined,
-    email: (row.email as string | null) ?? undefined,
-    addressLine1: (row.address_line1 as string | null) ?? undefined,
-    addressLine2: (row.address_line2 as string | null) ?? undefined,
-    city: (row.city as string | null) ?? undefined,
-    region: (row.region as string | null) ?? undefined,
-    postalCode: (row.postal_code as string | null) ?? undefined,
-    country: (row.country as string | null) ?? undefined,
-    notes: (row.notes as string | null) ?? undefined,
-    ownerId: row.owner_id as string,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
-    createdBy: row.created_by as string,
+    id: row.id,
+    tenantId: row.tenant_id,
+    name: row.name,
+    industry: row.industry ?? undefined,
+    website: row.website ?? undefined,
+    phone: row.phone ?? undefined,
+    email: row.email ?? undefined,
+    addressLine1: row.address_line1 ?? undefined,
+    addressLine2: row.address_line2 ?? undefined,
+    city: row.city ?? undefined,
+    region: row.region ?? undefined,
+    postalCode: row.postal_code ?? undefined,
+    country: row.country ?? undefined,
+    notes: row.notes ?? undefined,
+    ownerId: row.owner_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    createdBy: row.created_by,
   };
 }
 
-function rowToAccountListItem(row: Record<string, unknown>): AccountListItem {
+/**
+ * The list query adds a scalar subquery `opportunity_count` onto the
+ * base Accounts row. We type against the intersection so a rename on
+ * Accounts still surfaces here at compile time.
+ */
+type AccountListRow = Selectable<Accounts> & { opportunity_count: string | number };
+
+function rowToAccountListItem(row: AccountListRow): AccountListItem {
   return {
     ...rowToAccount(row),
-    opportunityCount: parseInt(row.opportunity_count as string, 10) || 0,
+    opportunityCount:
+      typeof row.opportunity_count === 'number'
+        ? row.opportunity_count
+        : parseInt(row.opportunity_count, 10) || 0,
   };
 }
+
+type OpportunityRow = Pick<
+  Selectable<Opportunities>,
+  | 'id'
+  | 'title'
+  | 'stage'
+  | 'value'
+  | 'currency'
+  | 'expected_close_date'
+  | 'created_at'
+  | 'updated_at'
+>;
 
 // ─── Helper ───────────────────────────────────────────────────────────────────
 
@@ -264,75 +295,115 @@ export async function createAccount(
 
   logger.info({ tenantId, accountId, requestingUserId }, 'Creating new account');
 
-  const result = await pool.query(
-    `INSERT INTO accounts
-       (id, tenant_id, name, industry, website, phone, email,
-        address_line1, address_line2, city, region, postal_code, country, notes,
-        owner_id, created_by, created_at, updated_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
-     RETURNING *`,
-    [
-      accountId,
-      tenantId,
-      name.trim(),
-      industry?.trim() ?? null,
-      website?.trim() ?? null,
-      phone?.trim() ?? null,
-      email?.trim() ?? null,
-      addressLine1?.trim() ?? null,
-      addressLine2?.trim() ?? null,
-      city?.trim() ?? null,
-      region?.trim() ?? null,
-      postalCode?.trim() ?? null,
-      country?.trim() ?? null,
-      notes?.trim() ?? null,
-      requestingUserId,
-      requestingUserId,
-      now,
-      now,
-    ],
-  );
+  const row = await db
+    .insertInto('accounts')
+    .values({
+      id: accountId,
+      tenant_id: tenantId,
+      name: name.trim(),
+      industry: industry?.trim() ?? null,
+      website: website?.trim() ?? null,
+      phone: phone?.trim() ?? null,
+      email: email?.trim() ?? null,
+      address_line1: addressLine1?.trim() ?? null,
+      address_line2: addressLine2?.trim() ?? null,
+      city: city?.trim() ?? null,
+      region: region?.trim() ?? null,
+      postal_code: postalCode?.trim() ?? null,
+      country: country?.trim() ?? null,
+      notes: notes?.trim() ?? null,
+      owner_id: requestingUserId,
+      created_by: requestingUserId,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ tenantId, accountId }, 'Account created successfully');
 
-  return rowToAccount(result.rows[0]);
+  return rowToAccount(row);
 }
 
 /**
  * Returns a paginated list of accounts belonging to the authenticated user.
  * Supports searching by name and email.
+ *
+ * The opportunity_count for each row is emitted as a correlated scalar
+ * subquery. The count path projects the full accounts row plus the
+ * subquery; the total-count path uses a separate lightweight COUNT(*)
+ * so we don't dedupe wide rows just to learn a number.
  */
 export async function listAccounts(
   params: ListAccountsParams,
 ): Promise<ListAccountsResult> {
   const { tenantId, ownerId, search, limit, offset } = params;
 
-  const queryParams: unknown[] = [tenantId, ownerId];
-  let whereClause = 'WHERE a.tenant_id = $1 AND a.owner_id = $2';
+  const searchTerm =
+    search && search.trim().length > 0
+      ? `%${escapeLikePattern(search.trim())}%`
+      : null;
 
-  if (search && search.trim().length > 0) {
-    const searchTerm = `%${escapeLikePattern(search.trim())}%`;
-    queryParams.push(searchTerm);
-    whereClause += ` AND (a.name ILIKE $${queryParams.length} OR a.email ILIKE $${queryParams.length})`;
+  // Count query — small, id-less projection for cheap COUNT(*).
+  let countQuery = db
+    .selectFrom('accounts as a')
+    .select((eb) => eb.fn.countAll<string>().as('total'))
+    .where('a.tenant_id', '=', tenantId)
+    .where('a.owner_id', '=', ownerId);
+
+  if (searchTerm) {
+    countQuery = countQuery.where((eb) =>
+      eb.or([
+        eb('a.name', 'ilike', searchTerm),
+        eb('a.email', 'ilike', searchTerm),
+      ]),
+    );
   }
 
-  const countResult = await pool.query(
-    `SELECT COUNT(*) AS total FROM accounts a ${whereClause}`,
-    queryParams,
-  );
-  const total = parseInt(countResult.rows[0].total as string, 10);
+  const countRow = await countQuery.executeTakeFirstOrThrow();
+  const total = parseInt(countRow.total, 10);
 
-  queryParams.push(limit, offset);
-  const dataResult = await pool.query(
-    `SELECT a.*, (SELECT COUNT(*) FROM opportunities o WHERE o.account_id = a.id AND o.tenant_id = a.tenant_id) AS opportunity_count
-     FROM accounts a ${whereClause}
-     ORDER BY a.created_at DESC
-     LIMIT $${queryParams.length - 1} OFFSET $${queryParams.length}`,
-    queryParams,
-  );
+  // Data query with correlated opportunity_count subquery.
+  //
+  // The subquery is explicitly scoped by tenant_id on both halves
+  // (the outer a.tenant_id and the inner o.tenant_id) as
+  // defence-in-depth (ADR-006).
+  let dataQuery = db
+    .selectFrom('accounts as a')
+    .selectAll('a')
+    .select((eb) =>
+      eb
+        .selectFrom('opportunities as o')
+        .select(eb.fn.countAll<string>().as('count'))
+        .whereRef('o.account_id', '=', 'a.id')
+        .whereRef('o.tenant_id', '=', 'a.tenant_id')
+        .as('opportunity_count'),
+    )
+    .where('a.tenant_id', '=', tenantId)
+    .where('a.owner_id', '=', ownerId);
+
+  if (searchTerm) {
+    dataQuery = dataQuery.where((eb) =>
+      eb.or([
+        eb('a.name', 'ilike', searchTerm),
+        eb('a.email', 'ilike', searchTerm),
+      ]),
+    );
+  }
+
+  const rows = await dataQuery
+    .orderBy('a.created_at', 'desc')
+    .limit(limit)
+    .offset(offset)
+    .execute();
 
   return {
-    data: dataResult.rows.map(rowToAccountListItem),
+    data: rows.map((r) =>
+      rowToAccountListItem({
+        ...r,
+        opportunity_count: r.opportunity_count ?? '0',
+      }),
+    ),
     total,
     limit,
     offset,
@@ -349,34 +420,44 @@ export async function getAccountWithOpportunities(
   tenantId: string,
   ownerId: string,
 ): Promise<AccountWithOpportunities | null> {
-  const accountResult = await pool.query(
-    'SELECT * FROM accounts WHERE id = $1 AND tenant_id = $2 AND owner_id = $3',
-    [id, tenantId, ownerId],
-  );
+  const accountRow = await db
+    .selectFrom('accounts')
+    .selectAll()
+    .where('id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .where('owner_id', '=', ownerId)
+    .executeTakeFirst();
 
-  if (accountResult.rows.length === 0) return null;
+  if (!accountRow) return null;
 
-  const account = rowToAccount(accountResult.rows[0]);
+  const account = rowToAccount(accountRow);
 
-  const oppResult = await pool.query(
-    `SELECT id, title, stage, value, currency, expected_close_date, created_at, updated_at
-     FROM opportunities
-     WHERE account_id = $1 AND tenant_id = $2
-     ORDER BY created_at DESC`,
-    [id, tenantId],
-  );
+  const oppRows: OpportunityRow[] = await db
+    .selectFrom('opportunities')
+    .select([
+      'id',
+      'title',
+      'stage',
+      'value',
+      'currency',
+      'expected_close_date',
+      'created_at',
+      'updated_at',
+    ])
+    .where('account_id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('created_at', 'desc')
+    .execute();
 
-  const opportunities = oppResult.rows.map((row: Record<string, unknown>) => ({
-    id: row.id as string,
-    title: row.title as string,
+  const opportunities = oppRows.map((row) => ({
+    id: row.id,
+    title: row.title,
     stage: row.stage as string,
     value: row.value != null ? Number(row.value) : undefined,
-    currency: (row.currency as string | null) ?? undefined,
-    expectedCloseDate: row.expected_close_date != null
-      ? new Date(row.expected_close_date as string)
-      : undefined,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    currency: row.currency ?? undefined,
+    expectedCloseDate: row.expected_close_date ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   }));
 
   return { ...account, opportunities };
@@ -396,12 +477,15 @@ export async function updateAccount(
   params: UpdateAccountParams,
 ): Promise<Account> {
   // Check existence and ownership
-  const existing = await pool.query(
-    'SELECT * FROM accounts WHERE id = $1 AND tenant_id = $2 AND owner_id = $3',
-    [id, tenantId, ownerId],
-  );
+  const existing = await db
+    .selectFrom('accounts')
+    .select('id')
+    .where('id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .where('owner_id', '=', ownerId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Account not found');
   }
 
@@ -426,74 +510,37 @@ export async function updateAccount(
     if (websiteError) throwValidationError(websiteError);
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
+  // Build the partial update — only include fields the caller provided,
+  // preserving the original "UPDATE only-what-you-set" semantics.
+  const patch: Record<string, unknown> = {
+    updated_at: new Date(),
+  };
 
-  if ('name' in params) {
-    updates.push(`name = $${paramIndex++}`);
-    values.push(params.name!.trim());
-  }
-  if ('industry' in params) {
-    updates.push(`industry = $${paramIndex++}`);
-    values.push(params.industry?.trim() ?? null);
-  }
-  if ('website' in params) {
-    updates.push(`website = $${paramIndex++}`);
-    values.push(params.website?.trim() ?? null);
-  }
-  if ('phone' in params) {
-    updates.push(`phone = $${paramIndex++}`);
-    values.push(params.phone?.trim() ?? null);
-  }
-  if ('email' in params) {
-    updates.push(`email = $${paramIndex++}`);
-    values.push(params.email?.trim() ?? null);
-  }
-  if ('addressLine1' in params) {
-    updates.push(`address_line1 = $${paramIndex++}`);
-    values.push(params.addressLine1?.trim() ?? null);
-  }
-  if ('addressLine2' in params) {
-    updates.push(`address_line2 = $${paramIndex++}`);
-    values.push(params.addressLine2?.trim() ?? null);
-  }
-  if ('city' in params) {
-    updates.push(`city = $${paramIndex++}`);
-    values.push(params.city?.trim() ?? null);
-  }
-  if ('region' in params) {
-    updates.push(`region = $${paramIndex++}`);
-    values.push(params.region?.trim() ?? null);
-  }
-  if ('postalCode' in params) {
-    updates.push(`postal_code = $${paramIndex++}`);
-    values.push(params.postalCode?.trim() ?? null);
-  }
-  if ('country' in params) {
-    updates.push(`country = $${paramIndex++}`);
-    values.push(params.country?.trim() ?? null);
-  }
-  if ('notes' in params) {
-    updates.push(`notes = $${paramIndex++}`);
-    values.push(params.notes?.trim() ?? null);
-  }
+  if ('name' in params) patch.name = params.name!.trim();
+  if ('industry' in params) patch.industry = params.industry?.trim() ?? null;
+  if ('website' in params) patch.website = params.website?.trim() ?? null;
+  if ('phone' in params) patch.phone = params.phone?.trim() ?? null;
+  if ('email' in params) patch.email = params.email?.trim() ?? null;
+  if ('addressLine1' in params) patch.address_line1 = params.addressLine1?.trim() ?? null;
+  if ('addressLine2' in params) patch.address_line2 = params.addressLine2?.trim() ?? null;
+  if ('city' in params) patch.city = params.city?.trim() ?? null;
+  if ('region' in params) patch.region = params.region?.trim() ?? null;
+  if ('postalCode' in params) patch.postal_code = params.postalCode?.trim() ?? null;
+  if ('country' in params) patch.country = params.country?.trim() ?? null;
+  if ('notes' in params) patch.notes = params.notes?.trim() ?? null;
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
-
-  values.push(id, tenantId, ownerId);
-
-  const result = await pool.query(
-    `UPDATE accounts SET ${updates.join(', ')} WHERE id = $${paramIndex++} AND tenant_id = $${paramIndex++} AND owner_id = $${paramIndex} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('accounts')
+    .set(patch)
+    .where('id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .where('owner_id', '=', ownerId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ tenantId, accountId: id, ownerId }, 'Account updated');
 
-  return rowToAccount(result.rows[0]);
+  return rowToAccount(row);
 }
 
 /**
@@ -506,12 +553,14 @@ export async function deleteAccount(
   tenantId: string,
   ownerId: string,
 ): Promise<void> {
-  const result = await pool.query(
-    'DELETE FROM accounts WHERE id = $1 AND tenant_id = $2 AND owner_id = $3',
-    [id, tenantId, ownerId],
-  );
+  const result = await db
+    .deleteFrom('accounts')
+    .where('id', '=', id)
+    .where('tenant_id', '=', tenantId)
+    .where('owner_id', '=', ownerId)
+    .executeTakeFirst();
 
-  if (result.rowCount === 0) {
+  if (!result || result.numDeletedRows === 0n) {
     throwNotFoundError('Account not found');
   }
 


### PR DESCRIPTION
## Summary

Replaces the 8 `pool.query` calls in `accountService.ts` with typed Kysely
query builders. The row mapper is typed against `Selectable<Accounts>` so a
column rename or nullability change on the generated schema surfaces as a
compile-time error at the service boundary, not as a silent `unknown` cast.

This is **PR 2 of 3** for Group C of Phase 3b (tracker: #445). PR 1 (#461 —
organisationService / profileService / userSyncService) is merged. PR 3
(`tenantProvisioning`) will follow.

## Notable shape decisions

- **`listAccounts`** emits `opportunity_count` as a **correlated scalar
  subquery** (`whereRef('o.account_id', '=', 'a.id')`) scoped by `tenant_id`
  on **both the outer and inner halves** — carrying ADR-006 defence-in-depth
  *into* the subquery, not just the outer clause:
  ```ts
  eb.selectFrom('opportunities as o')
    .select(eb.fn.countAll<string>().as('count'))
    .whereRef('o.account_id', '=', 'a.id')
    .whereRef('o.tenant_id', '=', 'a.tenant_id')
    .as('opportunity_count')
  ```
- **Count path** uses a separate lightweight `SELECT count(*)` rather than
  dedupe'ing the wide joined projection — no point paying to build a
  many-column row just to learn a number.
- **`updateAccount`** builds a conditional `patch` object so the compiled
  `UPDATE` only SETs columns the caller supplied, preserving the
  "UPDATE only-what-you-set" semantics of the hand-rolled SQL.
- **`deleteAccount`** checks `result.numDeletedRows === 0n` (bigint) rather
  than pg's `rowCount`.

## Test mock changes

The pg mock in `accountService.test.ts` now routes both `pool.query` and
`pool.connect().query` through a shared `runQuery` dispatcher — Kysely's
`PostgresDialect` acquires a client per query via `pool.connect()`, so
mocking only `pool.query` would leave Kysely's path unexercised. Notable
details I tripped over:

1. SQL identifier quotes are stripped before matching so the matchers stay
   quote-agnostic.
2. The count-query matcher anchors on `SELECT COUNT(*)` **at the start**
   (not `includes('COUNT(*)')`) because the data query's scalar subquery
   also contains `count(*)`.
3. `DELETE` responses must emit `command: 'DELETE'` — Kysely's postgres
   driver only lifts `rowCount` into `numAffectedRows` when `command` is
   one of `INSERT | UPDATE | DELETE | MERGE`. Without it,
   `result.numDeletedRows` comes back as `0n` and the test sees
   spurious `NOT_FOUND`s.

## New Kysely SQL regression suite

`accountService.kysely-sql.test.ts` complements the behavioural suite by
asserting directly on the SQL Kysely emits:

- Every data query carries `tenant_id` (including **both halves** of the
  `opportunity_count` subquery — asserts `O.TENANT_ID = A.TENANT_ID` is
  emitted).
- `INSERT INTO accounts` binds exactly 18 columns in the documented order
  (`id, tenant_id, name, industry, website, phone, email, address_line1,
  address_line2, city, region, postal_code, country, notes, owner_id,
  created_by, created_at, updated_at`).
- Count query is a separate lightweight `SELECT COUNT(*)` — does **not**
  contain `a.*`, `OPPORTUNITY_COUNT`, `LIMIT`, or `OFFSET`.
- `updateAccount` UPDATE only SETs supplied columns (asserts `NAME =` and
  `UPDATED_AT =` are present, `INDUSTRY =` / `WEBSITE =` / etc are not when
  the caller didn't include them).
- Search path binds the **escaped** ILIKE pattern as a parameter — the raw
  user input (`50%_off`) never appears in the SQL text.
- `getAccountWithOpportunities` projects only the 8 columns the API needs
  (no `SELECT *` on `opportunities`).
- No explicit `BEGIN` / `COMMIT` — every entry point runs outside an
  explicit transaction.

## Test plan

- [x] `npx vitest run apps/api/src/services/__tests__/accountService.test.ts` — 56/56 passing
- [x] `npx vitest run apps/api/src/services/__tests__/accountService.kysely-sql.test.ts` — 23/23 passing
- [x] Full API suite: `npx vitest run` in `apps/api` — **1467 passed / 1 skipped** (up from 1444 on main)
- [x] Typecheck: `npx tsc --noEmit -p apps/api` — clean
- [ ] Copilot review
- [ ] Merge when green

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf