### PR TITLE
Migrate tenantProvisioning.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/tenantProvisioning.e2e.test.ts
+++ b/apps/api/src/services/__tests__/tenantProvisioning.e2e.test.ts
@@ -44,20 +44,59 @@ const fakeObjects = new Map<string, FakeRow>();
 const fakeFields = new Map<string, FakeRow>();
 const fakeRelationships = new Map<string, FakeRow>();
 
-const mockClientQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-  const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+// Kysely's PostgresDriver calls `client.query({ text, values })`, while the
+// legacy seedDefaultObjects path calls `client.query(sql, params)` directly.
+// Normalise both call shapes so the single dispatcher handles both.
+const defaultClientQueryImpl = async (
+  sqlOrQuery: unknown,
+  paramsArg?: unknown[],
+) => {
+  const sql =
+    typeof sqlOrQuery === 'string'
+      ? sqlOrQuery
+      : (sqlOrQuery as { text: string }).text;
+  const params =
+    typeof sqlOrQuery === 'string'
+      ? paramsArg
+      : ((sqlOrQuery as { values?: unknown[] }).values ?? []);
+
+  // Strip identifier quotes so Kysely's `"tenants"` matches the legacy
+  // matchers that were written against unquoted identifiers.
+  const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
   // Transaction control
   if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
 
+  // Slug uniqueness check (routed through pool.connect by Kysely).
+  // Kysely compiles `db.selectFrom('tenants').select('id').where('slug', '=', ?)`
+  // to `SELECT id FROM tenants WHERE slug = $1` (+ optional LIMIT for
+  // executeTakeFirst).
+  if (s.startsWith('SELECT ID FROM TENANTS WHERE SLUG')) {
+    const slug = params![0] as string;
+    const match = [...fakeTenants.values()].find((t) => t.slug === slug);
+    return { rows: match ? [{ id: match.id }] : [], rowCount: match ? 1 : 0 };
+  }
+
   // INSERT INTO tenants ... RETURNING *
-  // Params: $1=id, $2=name, $3=slug, $4=plan, $5=created_at, $6=updated_at
-  // ('active' and '{}' are hardcoded in the SQL, not parameterised)
+  // Kysely compiles `values({ id, name, slug, status, plan, settings,
+  // created_at, updated_at })` to 8 positional params in the declared
+  // field order. All columns are now parameterised (no hardcoded
+  // 'active'/'{}' like the old raw-SQL path).
   if (s.startsWith('INSERT INTO TENANTS')) {
-    const [id, name, slug, plan, created_at, updated_at] = params as unknown[];
-    const row: FakeRow = { id: id as string, name, slug, status: 'active', plan, settings: '{}', created_at, updated_at };
+    const [id, name, slug, status, plan, settings, created_at, updated_at] =
+      params as unknown[];
+    const row: FakeRow = {
+      id: id as string,
+      name,
+      slug,
+      status,
+      plan,
+      settings,
+      created_at,
+      updated_at,
+    };
     fakeTenants.set(id as string, row);
-    return { rows: [row] };
+    return { rows: [row], rowCount: 1, command: 'INSERT' };
   }
 
   // SELECT id, api_name FROM object_definitions WHERE api_name = ANY($1) AND tenant_id = $2
@@ -154,7 +193,9 @@ const mockClientQuery = vi.fn(async (sql: string, params?: unknown[]) => {
 
   // Default
   return { rows: [], rowCount: 0 };
-});
+};
+
+const mockClientQuery = vi.fn(defaultClientQueryImpl);
 
 const mockRelease = vi.fn();
 const mockConnect = vi.fn(() => ({
@@ -192,6 +233,9 @@ beforeEach(() => {
   fakeObjects.clear();
   fakeFields.clear();
   fakeRelationships.clear();
+  // Restore the default dispatcher — tests that need failure injection
+  // should call mockImplementation(...) within that test's scope.
+  mockClientQuery.mockImplementation(defaultClientQueryImpl);
   mockCreateTenantWithId.mockResolvedValue({});
   mockDeleteTenant.mockResolvedValue({});
   mockDescopeInvite.mockResolvedValue({});
@@ -292,8 +336,27 @@ describe('provisionTenant — end-to-end flow', () => {
   });
 
   it('rolls back Descope tenant when DB transaction fails', async () => {
-    // Make the DB client throw on the INSERT INTO tenants query
-    mockClientQuery.mockRejectedValueOnce(new Error('DB insert failed'));
+    // Make the DB client throw on the INSERT INTO tenants query.
+    // We can't use mockRejectedValueOnce here because Kysely now routes
+    // the pre-insert slug-uniqueness check through pool.connect().query
+    // as well, so "the first call" is no longer the INSERT. Target the
+    // INSERT explicitly and pass other queries through to the default
+    // in-memory dispatcher.
+    mockClientQuery.mockImplementation(
+      async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+        const sqlRaw =
+          typeof sqlOrQuery === 'string'
+            ? sqlOrQuery
+            : (sqlOrQuery as { text: string }).text;
+        if (
+          sqlRaw.toUpperCase().includes('INSERT INTO') &&
+          sqlRaw.toUpperCase().includes('TENANTS')
+        ) {
+          throw new Error('DB insert failed');
+        }
+        return defaultClientQueryImpl(sqlOrQuery, paramsArg);
+      },
+    );
 
     await expect(
       provisionTenant({

--- a/apps/api/src/services/__tests__/tenantProvisioning.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/tenantProvisioning.kysely-sql.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Kysely SQL regression suite for tenantProvisioning.
+ *
+ * Complements `tenantProvisioning.test.ts` (validation behaviour) and
+ * `tenantProvisioning.e2e.test.ts` (end-to-end provisioning flow with an
+ * in-memory DB) by asserting directly on the SQL Kysely emits for every
+ * tenant-management entry point. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Verify the pre-insert slug check routes through the Kysely query
+ *      builder (not a stray raw `pool.query`).
+ *   3. Verify the transactional INSERT binds every column explicitly
+ *      (rather than relying on DB defaults) so a tenant's `status`,
+ *      `plan`, and `settings` shape stays under our control.
+ *   4. Verify the list path emits a lightweight `COUNT(*)` separate from
+ *      the wide data projection (same pattern as accountService).
+ *   5. Verify the user-count correlated scalar subquery is scoped to the
+ *      outer tenant via `m.tenant_id = t.id` (no cross-tenant leakage).
+ *   6. Verify updateTenant only writes the columns the caller supplied
+ *      (plus the always-touched `updated_at`).
+ *   7. Verify deleteTenant is a soft-delete (`UPDATE ... SET status =
+ *      'suspended'`) rather than a `DELETE FROM`.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── Mock Descope management client ──────────────────────────────────────────
+
+const mockCreateTenantWithId = vi.fn();
+const mockDeleteTenant = vi.fn();
+const mockDescopeInvite = vi.fn();
+
+vi.mock('../../lib/descopeManagementClient.js', () => ({
+  getDescopeManagementClient: vi.fn(() => ({
+    management: {
+      tenant: {
+        createWithId: mockCreateTenantWithId,
+        delete: mockDeleteTenant,
+      },
+      user: {
+        invite: mockDescopeInvite,
+      },
+    },
+  })),
+}));
+
+// ─── Mock seedWithClient — we don't want to exercise 1000+ lines of seed
+// SQL when we're only asserting on the tenant-management SQL. Return a
+// zero-row seed result so provisionTenant completes happily.
+vi.mock('../seedDefaultObjects.js', () => ({
+  seedWithClient: vi.fn(async () => ({
+    objectsCreated: 0,
+    fieldsCreated: 0,
+    relationshipsCreated: 0,
+    pipelinesCreated: 0,
+  })),
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  via: 'pool' | 'client';
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
+  () => {
+    const capturedQueries: CapturedQuery[] = [];
+
+    function makeTenantRow(overrides: Record<string, unknown> = {}) {
+      const now = new Date();
+      return {
+        id: 'sql-tenant-001',
+        name: 'SQL Corp',
+        slug: 'sql-tenant-001',
+        status: 'active',
+        plan: 'free',
+        settings: '{}',
+        created_at: now,
+        updated_at: now,
+        ...overrides,
+      };
+    }
+
+    function runQuery(
+      rawSql: string,
+      params: unknown[] | undefined,
+      via: 'pool' | 'client',
+    ) {
+      capturedQueries.push({ sql: rawSql, params: params ?? [], via });
+
+      const s = rawSql
+        .replace(/\s+/g, ' ')
+        .replace(/"/g, '')
+        .trim()
+        .toUpperCase();
+
+      if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (s.startsWith('SELECT SET_CONFIG')) {
+        return { rows: [] };
+      }
+
+      // Slug uniqueness check — return empty so provisionTenant proceeds.
+      if (s.startsWith('SELECT ID FROM TENANTS WHERE SLUG')) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      // INSERT INTO tenants ... RETURNING *  (compiled by Kysely, executed
+      // on the raw client inside the BEGIN/COMMIT envelope).
+      if (s.startsWith('INSERT INTO TENANTS')) {
+        const [
+          id,
+          name,
+          slug,
+          status,
+          plan,
+          settings,
+          created_at,
+          updated_at,
+        ] = (params ?? []) as unknown[];
+        return {
+          rows: [
+            {
+              id,
+              name,
+              slug,
+              status,
+              plan,
+              settings,
+              created_at,
+              updated_at,
+            },
+          ],
+          rowCount: 1,
+          command: 'INSERT',
+        };
+      }
+
+      // listTenants count path: SELECT count(*) as total FROM tenants
+      if (s.startsWith('SELECT COUNT(*)') && s.includes('FROM TENANTS')) {
+        return { rows: [{ total: '1' }] };
+      }
+
+      // listTenants data path: SELECT t.*, (SELECT count(*) ...) FROM tenants AS t
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM TENANTS AS T') &&
+        s.includes('LIMIT')
+      ) {
+        return { rows: [{ ...makeTenantRow(), user_count: '0' }] };
+      }
+
+      // getTenantById tenant SELECT:
+      //   SELECT * FROM tenants WHERE id = $1
+      if (
+        s.startsWith('SELECT') &&
+        s.includes('FROM TENANTS') &&
+        !s.includes('FROM TENANTS AS T')
+      ) {
+        return { rows: [makeTenantRow()] };
+      }
+
+      // getTenantById count path on tenant_memberships
+      if (
+        s.startsWith('SELECT COUNT(*)') &&
+        s.includes('FROM TENANT_MEMBERSHIPS')
+      ) {
+        return { rows: [{ count: '0' }] };
+      }
+
+      // UPDATE tenants ... RETURNING *  /  RETURNING ID
+      if (s.startsWith('UPDATE TENANTS')) {
+        return { rows: [makeTenantRow()], rowCount: 1, command: 'UPDATE' };
+      }
+
+      return { rows: [] };
+    }
+
+    const mockQuery = vi.fn(async (sql: unknown, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return runQuery(rawSql, params, 'pool');
+    });
+
+    const mockConnect = vi.fn(async () => ({
+      query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        return runQuery(rawSql, params, 'client');
+      }),
+      release: vi.fn(),
+    }));
+
+    function resetCapture() {
+      capturedQueries.length = 0;
+    }
+
+    return { capturedQueries, mockQuery, mockConnect, resetCapture };
+  },
+);
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  provisionTenant,
+  listTenants,
+  getTenantById,
+  updateTenant,
+  deleteTenant,
+} = await import('../tenantProvisioning.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+  mockCreateTenantWithId.mockResolvedValue({});
+  mockDeleteTenant.mockResolvedValue({});
+  mockDescopeInvite.mockResolvedValue({});
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('tenantProvisioning Kysely SQL — provisionTenant', () => {
+  it('slug uniqueness check is a compiled Kysely SELECT (not a raw pool.query)', async () => {
+    await provisionTenant({
+      name: 'SQL Corp',
+      slug: 'sql-tenant-001',
+      adminEmail: 'admin@sql.example',
+      adminName: 'SQL Admin',
+    });
+
+    const slugCheck = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('SELECT ID FROM TENANTS WHERE SLUG'),
+    );
+    expect(slugCheck).toBeDefined();
+    // Kysely routes every query through pool.connect(), so the slug
+    // check must have been captured via the 'client' path.
+    expect(slugCheck!.via).toBe('client');
+    expect(slugCheck!.params).toEqual(['sql-tenant-001']);
+  });
+
+  it('INSERT INTO tenants binds all 8 columns in the declared order', async () => {
+    await provisionTenant({
+      name: 'SQL Corp',
+      slug: 'sql-tenant-001',
+      adminEmail: 'admin@sql.example',
+      adminName: 'SQL Admin',
+    });
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO TENANTS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    const insert = inserts[0]!;
+    // Column order (as written in the service .values({...})):
+    //   id, name, slug, status, plan, settings, created_at, updated_at.
+    expect(insert.params.length).toBe(8);
+    expect(insert.params[0]).toBe('sql-tenant-001'); // id === slug
+    expect(insert.params[1]).toBe('SQL Corp'); // name (trimmed)
+    expect(insert.params[2]).toBe('sql-tenant-001'); // slug
+    expect(insert.params[3]).toBe('active'); // status — hardcoded default
+    expect(insert.params[4]).toBe('free'); // plan — default when not supplied
+    // settings is passed as a JSON string (not an object) so the raw
+    // client can forward it to pg's JSONB column without a custom
+    // serialiser.
+    expect(typeof insert.params[5]).toBe('string');
+    expect(JSON.parse(insert.params[5] as string)).toEqual({
+      currency: 'GBP',
+      dateFormat: 'DD/MM/YYYY',
+      timezone: 'Europe/London',
+    });
+    expect(insert.params[6]).toBeInstanceOf(Date); // created_at
+    expect(insert.params[7]).toBeInstanceOf(Date); // updated_at
+
+    const s = normalise(insert.sql);
+    expect(s).toContain('RETURNING');
+  });
+
+  it('INSERT runs inside the BEGIN/COMMIT envelope via the raw client', async () => {
+    await provisionTenant({
+      name: 'SQL Corp',
+      slug: 'sql-tenant-001',
+      adminEmail: 'admin@sql.example',
+      adminName: 'SQL Admin',
+    });
+
+    // Every query in provisionTenant (slug check + BEGIN + INSERT +
+    // COMMIT + the seed queries, which are mocked away) should have
+    // travelled through pool.connect(), not pool.query().
+    const poolCalls = capturedQueries.filter((q) => q.via === 'pool');
+    expect(poolCalls.length).toBe(0);
+
+    const order = capturedQueries.map((q) => normalise(q.sql));
+    const beginIdx = order.indexOf('BEGIN');
+    const commitIdx = order.indexOf('COMMIT');
+    const insertIdx = order.findIndex((s) => s.startsWith('INSERT INTO TENANTS'));
+
+    expect(beginIdx).toBeGreaterThan(-1);
+    expect(commitIdx).toBeGreaterThan(beginIdx);
+    expect(insertIdx).toBeGreaterThan(beginIdx);
+    expect(insertIdx).toBeLessThan(commitIdx);
+  });
+
+  it('honours a caller-supplied plan value on the INSERT', async () => {
+    await provisionTenant({
+      name: 'SQL Corp',
+      slug: 'sql-tenant-001',
+      adminEmail: 'admin@sql.example',
+      adminName: 'SQL Admin',
+      plan: 'enterprise',
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO TENANTS'),
+    );
+    expect(insert!.params[4]).toBe('enterprise');
+  });
+});
+
+describe('tenantProvisioning Kysely SQL — listTenants', () => {
+  it('count query is a separate lightweight SELECT COUNT(*) — not the wide data projection', async () => {
+    await listTenants(20, 0);
+
+    const countQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('SELECT COUNT(*)'),
+    );
+    expect(countQuery).toBeDefined();
+
+    const s = normalise(countQuery!.sql);
+    // The count query should NOT project the full tenants row or the
+    // user_count scalar — that's the data query's job.
+    expect(s).not.toContain('T.*');
+    expect(s).not.toContain('USER_COUNT');
+    // And no LIMIT/OFFSET on the count path
+    expect(s).not.toContain('LIMIT');
+    expect(s).not.toContain('OFFSET');
+  });
+
+  it('data query emits the correlated user_count scalar subquery', async () => {
+    await listTenants(20, 0);
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM TENANTS AS T') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    const s = normalise(dataPath!.sql);
+    expect(s).toContain('T.*');
+    expect(s).toContain('USER_COUNT');
+    expect(s).toContain('FROM TENANT_MEMBERSHIPS AS M');
+    // The subquery must be scoped to the outer tenant via whereRef so
+    // we cannot leak counts across tenants.
+    expect(s).toContain('M.TENANT_ID = T.ID');
+  });
+
+  it('list query orders by t.created_at DESC with LIMIT / OFFSET applied', async () => {
+    await listTenants(5, 10);
+
+    const dataPath = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM TENANTS AS T') && s.includes('LIMIT');
+    });
+    expect(dataPath).toBeDefined();
+
+    const s = normalise(dataPath!.sql);
+    expect(s).toContain('ORDER BY T.CREATED_AT DESC');
+    expect(s).toContain('LIMIT');
+    expect(s).toContain('OFFSET');
+    expect(dataPath!.params).toContain(5);
+    expect(dataPath!.params).toContain(10);
+  });
+});
+
+describe('tenantProvisioning Kysely SQL — getTenantById', () => {
+  it('emits a tenant SELECT + a scoped tenant_memberships COUNT(*)', async () => {
+    await getTenantById(TENANT_ID);
+
+    const queries = dataQueries();
+    // 1x tenant SELECT + 1x memberships count
+    expect(queries.length).toBe(2);
+
+    const tenantSelect = queries.find(
+      (q) =>
+        normalise(q.sql).startsWith('SELECT') &&
+        normalise(q.sql).includes('FROM TENANTS') &&
+        !normalise(q.sql).startsWith('SELECT COUNT(*)'),
+    );
+    expect(tenantSelect).toBeDefined();
+    expect(tenantSelect!.params).toContain(TENANT_ID);
+    expect(normalise(tenantSelect!.sql)).toContain('ID =');
+
+    const countQuery = queries.find(
+      (q) =>
+        normalise(q.sql).startsWith('SELECT COUNT(*)') &&
+        normalise(q.sql).includes('FROM TENANT_MEMBERSHIPS'),
+    );
+    expect(countQuery).toBeDefined();
+    // The membership count MUST be filtered by tenant_id so we don't
+    // return a cross-tenant total.
+    expect(normalise(countQuery!.sql)).toContain('TENANT_ID =');
+    expect(countQuery!.params).toContain(TENANT_ID);
+  });
+});
+
+describe('tenantProvisioning Kysely SQL — updateTenant', () => {
+  it('only sets columns the caller provided (plus updated_at)', async () => {
+    await updateTenant(TENANT_ID, { name: 'Renamed' });
+
+    const updateQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE TENANTS'),
+    );
+    expect(updateQuery).toBeDefined();
+
+    const s = normalise(updateQuery!.sql);
+    // Kysely's SET clause must include `name` and `updated_at` but
+    // NOT `status`, `plan`, `slug`, or `settings`.
+    expect(s).toContain('NAME =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).not.toContain('STATUS =');
+    expect(s).not.toContain('PLAN =');
+    expect(s).not.toContain('SLUG =');
+    expect(s).not.toContain('SETTINGS =');
+    expect(s).toContain('RETURNING');
+  });
+
+  it('sets status when the caller supplies a valid status', async () => {
+    await updateTenant(TENANT_ID, { status: 'suspended' });
+
+    const updateQuery = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE TENANTS'),
+    );
+    expect(updateQuery).toBeDefined();
+    const s = normalise(updateQuery!.sql);
+    expect(s).toContain('STATUS =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).not.toContain('NAME =');
+    expect(updateQuery!.params).toContain('suspended');
+  });
+
+  it('rejects an empty patch with VALIDATION_ERROR and never touches the DB', async () => {
+    await expect(updateTenant(TENANT_ID, {})).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR',
+    });
+    // No UPDATE should have been captured
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE TENANTS'),
+    );
+    expect(updates.length).toBe(0);
+  });
+});
+
+describe('tenantProvisioning Kysely SQL — deleteTenant', () => {
+  it('is a soft-delete via UPDATE status = suspended, not a DELETE FROM', async () => {
+    await deleteTenant(TENANT_ID);
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE TENANTS'),
+    );
+    expect(updates.length).toBe(1);
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM'),
+    );
+    expect(deletes.length).toBe(0);
+
+    const s = normalise(updates[0]!.sql);
+    expect(s).toContain('STATUS =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).toContain('ID =');
+    expect(s).toContain('RETURNING');
+    expect(updates[0]!.params).toContain('suspended');
+    expect(updates[0]!.params).toContain(TENANT_ID);
+  });
+});

--- a/apps/api/src/services/__tests__/tenantProvisioning.test.ts
+++ b/apps/api/src/services/__tests__/tenantProvisioning.test.ts
@@ -6,14 +6,30 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely's PostgresDialect acquires a client per query via `pool.connect()`,
+// so the mock routes both `pool.query` and `pool.connect().query` through
+// the same `runQuery` dispatcher. Validation tests only need the shape of
+// the slug-uniqueness check to resolve — the rest of the provisionTenant
+// path is covered by tenantProvisioning.e2e.test.ts.
 
-const { mockQuery } = vi.hoisted(() => {
+const { mockQuery, mockConnect } = vi.hoisted(() => {
   const mockQuery = vi.fn();
-  return { mockQuery };
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+      const rawSql =
+        typeof sql === 'string' ? sql : (sql as { text: string }).text;
+      return mockQuery(rawSql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery, connect: vi.fn() },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── validateSlug ─────────────────────────────────────────────────────────────

--- a/apps/api/src/services/tenantProvisioning.ts
+++ b/apps/api/src/services/tenantProvisioning.ts
@@ -1,5 +1,7 @@
-import { randomUUID } from 'crypto';
+import type { Selectable, Updateable } from 'kysely';
 import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { Tenants } from '../db/kysely.types.js';
 import { getDescopeManagementClient } from '../lib/descopeManagementClient.js';
 import { logger } from '../lib/logger.js';
 import { seedWithClient } from './seedDefaultObjects.js';
@@ -34,16 +36,17 @@ export interface ProvisionTenantResult {
   };
 }
 
-export interface TenantRow {
-  id: string;
-  name: string;
-  slug: string;
-  status: string;
+/**
+ * Row shape returned to API callers.
+ *
+ * Typed against `Selectable<Tenants>` (with `settings` widened to an
+ * object for the public contract) so a column rename or nullability
+ * change on the generated schema becomes a compile-time error here.
+ */
+export type TenantRow = Omit<Selectable<Tenants>, 'settings' | 'plan'> & {
   plan: string;
   settings: Record<string, unknown>;
-  created_at: Date;
-  updated_at: Date;
-}
+};
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
@@ -70,6 +73,42 @@ export function validateSlug(slug: unknown): string | null {
   return null;
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Normalises a Kysely/pg `tenants` row into the public TenantRow contract.
+ *
+ * `settings` comes back as either a JSON string (raw pg transactional path)
+ * or a pre-parsed object (pg's default JSONB parser via Kysely). We coerce
+ * both shapes into `Record<string, unknown>` so the API surface is stable.
+ */
+function coerceTenantRow(row: Selectable<Tenants>): TenantRow {
+  const rawSettings = row.settings;
+  let settings: Record<string, unknown>;
+  if (rawSettings == null) {
+    settings = {};
+  } else if (typeof rawSettings === 'string') {
+    try {
+      settings = JSON.parse(rawSettings) as Record<string, unknown>;
+    } catch {
+      settings = {};
+    }
+  } else {
+    settings = rawSettings as Record<string, unknown>;
+  }
+
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    status: row.status,
+    plan: row.plan ?? 'free',
+    settings,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 /**
@@ -88,6 +127,16 @@ export function validateSlug(slug: unknown): string | null {
  *   attempts to delete the Descope tenant before re-throwing.
  * - The DB insert + seed run inside a single transaction, so a seed failure
  *   automatically rolls back the tenant row.
+ *
+ * Transaction implementation note:
+ * - `seedWithClient` takes a raw pg `PoolClient` (it originates from the
+ *   1109-line `seedDefaultObjects.ts` which is out of scope for this
+ *   migration), so the BEGIN/COMMIT envelope is still managed via the raw
+ *   client — Kysely doesn't own that transaction. The tenant INSERT inside
+ *   the transaction is still built via Kysely and `.compile()`d so the
+ *   column list and value shapes stay under Kysely's compile-time safety
+ *   net; the compiled SQL + params are then handed to the raw client
+ *   (which holds the transaction) to keep INSERT and seed atomic.
  *
  * @throws {Error} with `code: 'VALIDATION_ERROR'` for invalid input.
  * @throws {Error} with `code: 'DUPLICATE_SLUG'` if the slug is already taken.
@@ -119,11 +168,12 @@ export async function provisionTenant(
   }
 
   // Check slug uniqueness before touching external systems
-  const existing = await pool.query(
-    'SELECT id FROM tenants WHERE slug = $1',
-    [slug],
-  );
-  if ((existing.rowCount ?? 0) > 0) {
+  const existing = await db
+    .selectFrom('tenants')
+    .select('id')
+    .where('slug', '=', slug)
+    .executeTakeFirst();
+  if (existing) {
     throw Object.assign(new Error(`Slug "${slug}" is already in use`), { code: 'DUPLICATE_SLUG' });
   }
 
@@ -151,13 +201,31 @@ export async function provisionTenant(
       dateFormat: 'DD/MM/YYYY',
       timezone: 'Europe/London',
     };
+
+    // Build the INSERT with Kysely so the column list, value shapes and
+    // RETURNING projection are all type-checked against the generated
+    // Tenants schema, then execute the compiled query on the raw client
+    // (which owns the BEGIN/COMMIT envelope shared with seedWithClient).
+    const insertTenant = db
+      .insertInto('tenants')
+      .values({
+        id: tenantId,
+        name: name.trim(),
+        slug,
+        status: 'active',
+        plan,
+        settings: JSON.stringify(defaultSettings),
+        created_at: now,
+        updated_at: now,
+      })
+      .returningAll()
+      .compile();
+
     const tenantResult = await client.query(
-      `INSERT INTO tenants (id, name, slug, status, plan, settings, created_at, updated_at)
-       VALUES ($1, $2, $3, 'active', $4, $5::jsonb, $6, $7)
-       RETURNING *`,
-      [tenantId, name.trim(), slug, plan, JSON.stringify(defaultSettings), now, now],
+      insertTenant.sql,
+      [...insertTenant.parameters],
     );
-    const tenantRow = tenantResult.rows[0] as TenantRow;
+    const tenantRow = coerceTenantRow(tenantResult.rows[0] as Selectable<Tenants>);
 
     logger.info({ tenantId }, 'Tenant record inserted, seeding default CRM data');
     seedResult = await seedWithClient(client, tenantId, tenantId);
@@ -227,33 +295,48 @@ export async function provisionTenant(
 // ─── List / get / update / delete helpers ─────────────────────────────────────
 
 /**
- * Lists all tenants with optional pagination.
- * Includes an approximate user count for each tenant.
+ * Lists all tenants with pagination.
+ *
+ * Includes a per-tenant membership count emitted as a correlated scalar
+ * subquery (rather than the previous LEFT JOIN with GROUP BY) — mirrors
+ * the pattern used by accountService for consistency and keeps the count
+ * scoped directly by `tenant_id = t.id` without needing a derived table.
  */
 export async function listTenants(
   limit: number,
   offset: number,
 ): Promise<{ tenants: (TenantRow & { userCount: number })[]; total: number }> {
-  const countResult = await pool.query('SELECT COUNT(*) AS total FROM tenants');
-  const total = parseInt((countResult.rows[0] as { total: string }).total, 10);
+  // Lightweight COUNT(*) — avoids dedupe'ing the wide joined projection.
+  const countRow = await db
+    .selectFrom('tenants')
+    .select((eb) => eb.fn.countAll<string>().as('total'))
+    .executeTakeFirstOrThrow();
+  const total = parseInt(countRow.total, 10);
 
-  const result = await pool.query(
-    `SELECT t.*, COALESCE(m.user_count, 0) AS user_count
-     FROM tenants t
-     LEFT JOIN (
-       SELECT tenant_id, COUNT(*) AS user_count
-       FROM tenant_memberships
-       GROUP BY tenant_id
-     ) m ON m.tenant_id = t.id
-     ORDER BY t.created_at DESC
-     LIMIT $1 OFFSET $2`,
-    [limit, offset],
-  );
+  const rows = await db
+    .selectFrom('tenants as t')
+    .selectAll('t')
+    .select((eb) =>
+      eb
+        .selectFrom('tenant_memberships as m')
+        .select(eb.fn.countAll<string>().as('count'))
+        .whereRef('m.tenant_id', '=', 't.id')
+        .as('user_count'),
+    )
+    .orderBy('t.created_at', 'desc')
+    .limit(limit)
+    .offset(offset)
+    .execute();
 
   return {
-    tenants: (result.rows as Array<TenantRow & { user_count: string }>).map((row) => ({
-      ...row,
-      userCount: parseInt(row.user_count, 10),
+    tenants: rows.map((row) => ({
+      ...coerceTenantRow(row),
+      userCount:
+        row.user_count == null
+          ? 0
+          : typeof row.user_count === 'number'
+            ? row.user_count
+            : parseInt(row.user_count, 10) || 0,
     })),
     total,
   };
@@ -262,20 +345,26 @@ export async function listTenants(
 /**
  * Returns a single tenant by ID with an approximate user count.
  */
-export async function getTenantById(id: string): Promise<(TenantRow & { userCount: number }) | null> {
-  const result = await pool.query('SELECT * FROM tenants WHERE id = $1', [id]);
-  if (result.rows.length === 0) return null;
+export async function getTenantById(
+  id: string,
+): Promise<(TenantRow & { userCount: number }) | null> {
+  const tenant = await db
+    .selectFrom('tenants')
+    .selectAll()
+    .where('id', '=', id)
+    .executeTakeFirst();
+  if (!tenant) return null;
 
-  const tenant = result.rows[0] as TenantRow;
+  const countRow = await db
+    .selectFrom('tenant_memberships')
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .where('tenant_id', '=', id)
+    .executeTakeFirstOrThrow();
 
-  // Count memberships for this tenant
-  const countResult = await pool.query(
-    'SELECT COUNT(*) AS count FROM tenant_memberships WHERE tenant_id = $1',
-    [id],
-  );
-  const userCount = parseInt((countResult.rows[0] as { count: string }).count, 10);
-
-  return { ...tenant, userCount };
+  return {
+    ...coerceTenantRow(tenant),
+    userCount: parseInt(countRow.count, 10),
+  };
 }
 
 export interface UpdateTenantInput {
@@ -286,6 +375,10 @@ export interface UpdateTenantInput {
 
 /**
  * Updates mutable fields on a tenant record.
+ *
+ * The patch object is typed against `Updateable<Tenants>` so a column
+ * rename or nullability change on the generated schema surfaces as a
+ * compile-time error here, not a silent runtime SQL mismatch.
  */
 export async function updateTenant(
   id: string,
@@ -301,38 +394,31 @@ export async function updateTenant(
     );
   }
 
-  const setClauses: string[] = [];
-  const values: unknown[] = [];
-  let idx = 1;
+  const patch: Updateable<Tenants> = {};
 
   if (name !== undefined) {
-    if (!name.trim()) throw Object.assign(new Error('Tenant name cannot be empty'), { code: 'VALIDATION_ERROR' });
-    setClauses.push(`name = $${idx++}`);
-    values.push(name.trim());
+    if (!name.trim()) {
+      throw Object.assign(new Error('Tenant name cannot be empty'), { code: 'VALIDATION_ERROR' });
+    }
+    patch.name = name.trim();
   }
-  if (status !== undefined) {
-    setClauses.push(`status = $${idx++}`);
-    values.push(status);
-  }
-  if (plan !== undefined) {
-    setClauses.push(`plan = $${idx++}`);
-    values.push(plan);
-  }
+  if (status !== undefined) patch.status = status;
+  if (plan !== undefined) patch.plan = plan;
 
-  if (setClauses.length === 0) {
+  if (Object.keys(patch).length === 0) {
     throw Object.assign(new Error('No fields to update'), { code: 'VALIDATION_ERROR' });
   }
 
-  setClauses.push(`updated_at = $${idx++}`);
-  values.push(new Date());
-  values.push(id);
+  patch.updated_at = new Date();
 
-  const result = await pool.query(
-    `UPDATE tenants SET ${setClauses.join(', ')} WHERE id = $${idx} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('tenants')
+    .set(patch)
+    .where('id', '=', id)
+    .returningAll()
+    .executeTakeFirst();
 
-  return result.rows.length > 0 ? (result.rows[0] as TenantRow) : null;
+  return row ? coerceTenantRow(row) : null;
 }
 
 /**
@@ -340,12 +426,14 @@ export async function updateTenant(
  * Removes the tenant from Descope if cascade is true.
  */
 export async function deleteTenant(id: string, cascade = false): Promise<boolean> {
-  const result = await pool.query(
-    `UPDATE tenants SET status = 'suspended', updated_at = $1 WHERE id = $2 RETURNING id`,
-    [new Date(), id],
-  );
+  const row = await db
+    .updateTable('tenants')
+    .set({ status: 'suspended', updated_at: new Date() })
+    .where('id', '=', id)
+    .returning('id')
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) return false;
+  if (!row) return false;
 
   if (cascade) {
     const descopeClient = getDescopeManagementClient();


### PR DESCRIPTION
## Summary

Third and final PR in Group C of the Phase 3b Kysely migration (#445). Replaces the 8 raw `pool.query` / `client.query` calls in `tenantProvisioning.ts` with typed Kysely query builders while keeping the transactional envelope on the raw pg `PoolClient` — `seedWithClient` originates in the 1109-line `seedDefaultObjects.ts` which is out of scope for this migration, so Kysely cannot own that transaction yet. The tenant INSERT inside the transaction is still built via Kysely and `.compile()`d so the column list and value shapes stay under Kysely's compile-time safety net; the compiled SQL + params are then handed to the raw client to keep INSERT + seed atomic.

## Changes

### `tenantProvisioning.ts`
- Adopts `Selectable<Tenants>` + `Updateable<Tenants>` for the public row contract and update patches.
- Adds a `coerceTenantRow` helper that normalises `settings` across the raw-client (JSON string) and Kysely (already-parsed object) code paths into a stable `Record<string, unknown>`.
- Slug uniqueness check, `listTenants`, `getTenantById`, `updateTenant`, and `deleteTenant` are all pure Kysely now.
- `listTenants` mirrors the `accountService` pattern from PR #462: a lightweight `SELECT count(*)` pagination query plus a data query with a correlated scalar subquery for `user_count`, scoped to the outer tenant via `whereRef('m.tenant_id', '=', 't.id')`.

### `tenantProvisioning.test.ts` (unit)
- Mock now routes both `pool.query` and `pool.connect().query` through the shared dispatcher, because Kysely's `PostgresDriver` always acquires a client per query via `pool.connect()`.

### `tenantProvisioning.e2e.test.ts`
- Mock normalisation strips identifier quotes so `"tenants"` matches the existing uppercase matchers.
- Slug-uniqueness handler moved onto the client dispatcher (Kysely routes it through `pool.connect()` now).
- `INSERT INTO tenants` destructuring updated from 6 → 8 params (`status` and `settings` are now bound, not hardcoded in the SQL string).
- Rollback test switched from `mockRejectedValueOnce` (which would now fire on the slug check) to targeted failure injection on the INSERT.

### `tenantProvisioning.kysely-sql.test.ts` (new)
Regression suite that asserts directly on the compiled SQL for every public entry point. Locks down:
- Slug check routes via `pool.connect` (not `pool.query`)
- INSERT binds all 8 columns in declared order with a JSON-string `settings` and `Date` timestamps
- INSERT executes between `BEGIN` and `COMMIT` on the client path
- `listTenants` count path is lightweight (no `t.*`, `user_count`, `LIMIT`, or `OFFSET`)
- `listTenants` correlated subquery scopes to `m.tenant_id = t.id` (no cross-tenant leakage)
- `getTenantById` emits a tenant SELECT + a tenant-scoped `tenant_memberships` COUNT(*)
- `updateTenant` only SETs supplied columns (+ `updated_at`), rejects empty patches before touching the DB
- `deleteTenant` is a soft-delete via `UPDATE status = 'suspended'`, not a `DELETE FROM`

## Architectural note

`seedDefaultObjects.ts` (1109 lines, 19 raw `client.query` calls) is explicitly out of scope for this PR. Its migration will need its own PR since it touches a wide schema surface (`object_definitions`, `field_definitions`, `relationship_definitions`, `layout_definitions`, `layout_field_assignments`, `pipeline_definitions`, `stage_definitions`, `lead_conversion_mappings`) and the transactional contract with `tenantProvisioning` needs care. Until then, the BEGIN/COMMIT envelope stays on the raw `PoolClient` and the tenant INSERT is compiled via Kysely + executed on that client to keep the two halves atomic.

## Test plan

- [x] `npx vitest run src/services/__tests__/tenantProvisioning` — 3 files, 43 tests passing
- [x] `npx vitest run` — 73 files, 1479 tests passing (+13 new regression assertions)
- [x] `npx tsc --noEmit` — clean
- [x] Unit suite covers the validation paths
- [x] E2E suite covers the end-to-end Descope + seed + invite flow
- [x] SQL suite locks down the emitted queries against drift

Part of #445 (Phase 3b, Group C, PR 3 of 3). Group C PR 1 was #461 (organisation/profile/userSync), Group C PR 2 was #462 (accountService).

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf