### PR TITLE
Migrate leadConversionService.ts + salesTargetService.ts to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/leadConversionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/leadConversionService.kysely-sql.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Kysely SQL regression suite for leadConversionService.
+ *
+ * Complements `leadConversionService.test.ts` (behavioural assertions)
+ * by asserting directly on the SQL Kysely emits inside the
+ * `db.transaction().execute()` closure. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every query inside the conversion transaction carries
+ *      a `tenant_id` filter as defence-in-depth against an RLS
+ *      misconfiguration (ADR-006).
+ *   3. Verify the conversion is actually a single Kysely transaction —
+ *      exactly one BEGIN and one COMMIT on exactly one checked-out
+ *      client, and every data query runs on that client (not on a
+ *      secondary connection).
+ *   4. Verify INSERT INTO records binds all 8 columns in declared order
+ *      (so `field_values` stays at param index 4, the contract the
+ *      behavioural tests rely on).
+ *   5. Verify the linkRecordInTransaction helper emits both a SELECT
+ *      against relationship_definitions *and* the INSERT into
+ *      record_relationships on the same transactional client.
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down on the transactional client.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+const OWNER_ID = 'user-sql-001';
+const LEAD_RECORD_ID = 'lead-sql-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+  clientIndex: number;
+}
+
+const {
+  capturedQueries,
+  mockQuery,
+  mockConnect,
+  resetCapture,
+  setFailOnFirstInsert,
+} = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+  let connectCount = 0;
+  let failOnFirstInsert = false;
+  let insertCount = 0;
+
+  function runQuery(
+    rawSql: string,
+    params: unknown[] | undefined,
+    clientIndex: number,
+  ) {
+    capturedQueries.push({
+      sql: rawSql,
+      params: params ?? [],
+      clientIndex,
+    });
+
+    const s = rawSql
+      .replace(/\s+/g, ' ')
+      .replace(/"/g, '')
+      .trim()
+      .toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // object_definitions lookup
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM OBJECT_DEFINITIONS') &&
+      s.includes('API_NAME')
+    ) {
+      const apiName = (params ?? [])[0] as string;
+      return { rows: [{ id: `obj-${apiName}-id` }] };
+    }
+
+    // lead record lookup: SELECT * FROM records WHERE id = $1 AND object_id = $2 AND tenant_id = $3
+    if (
+      s.startsWith('SELECT') &&
+      s.includes('FROM RECORDS') &&
+      s.includes('OBJECT_ID') &&
+      !s.startsWith('SELECT ID')
+    ) {
+      return {
+        rows: [
+          {
+            id: LEAD_RECORD_ID,
+            tenant_id: TENANT_ID,
+            object_id: 'obj-lead-id',
+            name: 'John Smith',
+            field_values: {
+              first_name: 'John',
+              last_name: 'Smith',
+              company: 'SQL Corp',
+              status: 'Qualified',
+            },
+            owner_id: OWNER_ID,
+          },
+        ],
+      };
+    }
+
+    // lead_conversion_mappings
+    if (s.includes('FROM LEAD_CONVERSION_MAPPINGS')) {
+      return {
+        rows: [
+          {
+            lead_field_api_name: 'company',
+            target_object: 'account',
+            target_field_api_name: 'name',
+          },
+          {
+            lead_field_api_name: 'first_name',
+            target_object: 'contact',
+            target_field_api_name: 'first_name',
+          },
+        ],
+      };
+    }
+
+    // INSERT INTO records (account / contact / opportunity)
+    if (s.startsWith('INSERT INTO RECORDS')) {
+      insertCount++;
+      if (failOnFirstInsert && insertCount === 1) {
+        throw new Error('simulated insert failure');
+      }
+      return { rows: [], rowCount: 1, command: 'INSERT' };
+    }
+
+    // relationship_definitions lookup
+    if (s.includes('FROM RELATIONSHIP_DEFINITIONS')) {
+      const apiName = (params ?? [])[0] as string;
+      return { rows: [{ id: `rel-${apiName}-id` }] };
+    }
+
+    // INSERT INTO record_relationships
+    if (s.startsWith('INSERT INTO RECORD_RELATIONSHIPS')) {
+      return { rows: [], rowCount: 1, command: 'INSERT' };
+    }
+
+    // UPDATE records (lead conversion metadata)
+    if (s.startsWith('UPDATE RECORDS')) {
+      return { rows: [], rowCount: 1, command: 'UPDATE' };
+    }
+
+    return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sql: unknown, params?: unknown[]) => {
+    const rawSql =
+      typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    // Pool-level calls (non-transactional validation) — index -1
+    return runQuery(rawSql, params, -1);
+  });
+
+  const mockConnect = vi.fn(async () => {
+    const myIndex = connectCount++;
+    return {
+      query: vi.fn(async (sql: unknown, params?: unknown[]) => {
+        const rawSql =
+          typeof sql === 'string' ? sql : (sql as { text: string }).text;
+        const paramValues =
+          typeof sql === 'string'
+            ? params
+            : (sql as { values?: unknown[] }).values;
+        return runQuery(rawSql, paramValues, myIndex);
+      }),
+      release: vi.fn(),
+    };
+  });
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+    connectCount = 0;
+    insertCount = 0;
+    failOnFirstInsert = false;
+  }
+
+  function setFailOnFirstInsert(v: boolean) {
+    failOnFirstInsert = v;
+  }
+
+  return {
+    capturedQueries,
+    mockQuery,
+    mockConnect,
+    resetCapture,
+    setFailOnFirstInsert,
+  };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { convertLead } = await import('../leadConversionService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+/**
+ * Returns the index of the checked-out client that owns both BEGIN and
+ * COMMIT (i.e. the transactional client), or -1 if no such client was
+ * captured. When Kysely's proxy-pool fires validation SET_CONFIG queries
+ * on a throwaway client, the transactional client is typically *not*
+ * index 0.
+ */
+function findTransactionalClientIndex(): number {
+  const perClient = new Map<number, { begin: boolean; commit: boolean }>();
+  for (const q of capturedQueries) {
+    const s = normalise(q.sql);
+    if (s === 'BEGIN' || s === 'COMMIT') {
+      const entry = perClient.get(q.clientIndex) ?? {
+        begin: false,
+        commit: false,
+      };
+      if (s === 'BEGIN') entry.begin = true;
+      if (s === 'COMMIT') entry.commit = true;
+      perClient.set(q.clientIndex, entry);
+    }
+  }
+  for (const [idx, state] of perClient) {
+    if (state.begin && state.commit) return idx;
+  }
+  return -1;
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('leadConversionService Kysely SQL — transaction envelope', () => {
+  it('runs the entire conversion inside a single BEGIN/COMMIT envelope', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const trxClient = findTransactionalClientIndex();
+    expect(trxClient).toBeGreaterThanOrEqual(0);
+
+    // Exactly one BEGIN, exactly one COMMIT, zero ROLLBACK on the
+    // transactional client.
+    const onTrxClient = capturedQueries.filter(
+      (q) => q.clientIndex === trxClient,
+    );
+    const beginCount = onTrxClient.filter(
+      (q) => normalise(q.sql) === 'BEGIN',
+    ).length;
+    const commitCount = onTrxClient.filter(
+      (q) => normalise(q.sql) === 'COMMIT',
+    ).length;
+    const rollbackCount = onTrxClient.filter(
+      (q) => normalise(q.sql) === 'ROLLBACK',
+    ).length;
+    expect(beginCount).toBe(1);
+    expect(commitCount).toBe(1);
+    expect(rollbackCount).toBe(0);
+  });
+
+  it('every data query runs on the transactional client (not via pool.query)', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const trxClient = findTransactionalClientIndex();
+    const queries = dataQueries();
+    expect(queries.length).toBeGreaterThan(0);
+
+    for (const q of queries) {
+      expect(
+        q.clientIndex,
+        `Query hit the wrong client (expected ${trxClient}):\n  ${q.sql}`,
+      ).toBe(trxClient);
+    }
+  });
+
+  it('rolls back the transaction via ROLLBACK when an INSERT throws', async () => {
+    setFailOnFirstInsert(true);
+
+    await expect(
+      convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {}),
+    ).rejects.toThrow('simulated insert failure');
+
+    const rolledBack = capturedQueries.some(
+      (q) => normalise(q.sql) === 'ROLLBACK',
+    );
+    expect(rolledBack).toBe(true);
+    // And no COMMIT — the transaction must not have been finalised.
+    const committed = capturedQueries.some(
+      (q) => normalise(q.sql) === 'COMMIT',
+    );
+    expect(committed).toBe(false);
+  });
+});
+
+describe('leadConversionService Kysely SQL — tenant_id defence-in-depth', () => {
+  it('every SELECT/INSERT/UPDATE inside the transaction carries tenant_id', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const trxClient = findTransactionalClientIndex();
+    const queries = dataQueries().filter((q) => q.clientIndex === trxClient);
+
+    expect(queries.length).toBeGreaterThan(0);
+
+    for (const q of queries) {
+      expect(
+        normalise(q.sql).includes('TENANT_ID'),
+        `Query missing TENANT_ID:\n  ${q.sql}`,
+      ).toBe(true);
+      expect(
+        q.params,
+        `Query params missing TENANT_ID bind:\n  ${q.sql}\n  params=${JSON.stringify(q.params)}`,
+      ).toContain(TENANT_ID);
+    }
+  });
+});
+
+describe('leadConversionService Kysely SQL — INSERT INTO records', () => {
+  it('binds all 8 columns in declared order (field_values at index 4)', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RECORDS'),
+    );
+    // account + contact + opportunity
+    expect(inserts.length).toBe(3);
+
+    for (const insert of inserts) {
+      // Column order (as written in the service .values({...})):
+      //   id, tenant_id, object_id, name, field_values, owner_id,
+      //   created_at, updated_at.
+      expect(insert.params.length).toBe(8);
+      expect(insert.params[1]).toBe(TENANT_ID); // tenant_id
+      // field_values must be a JSON string, not an object — pg's JSONB
+      // column wants a stringified payload.
+      expect(typeof insert.params[4]).toBe('string');
+      expect(() => JSON.parse(insert.params[4] as string)).not.toThrow();
+      expect(insert.params[5]).toBe(OWNER_ID); // owner_id
+      expect(insert.params[6]).toBeInstanceOf(Date); // created_at
+      expect(insert.params[7]).toBeInstanceOf(Date); // updated_at
+    }
+  });
+
+  it('skips the opportunity INSERT when createOpportunity=false', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {
+      createOpportunity: false,
+    });
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RECORDS'),
+    );
+    // account + contact only
+    expect(inserts.length).toBe(2);
+  });
+});
+
+describe('leadConversionService Kysely SQL — record_relationships linking', () => {
+  it('emits a relationship_definitions SELECT plus a record_relationships INSERT for each link', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const relSelects = dataQueries().filter((q) =>
+      normalise(q.sql).includes('FROM RELATIONSHIP_DEFINITIONS'),
+    );
+    const relInserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO RECORD_RELATIONSHIPS'),
+    );
+
+    // contact_account + opportunity_account + opportunity_contact
+    expect(relSelects.length).toBe(3);
+    expect(relInserts.length).toBe(3);
+
+    for (const insert of relInserts) {
+      // Column order: id, tenant_id, relationship_id, source_record_id,
+      // target_record_id, created_at.
+      expect(insert.params.length).toBe(6);
+      expect(insert.params[1]).toBe(TENANT_ID);
+      expect(insert.params[5]).toBeInstanceOf(Date);
+    }
+  });
+});
+
+describe('leadConversionService Kysely SQL — lead UPDATE', () => {
+  it('issues exactly one UPDATE records with field_values + updated_at in SET, scoped by id/object_id/tenant_id', async () => {
+    await convertLead(TENANT_ID, LEAD_RECORD_ID, OWNER_ID, {});
+
+    const updates = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('UPDATE RECORDS'),
+    );
+    expect(updates.length).toBe(1);
+
+    const update = updates[0]!;
+    const s = normalise(update.sql);
+    expect(s).toContain('FIELD_VALUES =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).toContain('ID =');
+    expect(s).toContain('OBJECT_ID =');
+    expect(s).toContain('TENANT_ID =');
+
+    // field_values is the first .set() key, so param index 0.
+    const fieldValues = JSON.parse(update.params[0] as string);
+    expect(fieldValues.status).toBe('Converted');
+    expect(fieldValues.converted_at).toBeDefined();
+    expect(fieldValues.converted_account_id).toBeDefined();
+    expect(fieldValues.converted_contact_id).toBeDefined();
+    expect(update.params).toContain(TENANT_ID);
+    expect(update.params).toContain(LEAD_RECORD_ID);
+  });
+});

--- a/apps/api/src/services/__tests__/leadConversionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/leadConversionService.kysely-sql.test.ts
@@ -163,8 +163,12 @@ const {
   const mockQuery = vi.fn(async (sql: unknown, params?: unknown[]) => {
     const rawSql =
       typeof sql === 'string' ? sql : (sql as { text: string }).text;
+    const paramValues =
+      typeof sql === 'string'
+        ? params
+        : (sql as { values?: unknown[] }).values;
     // Pool-level calls (non-transactional validation) — index -1
-    return runQuery(rawSql, params, -1);
+    return runQuery(rawSql, paramValues, -1);
   });
 
   const mockConnect = vi.fn(async () => {

--- a/apps/api/src/services/__tests__/leadConversionService.test.ts
+++ b/apps/api/src/services/__tests__/leadConversionService.test.ts
@@ -38,6 +38,20 @@ const { convertLead } = await import('../leadConversionService.js');
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
+/**
+ * Normalises a captured `clientQuery.mock.calls[i]` entry to `{ sql, params }`
+ * regardless of whether the caller used the legacy `(sql, params)` shape or
+ * Kysely's `({ text, values })` shape.
+ */
+function extractCall(call: unknown[]): { sql: string; params: unknown[] } {
+  const first = call[0];
+  if (typeof first === 'string') {
+    return { sql: first, params: (call[1] as unknown[]) ?? [] };
+  }
+  const obj = first as { text: string; values?: unknown[] };
+  return { sql: obj.text, params: obj.values ?? [] };
+}
+
 function setupLeadConversionMocks(overrides: {
   leadFieldValues?: Record<string, unknown>;
   leadStatus?: string;
@@ -66,8 +80,21 @@ function setupLeadConversionMocks(overrides: {
     existingAccountName = 'Existing Corp',
   } = overrides;
 
-  clientQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  clientQuery.mockImplementation(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    // Kysely's PostgresDriver calls client.query({ text, values }) while
+    // the legacy raw-pg path calls client.query(sql, params). Normalise
+    // both call shapes so a single dispatcher can handle both.
+    const sql =
+      typeof sqlOrQuery === 'string'
+        ? sqlOrQuery
+        : (sqlOrQuery as { text: string }).text;
+    const params =
+      typeof sqlOrQuery === 'string'
+        ? paramsArg
+        : ((sqlOrQuery as { values?: unknown[] }).values ?? []);
+    // Strip identifier quotes so Kysely's `"records"` matches the
+    // existing uppercase matchers written against unquoted identifiers.
+    const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
     // BEGIN / COMMIT / ROLLBACK
     if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
@@ -202,7 +229,7 @@ describe('convertLead', () => {
 
     // Verify transaction was used
     const calls = clientQuery.mock.calls.map((c: unknown[]) =>
-      (c[0] as string).replace(/\s+/g, ' ').trim().toUpperCase(),
+      extractCall(c).sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase(),
     );
     expect(calls[0]).toBe('BEGIN');
     expect(calls[calls.length - 1]).toBe('COMMIT');
@@ -271,8 +298,12 @@ describe('convertLead', () => {
     // Make the INSERT for account fail
     const originalImpl = clientQuery.getMockImplementation();
     let insertCount = 0;
-    clientQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
-      const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+    clientQuery.mockImplementation(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const sql =
+        typeof sqlOrQuery === 'string'
+          ? sqlOrQuery
+          : (sqlOrQuery as { text: string }).text;
+      const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
       if (s.startsWith('INSERT INTO RECORDS')) {
         insertCount++;
         if (insertCount === 1) {
@@ -280,7 +311,7 @@ describe('convertLead', () => {
         }
       }
       if (typeof originalImpl === 'function') {
-        return (originalImpl as (...args: unknown[]) => unknown)(sql, params);
+        return (originalImpl as (...args: unknown[]) => unknown)(sqlOrQuery, paramsArg);
       }
       return { rows: [] };
     });
@@ -291,7 +322,7 @@ describe('convertLead', () => {
 
     // Verify ROLLBACK was called
     const calls = clientQuery.mock.calls.map((c: unknown[]) =>
-      (c[0] as string).replace(/\s+/g, ' ').trim().toUpperCase(),
+      extractCall(c).sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase(),
     );
     expect(calls).toContain('ROLLBACK');
     expect(clientRelease).toHaveBeenCalled();
@@ -329,16 +360,20 @@ describe('convertLead', () => {
     await convertLead(TENANT_ID, 'lead-1', 'user-123', {});
 
     // Find INSERT INTO records calls
-    const insertCalls = clientQuery.mock.calls.filter((c: unknown[]) => {
-      const sql = (c[0] as string).replace(/\s+/g, ' ').trim().toUpperCase();
-      return sql.startsWith('INSERT INTO RECORDS');
-    });
+    const insertCalls = clientQuery.mock.calls
+      .map((c: unknown[]) => extractCall(c))
+      .filter((c) => {
+        const sql = c.sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+        return sql.startsWith('INSERT INTO RECORDS');
+      });
 
     expect(insertCalls.length).toBe(3); // account, contact, opportunity
 
+    // Kysely compiles `values({ id, tenant_id, object_id, name, field_values,
+    // owner_id, created_at, updated_at })` to 8 positional params in the
+    // declared field-order, so field_values is param index 4.
     // Account: lead.company → account.name, lead.industry → account.industry, etc.
-    const accountParams = insertCalls[0][1] as unknown[];
-    const accountFieldValues = JSON.parse(accountParams[4] as string);
+    const accountFieldValues = JSON.parse(insertCalls[0]!.params[4] as string);
     expect(accountFieldValues.name).toBe('Acme Corp');
     expect(accountFieldValues.industry).toBe('Technology');
     expect(accountFieldValues.website).toBe('https://acme.com');
@@ -347,8 +382,7 @@ describe('convertLead', () => {
     expect(accountFieldValues.address_line1).toBe('123 Main St');
 
     // Contact: lead.first_name → contact.first_name, etc.
-    const contactParams = insertCalls[1][1] as unknown[];
-    const contactFieldValues = JSON.parse(contactParams[4] as string);
+    const contactFieldValues = JSON.parse(insertCalls[1]!.params[4] as string);
     expect(contactFieldValues.first_name).toBe('John');
     expect(contactFieldValues.last_name).toBe('Smith');
     expect(contactFieldValues.email).toBe('john@acme.com');
@@ -356,8 +390,7 @@ describe('convertLead', () => {
     expect(contactFieldValues.job_title).toBe('CEO');
 
     // Opportunity: lead.estimated_value → opportunity.value, etc.
-    const oppParams = insertCalls[2][1] as unknown[];
-    const oppFieldValues = JSON.parse(oppParams[4] as string);
+    const oppFieldValues = JSON.parse(insertCalls[2]!.params[4] as string);
     expect(oppFieldValues.value).toBe(50000);
     expect(oppFieldValues.source).toBe('Website');
     expect(oppFieldValues.description).toBe('A great lead');
@@ -369,15 +402,18 @@ describe('convertLead', () => {
     const result = await convertLead(TENANT_ID, 'lead-1', 'user-123', {});
 
     // Find UPDATE records call
-    const updateCalls = clientQuery.mock.calls.filter((c: unknown[]) => {
-      const sql = (c[0] as string).replace(/\s+/g, ' ').trim().toUpperCase();
-      return sql.startsWith('UPDATE RECORDS');
-    });
+    const updateCalls = clientQuery.mock.calls
+      .map((c: unknown[]) => extractCall(c))
+      .filter((c) => {
+        const sql = c.sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+        return sql.startsWith('UPDATE RECORDS');
+      });
 
     expect(updateCalls.length).toBe(1);
 
-    const updateParams = updateCalls[0][1] as unknown[];
-    const updatedFieldValues = JSON.parse(updateParams[0] as string);
+    // Kysely compiles `.set({ field_values, updated_at })` to two
+    // positional params in declared order, so field_values is param 0.
+    const updatedFieldValues = JSON.parse(updateCalls[0]!.params[0] as string);
 
     expect(updatedFieldValues.status).toBe('Converted');
     expect(updatedFieldValues.converted_at).toBeDefined();

--- a/apps/api/src/services/__tests__/salesTargetService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/salesTargetService.kysely-sql.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Kysely SQL regression suite for salesTargetService.
+ *
+ * Complements `salesTargetService.test.ts` (behavioural assertions) by
+ * asserting on the SQL Kysely emits at compile time. It exists to:
+ *
+ *   1. Catch drift in the generated SQL as Kysely is upgraded or the
+ *      service is refactored.
+ *   2. Audit that every query carries a `tenant_id` filter — including
+ *      the previously-latent defence-in-depth gaps the Kysely migration
+ *      closes:
+ *        - `getRecordName` now accepts a `tenantId` and filters on it
+ *        - `calculateActual` scopes `od.tenant_id` + `sd.tenant_id` on
+ *          its JOINs in addition to `r.tenant_id`
+ *        - `calculateActualForUserRecord`, `getUserTarget`, and
+ *          `getTeamUserTargets` all scope `od.tenant_id` on the JOIN
+ *   3. Verify INSERT INTO sales_targets uses ON CONFLICT DO UPDATE SET
+ *      (upsert semantics) rather than two round-trips.
+ *   4. Verify the JSONB `field_values->>'descope_user_id'` and
+ *      `field_values->>'team_id'` lookups follow the ADR-006 Appendix A
+ *      pattern (column reference written via the `sql` tag, value bound
+ *      as a parameter).
+ *
+ * No real Postgres — the pg pool is mocked and captures every compiled
+ * SQL string Kysely hands down.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+
+  function normaliseForTopLevelMatch(rawSql: string): string {
+    return rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = normaliseForTopLevelMatch(rawSql);
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO sales_targets ... ON CONFLICT ... RETURNING *
+    if (s.startsWith('INSERT INTO SALES_TARGETS')) {
+      const [
+        tenant_id,
+        target_type,
+        target_entity_id,
+        period_type,
+        period_start,
+        period_end,
+        target_value,
+        currency,
+        created_by,
+      ] = params;
+      return {
+        rows: [
+          {
+            id: 'new-target-id',
+            tenant_id,
+            target_type,
+            target_entity_id,
+            period_type,
+            period_start,
+            period_end,
+            target_value,
+            currency,
+            created_by,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+        rowCount: 1,
+        command: 'INSERT',
+      };
+    }
+
+    // SELECT FROM sales_targets (list + summary + getUserTarget's target lookup)
+    if (s.includes('FROM SALES_TARGETS') && s.startsWith('SELECT')) {
+      return { rows: [] };
+    }
+
+    // DELETE FROM sales_targets
+    if (s.startsWith('DELETE FROM SALES_TARGETS')) {
+      return { rows: [], rowCount: 1, command: 'DELETE' };
+    }
+
+    // Actuals calculation query
+    if (s.includes('COALESCE(SUM')) {
+      return { rows: [{ actual: '0' }] };
+    }
+
+    // User record lookup (getUserTarget + calculateActualForUserRecord +
+    // getTeamUserTargets): records joined to object_definitions, filtered
+    // by api_name = 'user'.
+    if (s.includes('FROM RECORDS R') && s.includes('OBJECT_DEFINITIONS OD')) {
+      return { rows: [] };
+    }
+
+    // SELECT name FROM records (getRecordName)
+    if (s.startsWith('SELECT NAME FROM RECORDS')) {
+      return { rows: [{ name: 'Fake Team' }] };
+    }
+
+    return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+  }
+
+  return { capturedQueries, mockQuery, mockConnect, resetCapture };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  upsertTarget,
+  listTargets,
+  deleteTarget,
+  calculateActual,
+  getUserTarget,
+} = await import('../salesTargetService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('salesTargetService Kysely SQL — upsertTarget', () => {
+  it('emits INSERT INTO sales_targets with ON CONFLICT DO UPDATE SET', async () => {
+    await upsertTarget(TENANT_ID, {
+      targetType: 'business',
+      periodType: 'quarterly',
+      periodStart: '2026-01-01',
+      periodEnd: '2026-04-01',
+      targetValue: 500000,
+      currency: 'GBP',
+    });
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO SALES_TARGETS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    const insert = inserts[0]!;
+    const s = normalise(insert.sql);
+    expect(s).toContain('ON CONFLICT');
+    expect(s).toContain('DO UPDATE SET');
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('TARGET_TYPE');
+    expect(s).toContain('TARGET_ENTITY_ID');
+    expect(s).toContain('PERIOD_START');
+    expect(s).toContain('RETURNING');
+  });
+
+  it('binds all 9 columns with tenant_id at index 0', async () => {
+    await upsertTarget(TENANT_ID, {
+      targetType: 'business',
+      periodType: 'quarterly',
+      periodStart: '2026-01-01',
+      periodEnd: '2026-04-01',
+      targetValue: 500000,
+      currency: 'GBP',
+      createdBy: 'user-xyz',
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO SALES_TARGETS'),
+    )!;
+
+    // Column order: tenant_id, target_type, target_entity_id, period_type,
+    // period_start, period_end, target_value, currency, created_by
+    // (9 bound columns total).
+    expect(insert.params[0]).toBe(TENANT_ID);
+    expect(insert.params[1]).toBe('business');
+    expect(insert.params[2]).toBeNull();
+    expect(insert.params[3]).toBe('quarterly');
+    expect(insert.params[6]).toBe(500000);
+    expect(insert.params[7]).toBe('GBP');
+    expect(insert.params[8]).toBe('user-xyz');
+    // The first 9 params are the INSERT columns. Kysely may then bind
+    // additional params for DO UPDATE SET, so only assert that the
+    // INSERT-side parameters cover indices 0..8.
+    expect(insert.params.length).toBeGreaterThanOrEqual(9);
+  });
+});
+
+describe('salesTargetService Kysely SQL — listTargets', () => {
+  it('scopes by tenant_id with no period filters when none supplied', async () => {
+    await listTargets(TENANT_ID);
+
+    const selects = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT') && s.includes('FROM SALES_TARGETS');
+    });
+    expect(selects.length).toBe(1);
+
+    const select = selects[0]!;
+    const s = normalise(select.sql);
+    expect(s).toContain('TENANT_ID =');
+    expect(s).not.toContain('PERIOD_START >=');
+    expect(s).not.toContain('PERIOD_END <=');
+    expect(select.params).toContain(TENANT_ID);
+  });
+
+  it('appends period filters and orders by period_start DESC, target_type ASC', async () => {
+    await listTargets(TENANT_ID, '2026-01-01', '2026-12-31');
+
+    const select = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT') && s.includes('FROM SALES_TARGETS');
+    })!;
+    const s = normalise(select.sql);
+
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('PERIOD_START >=');
+    expect(s).toContain('PERIOD_END <=');
+    expect(s).toMatch(/ORDER BY PERIOD_START DESC, TARGET_TYPE ASC/);
+    expect(select.params).toContain(TENANT_ID);
+  });
+});
+
+describe('salesTargetService Kysely SQL — deleteTarget', () => {
+  it('emits DELETE scoped by id AND tenant_id', async () => {
+    await deleteTarget(TENANT_ID, 'target-xyz');
+
+    const deletes = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('DELETE FROM SALES_TARGETS'),
+    );
+    expect(deletes.length).toBe(1);
+
+    const del = deletes[0]!;
+    const s = normalise(del.sql);
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toEqual(['target-xyz', TENANT_ID]);
+  });
+});
+
+describe('salesTargetService Kysely SQL — calculateActual tenant_id defence-in-depth', () => {
+  it('scopes r.tenant_id + od.tenant_id + sd.tenant_id on the JOINed query', async () => {
+    await calculateActual(TENANT_ID, '2026-01-01', '2026-04-01');
+
+    const selects = dataQueries().filter((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT') && s.includes('COALESCE(SUM');
+    });
+    expect(selects.length).toBe(1);
+
+    const select = selects[0]!;
+    const s = normalise(select.sql);
+
+    // The ON clauses should carry tenant_id on *both* JOINed tables.
+    expect(s).toMatch(/OBJECT_DEFINITIONS AS OD[^W]*OD\.TENANT_ID =/);
+    expect(s).toMatch(/STAGE_DEFINITIONS AS SD[^W]*SD\.TENANT_ID =/);
+    // And the record-level filter is still present.
+    expect(s).toContain('R.TENANT_ID =');
+    expect(s).toContain('OD.API_NAME =');
+    expect(s).toContain('SD.STAGE_TYPE =');
+
+    // Every tenant_id bind in the params must be the tenant we asked for.
+    const tenantCount = select.params.filter((p) => p === TENANT_ID).length;
+    // r.tenant_id + od.tenant_id + sd.tenant_id = 3 tenant binds.
+    expect(tenantCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('appends r.owner_id = $N when ownerId is supplied', async () => {
+    await calculateActual(TENANT_ID, '2026-01-01', '2026-04-01', 'user-123');
+
+    const select = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT') && s.includes('COALESCE(SUM');
+    })!;
+    const s = normalise(select.sql);
+
+    expect(s).toContain('R.OWNER_ID =');
+    expect(select.params).toContain('user-123');
+  });
+});
+
+describe('salesTargetService Kysely SQL — getUserTarget JSONB + tenant_id', () => {
+  it('emits records JOIN object_definitions with od.tenant_id and a JSONB field_values lookup', async () => {
+    await getUserTarget(TENANT_ID, 'descope-user-1', '2026-01-01', '2026-04-01');
+
+    const userLookup = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return (
+        s.startsWith('SELECT') &&
+        s.includes('FROM RECORDS AS R') &&
+        s.includes('OBJECT_DEFINITIONS AS OD') &&
+        s.includes('DESCOPE_USER_ID')
+      );
+    });
+    expect(userLookup).toBeDefined();
+
+    const s = normalise(userLookup!.sql);
+    // Both r.tenant_id and od.tenant_id on the JOIN, defence-in-depth.
+    expect(s).toContain('R.TENANT_ID =');
+    expect(s).toMatch(/OD\.TENANT_ID =/);
+    // ADR-006 Appendix A: column reference in SQL, value as bind.
+    expect(s).toContain("R.FIELD_VALUES->>'DESCOPE_USER_ID'");
+    // Value must be a bound param ($N placeholder), not inlined.
+    expect(s).toMatch(/R\.FIELD_VALUES->>'DESCOPE_USER_ID' = \$\d+/);
+
+    // tenant_id + descope_user_id must both be bound on the lookup.
+    expect(userLookup!.params).toContain(TENANT_ID);
+    expect(userLookup!.params).toContain('descope-user-1');
+  });
+});
+
+describe('salesTargetService Kysely SQL — BEGIN/COMMIT envelope', () => {
+  it('does NOT wrap individual queries in BEGIN/COMMIT (each query is standalone)', async () => {
+    // salesTargetService does not use db.transaction().execute() — each
+    // operation is a standalone query. This test pins that contract so a
+    // future "let's wrap everything in a transaction" refactor shows up
+    // as a deliberate SQL change here.
+    await upsertTarget(TENANT_ID, {
+      targetType: 'business',
+      periodType: 'quarterly',
+      periodStart: '2026-01-01',
+      periodEnd: '2026-04-01',
+      targetValue: 500000,
+    });
+
+    const begins = capturedQueries.filter((q) => normalise(q.sql) === 'BEGIN');
+    const commits = capturedQueries.filter((q) => normalise(q.sql) === 'COMMIT');
+    expect(begins.length).toBe(0);
+    expect(commits.length).toBe(0);
+  });
+});

--- a/apps/api/src/services/__tests__/salesTargetService.test.ts
+++ b/apps/api/src/services/__tests__/salesTargetService.test.ts
@@ -7,50 +7,80 @@ vi.mock('../../lib/logger.js', () => ({
 }));
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
+//
+// Kysely's PostgresDriver calls `client.query({text, values})` while the
+// legacy raw-pg path used `pool.query(sql, params)` tuples. This mock
+// accepts both shapes and normalises identifier quoting so the SQL matchers
+// stay readable.
 
-const { fakeTargets, mockQuery } = vi.hoisted(() => {
+const { fakeTargets, mockQuery, mockConnect, clientCalls } = vi.hoisted(() => {
   const fakeTargets = new Map<string, Record<string, unknown>>();
+  const clientCalls: Array<{ sql: string; params: unknown[] }> = [];
+  let targetCounter = 0;
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(rawSql: string, params: unknown[]): { rows: unknown[]; rowCount?: number; command?: string } {
+    const s = rawSql
+      .replace(/\s+/g, ' ')
+      .replace(/"/g, '')
+      .trim()
+      .toUpperCase();
 
-    // INSERT INTO sales_targets ... RETURNING *
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+      return { rows: [] };
+    }
+    if (s.startsWith('SELECT SET_CONFIG')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO sales_targets ... ON CONFLICT ... RETURNING *
     if (s.startsWith('INSERT INTO SALES_TARGETS')) {
-      const id = 'new-target-id';
+      const id = `new-target-id-${++targetCounter}`;
+      const [
+        tenant_id,
+        target_type,
+        target_entity_id,
+        period_type,
+        period_start,
+        period_end,
+        target_value,
+        currency,
+        created_by,
+      ] = params as unknown[];
       const row = {
         id,
-        tenant_id: params![0],
-        target_type: params![1],
-        target_entity_id: params![2],
-        period_type: params![3],
-        period_start: new Date(params![4] as string),
-        period_end: new Date(params![5] as string),
-        target_value: params![6],
-        currency: params![7],
+        tenant_id,
+        target_type,
+        target_entity_id,
+        period_type,
+        period_start,
+        period_end,
+        target_value,
+        currency,
+        created_by,
         created_at: new Date(),
         updated_at: new Date(),
       };
       fakeTargets.set(id, row);
-      return { rows: [row] };
+      return { rows: [row], rowCount: 1, command: 'INSERT' };
     }
 
-    // SELECT * FROM sales_targets WHERE tenant_id = $1 (list)
-    if (s.startsWith('SELECT * FROM SALES_TARGETS WHERE TENANT_ID')) {
-      const tenantId = params![0] as string;
+    // SELECT FROM sales_targets (list)
+    if (s.includes('FROM SALES_TARGETS') && s.startsWith('SELECT')) {
+      const tenantId = params[0] as string;
       const rows = [...fakeTargets.values()].filter((t) => t.tenant_id === tenantId);
       return { rows };
     }
 
     // DELETE FROM sales_targets WHERE id = $1 AND tenant_id = $2
     if (s.startsWith('DELETE FROM SALES_TARGETS')) {
-      const targetId = params![0] as string;
-      const tenantId = params![1] as string;
+      const targetId = params[0] as string;
+      const tenantId = params[1] as string;
       const target = fakeTargets.get(targetId);
       if (target && target.tenant_id === tenantId) {
         fakeTargets.delete(targetId);
-        return { rowCount: 1 };
+        return { rows: [], rowCount: 1, command: 'DELETE' };
       }
-      return { rowCount: 0 };
+      return { rows: [], rowCount: 0, command: 'DELETE' };
     }
 
     // Actuals calculation query (COALESCE(SUM...))
@@ -60,13 +90,35 @@ const { fakeTargets, mockQuery } = vi.hoisted(() => {
 
     // Fallback
     return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  return { fakeTargets, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      clientCalls.push({ sql, params });
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeTargets, mockQuery, mockConnect, clientCalls };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 const { upsertTarget, listTargets, deleteTarget, calculateActual, calculatePace } = await import(
@@ -79,6 +131,7 @@ describe('salesTargetService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fakeTargets.clear();
+    clientCalls.length = 0;
   });
 
   // ── upsertTarget ──────────────────────────────────────────────────────────
@@ -95,10 +148,9 @@ describe('salesTargetService', () => {
       });
 
       expect(result).toBeDefined();
-      expect(result.id).toBe('new-target-id');
+      expect(result.id).toBe('new-target-id-1');
       expect(result.target_type).toBe('business');
       expect(result.target_value).toBe(500000);
-      expect(mockQuery).toHaveBeenCalledTimes(1);
     });
 
     it('rejects invalid target_type', async () => {
@@ -270,8 +322,13 @@ describe('salesTargetService', () => {
     it('passes owner_id when provided', async () => {
       await calculateActual(TENANT_ID, '2026-01-01', '2026-04-01', 'user-123');
 
-      const lastCall = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
-      expect(lastCall[1]).toContain('user-123');
+      // Kysely's PostgresDriver checks out a client and runs the SELECT
+      // against it; assert the owner_id bind landed on one of the
+      // captured client.query calls.
+      const ownerIdBound = clientCalls.some((c) =>
+        c.params.some((p) => p === 'user-123'),
+      );
+      expect(ownerIdBound).toBe(true);
     });
   });
 
@@ -317,9 +374,9 @@ describe('salesTargetService', () => {
     });
 
     it('returns on_track before the period starts', () => {
-      vi.setSystemTime(new Date('2025-12-01'));
+      vi.setSystemTime(new Date('2026-12-01'));
 
-      const result = calculatePace(0, '2026-01-01', '2026-04-01');
+      const result = calculatePace(0, '2027-01-01', '2027-04-01');
       expect(result).toBe('on_track');
     });
   });

--- a/apps/api/src/services/leadConversionService.ts
+++ b/apps/api/src/services/leadConversionService.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'crypto';
-import type pg from 'pg';
+import type { Kysely } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { DB } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,6 +24,13 @@ interface ConversionMapping {
   leadFieldApiName: string;
   targetFieldApiName: string;
 }
+
+/**
+ * Executor type used by helpers that need to run inside either a top-level
+ * Kysely instance or a checked-out transaction. `Transaction<DB>` extends
+ * `Kysely<DB>`, so callers can pass either without a cast.
+ */
+type DbExecutor = Kysely<DB>;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -64,8 +72,12 @@ function applyMappings(
 /**
  * Converts a Lead into an Account + Contact + Opportunity.
  *
- * The entire operation is performed within a single database transaction.
- * If any step fails, all changes are rolled back.
+ * The entire operation is performed within a single Kysely transaction. If
+ * any step fails, Kysely rolls back automatically when the closure throws.
+ *
+ * Tenant defence-in-depth (ADR-006): every SELECT/INSERT/UPDATE in the
+ * closure is scoped by an explicit `tenant_id` filter as the second line of
+ * defence behind RLS.
  *
  * @param leadRecordId - UUID of the lead record to convert
  * @param ownerId - Descope user ID from auth
@@ -77,31 +89,32 @@ export async function convertLead(
   ownerId: string,
   options: ConvertLeadOptions,
 ): Promise<ConvertLeadResult> {
-  const client = await pool.connect();
-
-  try {
-    await client.query('BEGIN');
-
+  return db.transaction().execute(async (trx) => {
     // 1. Resolve lead object definition
-    const leadObjResult = await client.query(
-      'SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2',
-      ['lead', tenantId],
-    );
-    if (leadObjResult.rows.length === 0) {
+    const leadObjRow = await trx
+      .selectFrom('object_definitions')
+      .select('id')
+      .where('api_name', '=', 'lead')
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (!leadObjRow) {
       throwNotFoundError("Object type 'lead' not found");
     }
-    const leadObjectId = (leadObjResult.rows[0] as Record<string, unknown>).id as string;
+    const leadObjectId = leadObjRow.id;
 
     // 2. Fetch the lead record
-    const leadResult = await client.query(
-      'SELECT * FROM records WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-      [leadRecordId, leadObjectId, tenantId],
-    );
-    if (leadResult.rows.length === 0) {
+    const leadRow = await trx
+      .selectFrom('records')
+      .selectAll()
+      .where('id', '=', leadRecordId)
+      .where('object_id', '=', leadObjectId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (!leadRow) {
       throwNotFoundError('Lead not found');
     }
-    const leadRow = leadResult.rows[0] as Record<string, unknown>;
-    const leadFieldValues = (leadRow.field_values as Record<string, unknown>) ?? {};
+    const leadFieldValues =
+      (leadRow.field_values as Record<string, unknown> | null) ?? {};
 
     // 3. Validate lead is not already converted
     if (leadFieldValues['status'] === 'Converted') {
@@ -109,30 +122,34 @@ export async function convertLead(
     }
 
     // 4. Read conversion mappings
-    const mappingsResult = await client.query(
-      'SELECT lead_field_api_name, target_object, target_field_api_name FROM lead_conversion_mappings WHERE tenant_id = $1 ORDER BY target_object',
-      [tenantId],
-    );
-    const mappings: ConversionMapping[] = mappingsResult.rows.map(
-      (row: Record<string, unknown>) => ({
-        targetObject: row.target_object as string,
-        leadFieldApiName: row.lead_field_api_name as string,
-        targetFieldApiName: row.target_field_api_name as string,
-      }),
-    );
+    const mappingRows = await trx
+      .selectFrom('lead_conversion_mappings')
+      .select(['lead_field_api_name', 'target_object', 'target_field_api_name'])
+      .where('tenant_id', '=', tenantId)
+      .orderBy('target_object')
+      .execute();
+    const mappings: ConversionMapping[] = mappingRows.map((row) => ({
+      targetObject: row.target_object,
+      leadFieldApiName: row.lead_field_api_name,
+      targetFieldApiName: row.target_field_api_name,
+    }));
 
     // 5. Resolve target object definitions
-    const accountObjResult = await client.query(
-      'SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2',
-      ['account', tenantId],
-    );
-    const accountObjectId = (accountObjResult.rows[0] as Record<string, unknown>).id as string;
+    const accountObjRow = await trx
+      .selectFrom('object_definitions')
+      .select('id')
+      .where('api_name', '=', 'account')
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirstOrThrow();
+    const accountObjectId = accountObjRow.id;
 
-    const contactObjResult = await client.query(
-      'SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2',
-      ['contact', tenantId],
-    );
-    const contactObjectId = (contactObjResult.rows[0] as Record<string, unknown>).id as string;
+    const contactObjRow = await trx
+      .selectFrom('object_definitions')
+      .select('id')
+      .where('api_name', '=', 'contact')
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirstOrThrow();
+    const contactObjectId = contactObjRow.id;
 
     // 6. Create or link Account
     let accountId: string;
@@ -140,48 +157,70 @@ export async function convertLead(
 
     if (options.accountId) {
       // Use existing account
-      const existingAccount = await client.query(
-        'SELECT id, name FROM records WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-        [options.accountId, accountObjectId, tenantId],
-      );
-      if (existingAccount.rows.length === 0) {
+      const existingAccount = await trx
+        .selectFrom('records')
+        .select(['id', 'name'])
+        .where('id', '=', options.accountId)
+        .where('object_id', '=', accountObjectId)
+        .where('tenant_id', '=', tenantId)
+        .executeTakeFirst();
+      if (!existingAccount) {
         throwNotFoundError('Account not found');
       }
-      accountId = (existingAccount.rows[0] as Record<string, unknown>).id as string;
-      accountName = (existingAccount.rows[0] as Record<string, unknown>).name as string;
+      accountId = existingAccount.id;
+      accountName = existingAccount.name;
     } else {
       // Create new account from mapped fields
       const accountFieldValues = applyMappings(leadFieldValues, mappings, 'account');
-      accountName = (accountFieldValues['name'] as string) ||
+      accountName =
+        (accountFieldValues['name'] as string) ||
         (leadFieldValues['company'] as string) ||
         'Untitled Account';
       accountId = randomUUID();
       const now = new Date();
 
-      await client.query(
-        `INSERT INTO records (id, tenant_id, object_id, name, field_values, owner_id, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [accountId, tenantId, accountObjectId, accountName, JSON.stringify(accountFieldValues), ownerId, now, now],
-      );
+      await trx
+        .insertInto('records')
+        .values({
+          id: accountId,
+          tenant_id: tenantId,
+          object_id: accountObjectId,
+          name: accountName,
+          field_values: JSON.stringify(accountFieldValues),
+          owner_id: ownerId,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
     }
 
     // 7. Create Contact
     const contactFieldValues = applyMappings(leadFieldValues, mappings, 'contact');
     const firstName = (contactFieldValues['first_name'] as string) || '';
     const lastName = (contactFieldValues['last_name'] as string) || '';
-    const contactName = [firstName, lastName].filter((s) => s.trim().length > 0).join(' ') || 'Untitled Contact';
+    const contactName =
+      [firstName, lastName].filter((s) => s.trim().length > 0).join(' ') ||
+      'Untitled Contact';
 
     const contactId = randomUUID();
     const contactNow = new Date();
 
-    await client.query(
-      `INSERT INTO records (id, tenant_id, object_id, name, field_values, owner_id, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-      [contactId, tenantId, contactObjectId, contactName, JSON.stringify(contactFieldValues), ownerId, contactNow, contactNow],
-    );
+    await trx
+      .insertInto('records')
+      .values({
+        id: contactId,
+        tenant_id: tenantId,
+        object_id: contactObjectId,
+        name: contactName,
+        field_values: JSON.stringify(contactFieldValues),
+        owner_id: ownerId,
+        created_at: contactNow,
+        updated_at: contactNow,
+      })
+      .execute();
 
     // Link contact to account via contact_account relationship
-    await linkRecordInTransaction(client, 'contact_account', contactId, accountId, tenantId);
+    await linkRecordInTransaction(trx, 'contact_account', contactId, accountId, tenantId);
 
     // 8. Create Opportunity (optional, default true)
     const createOpportunity = options.createOpportunity !== false;
@@ -189,11 +228,13 @@ export async function convertLead(
     let opportunityName: string | null = null;
 
     if (createOpportunity) {
-      const opportunityObjResult = await client.query(
-        'SELECT id FROM object_definitions WHERE api_name = $1 AND tenant_id = $2',
-        ['opportunity', tenantId],
-      );
-      const opportunityObjectId = (opportunityObjResult.rows[0] as Record<string, unknown>).id as string;
+      const opportunityObjRow = await trx
+        .selectFrom('object_definitions')
+        .select('id')
+        .where('api_name', '=', 'opportunity')
+        .where('tenant_id', '=', tenantId)
+        .executeTakeFirstOrThrow();
+      const opportunityObjectId = opportunityObjRow.id;
 
       const opportunityFieldValues = applyMappings(leadFieldValues, mappings, 'opportunity');
 
@@ -205,17 +246,25 @@ export async function convertLead(
       opportunityId = randomUUID();
       const oppNow = new Date();
 
-      await client.query(
-        `INSERT INTO records (id, tenant_id, object_id, name, field_values, owner_id, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [opportunityId, tenantId, opportunityObjectId, opportunityName, JSON.stringify(opportunityFieldValues), ownerId, oppNow, oppNow],
-      );
+      await trx
+        .insertInto('records')
+        .values({
+          id: opportunityId,
+          tenant_id: tenantId,
+          object_id: opportunityObjectId,
+          name: opportunityName,
+          field_values: JSON.stringify(opportunityFieldValues),
+          owner_id: ownerId,
+          created_at: oppNow,
+          updated_at: oppNow,
+        })
+        .execute();
 
       // Link opportunity to account
-      await linkRecordInTransaction(client, 'opportunity_account', opportunityId, accountId, tenantId);
+      await linkRecordInTransaction(trx, 'opportunity_account', opportunityId, accountId, tenantId);
 
       // Link opportunity to contact
-      await linkRecordInTransaction(client, 'opportunity_contact', opportunityId, contactId, tenantId);
+      await linkRecordInTransaction(trx, 'opportunity_contact', opportunityId, contactId, tenantId);
     }
 
     // 9. Update lead status to "Converted" with metadata
@@ -229,14 +278,16 @@ export async function convertLead(
       ...(opportunityId ? { converted_opportunity_id: opportunityId } : {}),
     };
 
-    await client.query(
-      `UPDATE records
-       SET field_values = $1, updated_at = $2
-       WHERE id = $3 AND object_id = $4 AND tenant_id = $5`,
-      [JSON.stringify(updatedFieldValues), new Date(), leadRecordId, leadObjectId, tenantId],
-    );
-
-    await client.query('COMMIT');
+    await trx
+      .updateTable('records')
+      .set({
+        field_values: JSON.stringify(updatedFieldValues),
+        updated_at: new Date(),
+      })
+      .where('id', '=', leadRecordId)
+      .where('object_id', '=', leadObjectId)
+      .where('tenant_id', '=', tenantId)
+      .execute();
 
     logger.info(
       { leadRecordId, accountId, contactId, opportunityId, ownerId },
@@ -246,35 +297,36 @@ export async function convertLead(
     return {
       account: { id: accountId, name: accountName },
       contact: { id: contactId, name: contactName },
-      opportunity: opportunityId && opportunityName
-        ? { id: opportunityId, name: opportunityName }
-        : null,
+      opportunity:
+        opportunityId && opportunityName
+          ? { id: opportunityId, name: opportunityName }
+          : null,
       lead: { id: leadRecordId, status: 'Converted' },
     };
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
-  }
+  });
 }
 
 /**
- * Creates a record_relationship within an existing transaction.
+ * Creates a record_relationship within an existing Kysely transaction.
+ *
+ * If the relationship definition isn't seeded yet, logs a warning and
+ * returns without inserting — matches the original raw-pg behaviour.
  */
 async function linkRecordInTransaction(
-  client: pg.PoolClient,
+  trx: DbExecutor,
   relationshipApiName: string,
   sourceRecordId: string,
   targetRecordId: string,
   tenantId: string,
 ): Promise<void> {
-  const relDefResult = await client.query(
-    'SELECT id FROM relationship_definitions WHERE api_name = $1 AND tenant_id = $2',
-    [relationshipApiName, tenantId],
-  );
+  const relDefRow = await trx
+    .selectFrom('relationship_definitions')
+    .select('id')
+    .where('api_name', '=', relationshipApiName)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (relDefResult.rows.length === 0) {
+  if (!relDefRow) {
     // Relationship not defined — skip silently (the system may not have it seeded yet)
     logger.warn(
       { relationshipApiName, sourceRecordId, targetRecordId },
@@ -283,13 +335,19 @@ async function linkRecordInTransaction(
     return;
   }
 
-  const relationshipId = (relDefResult.rows[0] as Record<string, unknown>).id as string;
+  const relationshipId = relDefRow.id;
   const linkId = randomUUID();
   const now = new Date();
 
-  await client.query(
-    `INSERT INTO record_relationships (id, tenant_id, relationship_id, source_record_id, target_record_id, created_at)
-     VALUES ($1, $2, $3, $4, $5, $6)`,
-    [linkId, tenantId, relationshipId, sourceRecordId, targetRecordId, now],
-  );
+  await trx
+    .insertInto('record_relationships')
+    .values({
+      id: linkId,
+      tenant_id: tenantId,
+      relationship_id: relationshipId,
+      source_record_id: sourceRecordId,
+      target_record_id: targetRecordId,
+      created_at: now,
+    })
+    .execute();
 }

--- a/apps/api/src/services/leadConversionService.ts
+++ b/apps/api/src/services/leadConversionService.ts
@@ -140,7 +140,10 @@ export async function convertLead(
       .select('id')
       .where('api_name', '=', 'account')
       .where('tenant_id', '=', tenantId)
-      .executeTakeFirstOrThrow();
+      .executeTakeFirst();
+    if (!accountObjRow) {
+      throwNotFoundError("Object type 'account' not found");
+    }
     const accountObjectId = accountObjRow.id;
 
     const contactObjRow = await trx
@@ -148,7 +151,10 @@ export async function convertLead(
       .select('id')
       .where('api_name', '=', 'contact')
       .where('tenant_id', '=', tenantId)
-      .executeTakeFirstOrThrow();
+      .executeTakeFirst();
+    if (!contactObjRow) {
+      throwNotFoundError("Object type 'contact' not found");
+    }
     const contactObjectId = contactObjRow.id;
 
     // 6. Create or link Account
@@ -233,7 +239,10 @@ export async function convertLead(
         .select('id')
         .where('api_name', '=', 'opportunity')
         .where('tenant_id', '=', tenantId)
-        .executeTakeFirstOrThrow();
+        .executeTakeFirst();
+      if (!opportunityObjRow) {
+        throwNotFoundError("Object type 'opportunity' not found");
+      }
       const opportunityObjectId = opportunityObjRow.id;
 
       const opportunityFieldValues = applyMappings(leadFieldValues, mappings, 'opportunity');

--- a/apps/api/src/services/salesTargetService.ts
+++ b/apps/api/src/services/salesTargetService.ts
@@ -188,11 +188,11 @@ export async function listTargets(
     .where('tenant_id', '=', tenantId);
 
   if (periodStart) {
-    query = query.where('period_start', '>=', new Date(periodStart));
+    query = query.where('period_start', '>=', sql<Date>`${periodStart}::date`);
   }
 
   if (periodEnd) {
-    query = query.where('period_end', '<=', new Date(periodEnd));
+    query = query.where('period_end', '<=', sql<Date>`${periodEnd}::date`);
   }
 
   const rows = await query
@@ -316,8 +316,8 @@ export async function getTargetSummary(
     .selectFrom('sales_targets')
     .selectAll()
     .where('tenant_id', '=', tenantId)
-    .where('period_start', '<=', new Date(defaultEnd))
-    .where('period_end', '>=', new Date(defaultStart))
+    .where('period_start', '<=', sql<Date>`${defaultEnd}::date`)
+    .where('period_end', '>=', sql<Date>`${defaultStart}::date`)
     .orderBy('target_type', 'asc')
     .execute();
 
@@ -459,8 +459,8 @@ export async function getUserTarget(
       .where('tenant_id', '=', tenantId)
       .where('target_type', '=', 'user')
       .where('target_entity_id', '=', userRecord.id)
-      .where('period_start', '<=', new Date(defaultEnd))
-      .where('period_end', '>=', new Date(defaultStart))
+      .where('period_start', '<=', sql<Date>`${defaultEnd}::date`)
+      .where('period_end', '>=', sql<Date>`${defaultStart}::date`)
       .limit(1)
       .executeTakeFirst();
     target = targetRow ? mapRow(targetRow) : undefined;
@@ -495,8 +495,8 @@ function mapRow(row: Selectable<SalesTargets>): SalesTarget {
     target_value: parseFloat(String(row.target_value)),
     currency: row.currency ?? 'GBP',
     created_by: row.created_by,
-    created_at: row.created_at == null ? '' : String(row.created_at),
-    updated_at: row.updated_at == null ? '' : String(row.updated_at),
+    created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
+    updated_at: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at ?? ''),
   };
 }
 

--- a/apps/api/src/services/salesTargetService.ts
+++ b/apps/api/src/services/salesTargetService.ts
@@ -1,4 +1,6 @@
-import { pool } from '../db/client.js';
+import { sql, type Selectable } from 'kysely';
+import { db } from '../db/kysely.js';
+import type { SalesTargets } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -142,31 +144,34 @@ export async function upsertTarget(
 ): Promise<SalesTarget> {
   validateTargetParams(params);
 
-  const result = await pool.query(
-    `INSERT INTO sales_targets (tenant_id, target_type, target_entity_id, period_type, period_start, period_end, target_value, currency, created_by)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-     ON CONFLICT (tenant_id, target_type, target_entity_id, period_start)
-     DO UPDATE SET
-       period_end = EXCLUDED.period_end,
-       target_value = EXCLUDED.target_value,
-       currency = EXCLUDED.currency,
-       period_type = EXCLUDED.period_type,
-       updated_at = NOW()
-     RETURNING *`,
-    [
-      tenantId,
-      params.targetType,
-      params.targetEntityId ?? null,
-      params.periodType,
-      params.periodStart,
-      params.periodEnd,
-      params.targetValue,
-      params.currency ?? 'GBP',
-      params.createdBy ?? null,
-    ],
-  );
+  const row = await db
+    .insertInto('sales_targets')
+    .values({
+      tenant_id: tenantId,
+      target_type: params.targetType,
+      target_entity_id: params.targetEntityId ?? null,
+      period_type: params.periodType,
+      period_start: params.periodStart,
+      period_end: params.periodEnd,
+      target_value: params.targetValue,
+      currency: params.currency ?? 'GBP',
+      created_by: params.createdBy ?? null,
+    })
+    .onConflict((oc) =>
+      oc
+        .columns(['tenant_id', 'target_type', 'target_entity_id', 'period_start'])
+        .doUpdateSet({
+          period_end: params.periodEnd,
+          target_value: params.targetValue,
+          currency: params.currency ?? 'GBP',
+          period_type: params.periodType,
+          updated_at: new Date(),
+        }),
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
-  return mapRow(result.rows[0]);
+  return mapRow(row);
 }
 
 /**
@@ -177,35 +182,39 @@ export async function listTargets(
   periodStart?: string,
   periodEnd?: string,
 ): Promise<SalesTarget[]> {
-  let query = 'SELECT * FROM sales_targets WHERE tenant_id = $1';
-  const queryParams: unknown[] = [tenantId];
+  let query = db
+    .selectFrom('sales_targets')
+    .selectAll()
+    .where('tenant_id', '=', tenantId);
 
   if (periodStart) {
-    queryParams.push(periodStart);
-    query += ` AND period_start >= $${queryParams.length}`;
+    query = query.where('period_start', '>=', new Date(periodStart));
   }
 
   if (periodEnd) {
-    queryParams.push(periodEnd);
-    query += ` AND period_end <= $${queryParams.length}`;
+    query = query.where('period_end', '<=', new Date(periodEnd));
   }
 
-  query += ' ORDER BY period_start DESC, target_type ASC';
+  const rows = await query
+    .orderBy('period_start', 'desc')
+    .orderBy('target_type', 'asc')
+    .execute();
 
-  const result = await pool.query(query, queryParams);
-  return result.rows.map(mapRow);
+  return rows.map(mapRow);
 }
 
 /**
  * Deletes a sales target by ID, scoped to tenant.
  */
 export async function deleteTarget(tenantId: string, targetId: string): Promise<void> {
-  const result = await pool.query(
-    'DELETE FROM sales_targets WHERE id = $1 AND tenant_id = $2',
-    [targetId, tenantId],
-  );
+  const result = await db
+    .deleteFrom('sales_targets')
+    .where('id', '=', targetId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (result.rowCount === 0) {
+  // Kysely returns DeleteResult with `numDeletedRows` as bigint.
+  if (result.numDeletedRows === 0n) {
     throw createServiceError('Target not found', 'NOT_FOUND');
   }
 }
@@ -215,6 +224,10 @@ export async function deleteTarget(tenantId: string, targetId: string): Promise<
 /**
  * Calculates the actual closed-won revenue for a given tenant and period.
  * Optionally scoped to a specific owner (user targets).
+ *
+ * Tenant defence-in-depth (ADR-006): every joined table is explicitly
+ * filtered on `tenant_id` so the query stays safe even if the pool-proxy
+ * RLS context is ever bypassed.
  */
 export async function calculateActual(
   tenantId: string,
@@ -222,28 +235,29 @@ export async function calculateActual(
   periodEnd: string,
   ownerId?: string,
 ): Promise<number> {
-  let query = `
-    SELECT COALESCE(SUM(
-      (r.field_values->>'value')::decimal
-    ), 0) as actual
-    FROM records r
-    JOIN object_definitions od ON r.object_id = od.id
-    JOIN stage_definitions sd ON r.current_stage_id = sd.id
-    WHERE od.api_name = 'opportunity'
-      AND r.tenant_id = $1
-      AND sd.stage_type = 'won'
-      AND r.updated_at >= $2
-      AND r.updated_at < $3`;
-
-  const queryParams: unknown[] = [tenantId, periodStart, periodEnd];
+  let query = db
+    .selectFrom('records as r')
+    .innerJoin('object_definitions as od', (join) =>
+      join.onRef('r.object_id', '=', 'od.id').on('od.tenant_id', '=', tenantId),
+    )
+    .innerJoin('stage_definitions as sd', (join) =>
+      join.onRef('r.current_stage_id', '=', 'sd.id').on('sd.tenant_id', '=', tenantId),
+    )
+    .where('r.tenant_id', '=', tenantId)
+    .where('od.api_name', '=', 'opportunity')
+    .where('sd.stage_type', '=', 'won')
+    .where('r.updated_at', '>=', new Date(periodStart))
+    .where('r.updated_at', '<', new Date(periodEnd))
+    .select(
+      sql<string>`COALESCE(SUM((r.field_values->>'value')::decimal), 0)`.as('actual'),
+    );
 
   if (ownerId) {
-    queryParams.push(ownerId);
-    query += ` AND r.owner_id = $${queryParams.length}`;
+    query = query.where('r.owner_id', '=', ownerId);
   }
 
-  const result = await pool.query(query, queryParams);
-  return parseFloat(result.rows[0]?.actual ?? '0');
+  const row = await query.executeTakeFirst();
+  return parseFloat(row?.actual ?? '0');
 }
 
 /**
@@ -298,16 +312,16 @@ export async function getTargetSummary(
   const periodLabel = formatPeriodLabel(defaultStart, defaultEnd);
 
   // Fetch all targets for this period
-  const targetsResult = await pool.query(
-    `SELECT * FROM sales_targets
-     WHERE tenant_id = $1
-       AND period_start <= $2
-       AND period_end >= $3
-     ORDER BY target_type ASC`,
-    [tenantId, defaultEnd, defaultStart],
-  );
+  const targetRows = await db
+    .selectFrom('sales_targets')
+    .selectAll()
+    .where('tenant_id', '=', tenantId)
+    .where('period_start', '<=', new Date(defaultEnd))
+    .where('period_end', '>=', new Date(defaultStart))
+    .orderBy('target_type', 'asc')
+    .execute();
 
-  const targets = targetsResult.rows.map(mapRow);
+  const targets = targetRows.map(mapRow);
 
   // Separate by type
   const businessTargets = targets.filter((t) => t.target_type === 'business');
@@ -323,7 +337,7 @@ export async function getTargetSummary(
 
   for (const teamTarget of teamTargets) {
     // Get team name from records
-    const teamName = await getRecordName(teamTarget.target_entity_id);
+    const teamName = await getRecordName(tenantId, teamTarget.target_entity_id);
 
     // Find user targets for this team
     const teamUsers = await getTeamUserTargets(
@@ -354,7 +368,7 @@ export async function getTargetSummary(
   if (standaloneUsers.length > 0) {
     const standaloneUserSummaries: UserTargetSummary[] = [];
     for (const ut of standaloneUsers) {
-      const userName = await getRecordName(ut.target_entity_id);
+      const userName = await getRecordName(tenantId, ut.target_entity_id);
       const userActual = await calculateActualForUserRecord(tenantId, ut.target_entity_id!, defaultStart, defaultEnd);
       standaloneUserSummaries.push({
         name: userName ?? 'Unknown User',
@@ -422,33 +436,34 @@ export async function getUserTarget(
   const defaultStart = periodStart ?? new Date(now.getFullYear(), currentQuarter * 3, 1).toISOString().split('T')[0];
   const defaultEnd = periodEnd ?? new Date(now.getFullYear(), currentQuarter * 3 + 3, 1).toISOString().split('T')[0];
 
-  // Find the user record by looking up records that have a descope_user_id matching userId
-  const userRecordResult = await pool.query(
-    `SELECT r.id, r.name FROM records r
-     JOIN object_definitions od ON r.object_id = od.id
-     WHERE od.api_name = 'user'
-       AND r.tenant_id = $1
-       AND r.field_values->>'descope_user_id' = $2
-     LIMIT 1`,
-    [tenantId, userId],
-  );
-
-  const userRecord = userRecordResult.rows[0] as { id: string; name: string } | undefined;
+  // Find the user record by looking up records that have a descope_user_id
+  // matching userId. Both sides of the JOIN are tenant-scoped.
+  const userRecord = await db
+    .selectFrom('records as r')
+    .innerJoin('object_definitions as od', (join) =>
+      join.onRef('r.object_id', '=', 'od.id').on('od.tenant_id', '=', tenantId),
+    )
+    .where('od.api_name', '=', 'user')
+    .where('r.tenant_id', '=', tenantId)
+    .where(sql<string>`r.field_values->>'descope_user_id'`, '=', userId)
+    .select(['r.id', 'r.name'])
+    .limit(1)
+    .executeTakeFirst();
 
   // Try to find a target using the user record ID
   let target: SalesTarget | undefined;
   if (userRecord) {
-    const targetResult = await pool.query(
-      `SELECT * FROM sales_targets
-       WHERE tenant_id = $1
-         AND target_type = 'user'
-         AND target_entity_id = $2
-         AND period_start <= $3
-         AND period_end >= $4
-       LIMIT 1`,
-      [tenantId, userRecord.id, defaultEnd, defaultStart],
-    );
-    target = targetResult.rows[0] ? mapRow(targetResult.rows[0]) : undefined;
+    const targetRow = await db
+      .selectFrom('sales_targets')
+      .selectAll()
+      .where('tenant_id', '=', tenantId)
+      .where('target_type', '=', 'user')
+      .where('target_entity_id', '=', userRecord.id)
+      .where('period_start', '<=', new Date(defaultEnd))
+      .where('period_end', '>=', new Date(defaultStart))
+      .limit(1)
+      .executeTakeFirst();
+    target = targetRow ? mapRow(targetRow) : undefined;
   }
 
   // Calculate actual using owner_id (Descope user ID on records)
@@ -468,20 +483,20 @@ export async function getUserTarget(
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-function mapRow(row: Record<string, unknown>): SalesTarget {
+function mapRow(row: Selectable<SalesTargets>): SalesTarget {
   return {
-    id: row.id as string,
-    tenant_id: row.tenant_id as string,
+    id: row.id,
+    tenant_id: row.tenant_id,
     target_type: row.target_type as SalesTarget['target_type'],
-    target_entity_id: (row.target_entity_id as string) ?? null,
+    target_entity_id: row.target_entity_id,
     period_type: row.period_type as SalesTarget['period_type'],
     period_start: formatDate(row.period_start),
     period_end: formatDate(row.period_end),
     target_value: parseFloat(String(row.target_value)),
-    currency: (row.currency as string) ?? 'GBP',
-    created_by: (row.created_by as string) ?? null,
-    created_at: String(row.created_at),
-    updated_at: String(row.updated_at),
+    currency: row.currency ?? 'GBP',
+    created_by: row.created_by,
+    created_at: row.created_at == null ? '' : String(row.created_at),
+    updated_at: row.updated_at == null ? '' : String(row.updated_at),
   };
 }
 
@@ -544,15 +559,27 @@ function inferPeriodType(start: string, end: string): string {
   return 'quarterly';
 }
 
-async function getRecordName(recordId: string | null): Promise<string | null> {
+/**
+ * Resolves a record's display name, scoped to the tenant.
+ *
+ * The original raw-SQL version accepted only `recordId` with no tenant_id
+ * filter — a latent defence-in-depth gap. The Kysely migration is the
+ * natural moment to pin this with an explicit tenant_id filter.
+ */
+async function getRecordName(
+  tenantId: string,
+  recordId: string | null,
+): Promise<string | null> {
   if (!recordId) return null;
 
-  const result = await pool.query(
-    'SELECT name FROM records WHERE id = $1',
-    [recordId],
-  );
+  const row = await db
+    .selectFrom('records')
+    .select('name')
+    .where('id', '=', recordId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  return (result.rows[0]?.name as string) ?? null;
+  return row?.name ?? null;
 }
 
 /**
@@ -566,16 +593,22 @@ async function calculateActualForUserRecord(
   periodStart: string,
   periodEnd: string,
 ): Promise<number> {
-  // Resolve descope_user_id from the user record
-  const userResult = await pool.query(
-    `SELECT r.field_values->>'descope_user_id' as descope_user_id
-     FROM records r
-     JOIN object_definitions od ON r.object_id = od.id
-     WHERE r.id = $1 AND od.api_name = 'user'`,
-    [userRecordId],
-  );
+  // Resolve descope_user_id from the user record. Both sides of the JOIN
+  // are tenant-scoped (defence-in-depth per ADR-006).
+  const userRow = await db
+    .selectFrom('records as r')
+    .innerJoin('object_definitions as od', (join) =>
+      join.onRef('r.object_id', '=', 'od.id').on('od.tenant_id', '=', tenantId),
+    )
+    .where('r.id', '=', userRecordId)
+    .where('r.tenant_id', '=', tenantId)
+    .where('od.api_name', '=', 'user')
+    .select(
+      sql<string | null>`r.field_values->>'descope_user_id'`.as('descope_user_id'),
+    )
+    .executeTakeFirst();
 
-  const descopeUserId = userResult.rows[0]?.descope_user_id as string | undefined;
+  const descopeUserId = userRow?.descope_user_id ?? undefined;
   if (!descopeUserId) {
     return 0;
   }
@@ -594,23 +627,29 @@ async function getTeamUserTargets(
   periodStart: string,
   periodEnd: string,
 ): Promise<UserTargetSummary[]> {
-  // Find user records that belong to this team
-  const teamUsersResult = await pool.query(
-    `SELECT r.id, r.name, r.field_values->>'descope_user_id' as descope_user_id
-     FROM records r
-     JOIN object_definitions od ON r.object_id = od.id
-     WHERE od.api_name = 'user'
-       AND r.tenant_id = $1
-       AND r.field_values->>'team_id' = $2`,
-    [tenantId, teamRecordId],
-  );
+  // Find user records that belong to this team. Both sides of the JOIN
+  // are tenant-scoped (defence-in-depth per ADR-006).
+  const teamUsers = await db
+    .selectFrom('records as r')
+    .innerJoin('object_definitions as od', (join) =>
+      join.onRef('r.object_id', '=', 'od.id').on('od.tenant_id', '=', tenantId),
+    )
+    .where('od.api_name', '=', 'user')
+    .where('r.tenant_id', '=', tenantId)
+    .where(sql<string>`r.field_values->>'team_id'`, '=', teamRecordId)
+    .select([
+      'r.id',
+      'r.name',
+      sql<string | null>`r.field_values->>'descope_user_id'`.as('descope_user_id'),
+    ])
+    .execute();
 
   const userSummaries: UserTargetSummary[] = [];
 
-  for (const userRow of teamUsersResult.rows) {
-    const userRecordId = userRow.id as string;
-    const userName = userRow.name as string;
-    const descopeUserId = userRow.descope_user_id as string | undefined;
+  for (const userRow of teamUsers) {
+    const userRecordId = userRow.id;
+    const userName = userRow.name;
+    const descopeUserId = userRow.descope_user_id ?? undefined;
 
     // Find the matching target
     const userTarget = allUserTargets.find(


### PR DESCRIPTION
## Summary

Bundled PR covering **PR 1 and PR 2 of Group D** (the original plan had them landing separately; I pushed the second commit to the same branch before #464 merged, so they ship together). Both services are migrated to typed Kysely query builders. `leadConversionService` is straightforward behavioural parity; `salesTargetService` uses the migration to close five latent tenant_id defence-in-depth gaps.

## `leadConversionService.ts`
- Entire `convertLead` body moves into a `db.transaction().execute(async (trx) => { ... })` closure. BEGIN/COMMIT/ROLLBACK is now managed by Kysely; manual `client.connect`/`release` is gone. Because the raw-pg version already ran inside an explicit envelope, the migration collapses cleanly — no raw-client escape hatch needed (unlike `tenantProvisioning` #463 which is still waiting on `seedDefaultObjects`).
- `linkRecordInTransaction` is retyped to take a `Kysely<DB>` executor alias instead of `pg.PoolClient`; the `pg` type import is dropped.
- `executeTakeFirstOrThrow()` is used for the account/contact/opportunity object lookups so the pre-existing latent failure mode (if those objects aren't seeded) surfaces as a Kysely `NoResultError` rather than a TypeError from the old `rows[0].id` destructure.
- Every SELECT/INSERT/UPDATE already carried an explicit `tenant_id` filter; that's preserved.

### `leadConversionService.kysely-sql.test.ts` (new)
SQL regression suite (8 assertions, 5 describe blocks) pinning:
- The entire conversion runs inside exactly one BEGIN/COMMIT on one transactional client (isolated from Kysely's proxy-pool validation client by a per-client bookkeeping helper).
- Every data query runs on that same transactional client.
- Every query carries an explicit `tenant_id` filter + bind.
- `INSERT INTO records` binds all 8 columns in declared order, with `field_values` at param index 4 (JSON string).
- `createOpportunity: false` skips the opportunity INSERT.
- Each relationship link emits a `relationship_definitions` SELECT followed by a `record_relationships` INSERT.
- The final `UPDATE records` has `field_values + updated_at` in its SET clause and `id/object_id/tenant_id` in the WHERE clause.
- A simulated INSERT failure triggers `ROLLBACK` and no `COMMIT`.

Failure injection uses a module-scoped `setFailOnFirstInsert` flag inside `vi.hoisted` rather than `mockImplementationOnce` — the latter pattern leaks unused stubs into the next test when Kysely's proxy-pool acquires more clients than the test expects. Flagged in the tracker retrospective notes.

## `salesTargetService.ts`

### Latent tenant_id defence-in-depth gaps closed by this migration
- `getRecordName` previously ran `SELECT name FROM records WHERE id = $1` with **no** tenant_id filter at all — RLS was the only line of defence. Now takes a `tenantId` parameter and scopes the SELECT on both `id` and `tenant_id`.
- `calculateActual` JOINs `object_definitions` and `stage_definitions`; previously only `r.tenant_id` was filtered. The ON clauses now explicitly pin `od.tenant_id` and `sd.tenant_id`.
- `calculateActualForUserRecord` resolves `descope_user_id` from a user record; the resolving SELECT is now scoped on `r.tenant_id` and `od.tenant_id` (JOIN).
- `getTeamUserTargets` picks up team users via a JOINed SELECT; now scopes `od.tenant_id` on the JOIN in addition to `r.tenant_id`.
- `getUserTarget` looks up the user record via a JOINed SELECT; now scopes `od.tenant_id` on the JOIN in addition to `r.tenant_id`.

### Query-builder patterns
- `upsertTarget` uses `.onConflict((oc) => oc.columns([...]).doUpdateSet({...}))` for the upsert, returning the row via `.returningAll().executeTakeFirstOrThrow()`.
- JSONB lookups on `field_values->>'descope_user_id'` and `field_values->>'team_id'` follow the ADR-006 Appendix A pattern: column reference written via a `sql<string>` template tag so Kysely binds the value as a parameter rather than inlining it.
- `calculateActual` uses `.innerJoin()` with a callback that chains `onRef()` + `on()` so the ON-clause tenant filter lands inside the JOIN.
- `deleteTarget` reads `result.numDeletedRows === 0n` (Kysely's bigint return shape) instead of `result.rowCount === 0`.
- `mapRow` is typed against `Selectable<SalesTargets>` so the row contract is pinned at compile time.
- pg DATE columns accept `Date` in Kysely where-clauses; `new Date(isoString)` is used at the boundary (Kysely's `Timestamp` select-side type is `Date`, so string literals don't type-check against `where('period_start', '>=', ...)`).

### `salesTargetService.kysely-sql.test.ts` (new)
Regression suite (9 assertions, 5 describe blocks) asserting directly on compiled SQL:
- `upsertTarget` emits `INSERT INTO sales_targets ... ON CONFLICT ... DO UPDATE SET ... RETURNING`, with 9 column binds in declared order.
- `listTargets` scopes `tenant_id` with no period filters by default; appends both filters + `ORDER BY period_start DESC, target_type ASC` when supplied.
- `deleteTarget` emits `DELETE` scoped by `id AND tenant_id`.
- `calculateActual` pins all three tenant_id filters (r/od/sd) plus the optional `r.owner_id` bind.
- `getUserTarget` JSONB lookup binds `descope_user_id` as a parameter and scopes both `r.tenant_id` and `od.tenant_id` on the JOIN.
- A pin on the **no-BEGIN/COMMIT** envelope contract so a future "let's wrap everything in a transaction" refactor shows up as a deliberate SQL-level change.

### `salesTargetService.test.ts` (updated)
- Dispatcher normalises both `client.query(sql, params)` and Kysely's `client.query({ text, values })` call shapes via a shared `normaliseCall()` helper.
- Quote stripping on the SQL matcher (`.replace(/"/g, '')`) so Kysely's quoted identifiers match.
- `passes owner_id when provided` now walks a `clientCalls` array captured inside `mockConnect` rather than `mockQuery.mock.calls` — Kysely routes SELECTs through `pool.connect()`, not `pool.query`.

## Test plan

- [x] `npx vitest run src/services/__tests__/leadConversionService` — 19 tests (11 behavioural + 8 SQL regression)
- [x] `npx vitest run src/services/__tests__/salesTargetService` — 30 tests (21 behavioural + 9 SQL regression)
- [x] `npx vitest run` — 75 files, 1496 tests passing (+17 new assertions across the two services)
- [x] `npx tsc --noEmit` — clean

Part of #445 (Phase 3b, Group D). Remaining Group D PRs:
- **PR 3** — `layoutDefinitionService.ts` + `pageLayoutService.ts` (layout pair, ~1252 lines combined)
- **PR 4** — `seedDefaultObjects.ts` (1109 lines; unlocks dropping the raw-client escape hatch in `tenantProvisioning`)

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf