### PR TITLE
Migrate layoutDefinitionService + pageLayoutService to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/layoutDefinitionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/layoutDefinitionService.kysely-sql.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Kysely SQL regression suite for layoutDefinitionService.
+ *
+ * Pins the SQL Kysely emits so drift is caught early. Key things verified:
+ *
+ *   1. fetchLayoutFields JOIN carries fd.tenant_id ON clause +
+ *      lf.tenant_id WHERE filter (closes previously-latent gap).
+ *   2. INSERT INTO layout_fields includes tenant_id column
+ *      (fixes latent production bug — column is NOT NULL, no default).
+ *   3. DELETE layout_definitions scoped by id + tenant_id (was just id).
+ *   4. DELETE layout_fields scoped by layout_id + tenant_id.
+ *   5. Every data query carries a tenant_id bind.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+
+  function norm(rawSql: string): string {
+    return rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = norm(rawSql);
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
+
+    // object_definitions existence check
+    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS')) {
+      return { rows: [{ id: params[0] }] };
+    }
+
+    // Uniqueness check for layout name
+    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS') && s.includes('NAME =')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO layout_definitions
+    if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
+      const [id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params;
+      return {
+        rows: [{
+          id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at,
+        }],
+      };
+    }
+
+    // SELECT * FROM layout_definitions (list or getById)
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT')) {
+      return {
+        rows: [{
+          id: 'layout-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default Form', layout_type: 'form', is_default: false,
+          created_at: new Date(), updated_at: new Date(),
+        }],
+      };
+    }
+
+    // fetchLayoutFields JOIN query
+    if (s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS')) {
+      return { rows: [] };
+    }
+
+    // SELECT id FROM field_definitions (setLayoutFields validation)
+    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS')) {
+      return { rows: [{ id: 'field-1' }] };
+    }
+
+    // DELETE FROM layout_fields
+    if (s.startsWith('DELETE FROM LAYOUT_FIELDS')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO layout_fields
+    if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
+      return { rows: [{}] };
+    }
+
+    // UPDATE layout_definitions
+    if (s.startsWith('UPDATE LAYOUT_DEFINITIONS')) {
+      return {
+        rows: [{
+          id: 'layout-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Updated', layout_type: 'form', is_default: false,
+          created_at: new Date(), updated_at: new Date(),
+        }],
+      };
+    }
+
+    // DELETE FROM layout_definitions
+    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS')) {
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+  }
+
+  return { capturedQueries, mockQuery, mockConnect, resetCapture };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createLayoutDefinition,
+  getLayoutDefinitionById,
+  setLayoutFields,
+  deleteLayoutDefinition,
+} = await import('../layoutDefinitionService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('layoutDefinitionService Kysely SQL — createLayoutDefinition', () => {
+  it('INSERT carries tenant_id and returns all columns', async () => {
+    await createLayoutDefinition(TENANT_ID, 'obj-1', {
+      name: 'Detail View',
+      layoutType: 'detail',
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO LAYOUT_DEFINITIONS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('RETURNING');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('Detail View');
+    expect(insert.params).toContain('detail');
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — fetchLayoutFields tenant_id defence', () => {
+  it('JOIN ON carries fd.tenant_id and WHERE carries lf.tenant_id', async () => {
+    await getLayoutDefinitionById(TENANT_ID, 'obj-1', 'layout-1');
+
+    const joinQuery = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS');
+    })!;
+    const s = normalise(joinQuery.sql);
+
+    expect(s).toMatch(/JOIN FIELD_DEFINITIONS AS FD ON FD\.ID = LF\.FIELD_ID AND FD\.TENANT_ID =/);
+    expect(s).toContain('LF.TENANT_ID =');
+    expect(s).toContain('LF.LAYOUT_ID =');
+
+    const tenantCount = joinQuery.params.filter((p) => p === TENANT_ID).length;
+    expect(tenantCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — setLayoutFields', () => {
+  it('INSERT INTO layout_fields includes tenant_id column', async () => {
+    await setLayoutFields(TENANT_ID, 'obj-1', 'layout-1', [
+      { label: 'Info', fields: [{ fieldId: 'field-1', width: 'half' }] },
+    ]);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO LAYOUT_FIELDS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    const s = normalise(inserts[0].sql);
+    expect(s).toContain('TENANT_ID');
+    expect(inserts[0].params).toContain(TENANT_ID);
+  });
+
+  it('DELETE FROM layout_fields scoped by layout_id + tenant_id', async () => {
+    await setLayoutFields(TENANT_ID, 'obj-1', 'layout-1', [
+      { label: 'Info', fields: [{ fieldId: 'field-1' }] },
+    ]);
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM LAYOUT_FIELDS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('LAYOUT_ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — deleteLayoutDefinition', () => {
+  it('DELETE scoped by id + tenant_id', async () => {
+    await deleteLayoutDefinition(TENANT_ID, 'obj-1', 'layout-1');
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM LAYOUT_DEFINITIONS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+    expect(del.params).toContain('layout-1');
+  });
+});

--- a/apps/api/src/services/__tests__/layoutDefinitionService.test.ts
+++ b/apps/api/src/services/__tests__/layoutDefinitionService.test.ts
@@ -18,41 +18,42 @@ vi.mock('../../lib/logger.js', () => ({
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
 
-const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi.hoisted(() => {
+const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery, mockConnect } = vi.hoisted(() => {
   const fakeObjects = new Map<string, Record<string, unknown>>();
   const fakeLayouts = new Map<string, Record<string, unknown>>();
   const fakeLayoutFields = new Map<string, Record<string, unknown>>();
   const fakeFields = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
 
     // SELECT id FROM object_definitions WHERE id = $1
     if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
-      const id = params![0] as string;
+      const id = params[0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
       return { rows: [] };
     }
 
-    // SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2
-    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID = $1 AND NAME = $2') && !s.includes('ID != $3')) {
-      const objectId = params![0] as string;
-      const name = params![1] as string;
+    // SELECT id FROM layout_definitions WHERE object_id AND name (uniqueness check)
+    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS') && s.includes('NAME =')) {
+      const hasExclude = s.includes('ID !=');
+      const objectId = params[0] as string;
+      const name = params[1] as string;
+      const excludeId = hasExclude ? (params[2] as string) : null;
       const match = [...fakeLayouts.values()].find(
-        (l) => l.object_id === objectId && l.name === name,
-      );
-      if (match) return { rows: [{ id: match.id }] };
-      return { rows: [] };
-    }
-
-    // SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND id != $3
-    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID = $1 AND NAME = $2 AND ID != $3')) {
-      const objectId = params![0] as string;
-      const name = params![1] as string;
-      const excludeId = params![2] as string;
-      const match = [...fakeLayouts.values()].find(
-        (l) => l.object_id === objectId && l.name === name && l.id !== excludeId,
+        (l) => l.object_id === objectId && l.name === name && (excludeId ? l.id !== excludeId : true),
       );
       if (match) return { rows: [{ id: match.id }] };
       return { rows: [] };
@@ -60,7 +61,7 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
 
     // INSERT INTO layout_definitions
     if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
-      const [id, _tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params as unknown[];
+      const [id, _tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params;
       const row: Record<string, unknown> = {
         id, object_id, name, layout_type, is_default, created_at, updated_at,
       };
@@ -68,9 +69,9 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
       return { rows: [row] };
     }
 
-    // SELECT * FROM layout_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY
-    if (s.startsWith('SELECT * FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID') && s.includes('ORDER BY')) {
-      const objectId = params![0] as string;
+    // SELECT * FROM layout_definitions ... ORDER BY (list)
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      const objectId = params[0] as string;
       const rows = [...fakeLayouts.values()]
         .filter((l) => l.object_id === objectId)
         .sort((a, b) => {
@@ -82,17 +83,29 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
     }
 
     // SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2
-    if (s.startsWith('SELECT * FROM LAYOUT_DEFINITIONS WHERE ID = $1 AND OBJECT_ID')) {
-      const layoutId = params![0] as string;
-      const objectId = params![1] as string;
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT') && s.includes('ID =') && s.includes('OBJECT_ID =')) {
+      const layoutId = params[0] as string;
+      const objectId = params[1] as string;
       const match = fakeLayouts.get(layoutId);
       if (match && match.object_id === objectId) return { rows: [match] };
       return { rows: [] };
     }
 
     // SELECT lf.*, fd.api_name ... FROM layout_fields lf JOIN field_definitions fd
-    if (s.includes('FROM LAYOUT_FIELDS LF') && s.includes('JOIN FIELD_DEFINITIONS FD')) {
-      const layoutId = params![0] as string;
+    if (s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS')) {
+      // Under Kysely, the tenant_id params come before the layout_id param.
+      // Walk params to find a value that matches a known layout_id.
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayoutFields.size > 0) {
+          const hasMatch = [...fakeLayoutFields.values()].some((lf) => lf.layout_id === p);
+          if (hasMatch) { layoutId = p; break; }
+        }
+      }
+      if (!layoutId) {
+        // Fallback: any param that's not the tenant_id
+        layoutId = (params.find((p) => p !== 'test-tenant-001') as string) ?? '';
+      }
       const rows = [...fakeLayoutFields.values()]
         .filter((lf) => lf.layout_id === layoutId)
         .sort((a, b) => {
@@ -114,79 +127,108 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
       return { rows };
     }
 
-    // UPDATE layout_definitions SET ... (general update)
+    // UPDATE layout_definitions SET ... RETURNING
     if (s.startsWith('UPDATE LAYOUT_DEFINITIONS SET') && s.includes('RETURNING')) {
-      // The layout_id and object_id are the last two params
-      const layoutId = params![params!.length - 2] as string;
-      const objectId = params![params!.length - 1] as string;
-      const layout = fakeLayouts.get(layoutId);
-      if (layout && layout.object_id === objectId) {
+      // Find the layout_id from WHERE params — it's the first UUID-looking
+      // param after all the SET params. Walk from the end of the params:
+      // the last few are WHERE clause values.
+      // Under Kysely: SET name=$1, updated_at=$2 WHERE id=$3 AND object_id=$4 AND tenant_id=$5
+      // We need the id from the WHERE. Find it by searching fakeLayouts.
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          layoutId = p;
+          break;
+        }
+      }
+      const layout = layoutId ? fakeLayouts.get(layoutId) : undefined;
+      if (layout) {
         const updated: Record<string, unknown> = { ...layout, updated_at: new Date() };
         let paramIdx = 0;
-        if (s.includes('NAME =')) { updated.name = params![paramIdx++]; }
-        if (s.includes('LAYOUT_TYPE =')) { updated.layout_type = params![paramIdx++]; }
-        fakeLayouts.set(layoutId, updated);
+        if (s.includes('NAME =')) { updated.name = params[paramIdx++]; }
+        if (s.includes('LAYOUT_TYPE =')) { updated.layout_type = params[paramIdx++]; }
+        fakeLayouts.set(layoutId!, updated);
         return { rows: [updated] };
       }
       return { rows: [] };
     }
 
-    // UPDATE layout_definitions SET updated_at = $1 WHERE id = $2 (timestamp only)
+    // UPDATE layout_definitions SET updated_at (timestamp only, no RETURNING)
     if (s.startsWith('UPDATE LAYOUT_DEFINITIONS SET UPDATED_AT') && !s.includes('RETURNING')) {
-      const updatedAt = params![0];
-      const layoutId = params![1] as string;
-      const layout = fakeLayouts.get(layoutId);
-      if (layout) {
-        layout.updated_at = updatedAt;
+      const updatedAt = params[0];
+      // Find layout_id in remaining params
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          fakeLayouts.get(p)!.updated_at = updatedAt;
+          break;
+        }
       }
       return { rows: [] };
     }
 
-    // SELECT id FROM field_definitions WHERE object_id = $1 (for field validation)
-    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS WHERE OBJECT_ID')) {
-      const objectId = params![0] as string;
+    // SELECT id FROM field_definitions WHERE object_id = $1
+    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS')) {
+      const objectId = params[0] as string;
       const rows = [...fakeFields.values()]
         .filter((f) => f.object_id === objectId)
         .map((f) => ({ id: f.id }));
       return { rows };
     }
 
-    // DELETE FROM layout_fields WHERE layout_id = $1
-    if (s.startsWith('DELETE FROM LAYOUT_FIELDS WHERE LAYOUT_ID')) {
-      const layoutId = params![0] as string;
+    // DELETE FROM layout_fields
+    if (s.startsWith('DELETE FROM LAYOUT_FIELDS')) {
+      const layoutId = params[0] as string;
       for (const [key, lf] of fakeLayoutFields.entries()) {
         if (lf.layout_id === layoutId) fakeLayoutFields.delete(key);
       }
       return { rows: [] };
     }
 
-    // INSERT INTO layout_fields
+    // INSERT INTO layout_fields — columns: id, tenant_id, layout_id,
+    // field_id, section, section_label, sort_order, width (8 params)
     if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
-      const [id, layout_id, field_id, section, section_label, sort_order, width] = params as unknown[];
+      const [id, _tenant_id, layout_id, field_id, section, section_label, sort_order, width] = params;
       const row: Record<string, unknown> = { id, layout_id, field_id, section, section_label, sort_order, width };
       fakeLayoutFields.set(id as string, row);
       return { rows: [row] };
     }
 
-    // DELETE FROM layout_definitions WHERE id = $1
-    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS WHERE ID')) {
-      const layoutId = params![0] as string;
-      fakeLayouts.delete(layoutId);
-      // Also clean up layout_fields
-      for (const [key, lf] of fakeLayoutFields.entries()) {
-        if (lf.layout_id === layoutId) fakeLayoutFields.delete(key);
+    // DELETE FROM layout_definitions
+    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS')) {
+      // Find the layout_id param
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          fakeLayouts.delete(p);
+          for (const [key, lf] of fakeLayoutFields.entries()) {
+            if (lf.layout_id === p) fakeLayoutFields.delete(key);
+          }
+          break;
+        }
       }
       return { rows: [] };
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  return { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Test helpers ────────────────────────────────────────────────────────────

--- a/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
@@ -280,13 +280,14 @@ describe('pageLayoutService Kysely SQL — publishPageLayout', () => {
     )!;
     const s = normalise(update.sql);
 
-    expect(s).toContain('PUBLISHED_LAYOUT =');
+    expect(s).toContain('PUBLISHED_LAYOUT = LAYOUT');
     expect(s).toContain('VERSION =');
     expect(s).toContain('STATUS =');
     expect(s).toContain('PUBLISHED_AT =');
     expect(s).toContain('UPDATED_AT =');
     expect(s).toContain('RETURNING');
     expect(update.params).toContain(TENANT_ID);
+    expect(update.params.find((p) => typeof p === 'object' && p !== null && !(p instanceof Date))).toBeUndefined();
   });
 
   it('INSERT INTO page_layout_versions carries tenant_id and version', async () => {

--- a/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Kysely SQL regression suite for pageLayoutService.
+ *
+ * Pins the SQL Kysely emits so drift is caught early. Key things verified:
+ *
+ *   1. publishPageLayout uses db.transaction() — no manual BEGIN/COMMIT
+ *      envelope; instead UPDATE + INSERT version run inside a Kysely
+ *      transaction (the driver wraps them in BEGIN/COMMIT).
+ *   2. Conflict check uses IS NULL for null role (no parameter binding).
+ *   3. DELETE scoped by id + tenant_id.
+ *   4. Every data query carries a tenant_id bind.
+ *   5. UPDATE + INSERT version within publish carry correct column sets.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+
+  function norm(rawSql: string): string {
+    return rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  const VALID_LAYOUT = JSON.stringify({
+    header: { primaryField: 'name' },
+    tabs: [{ id: 't1', label: 'Tab', sections: [] }],
+  });
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = norm(rawSql);
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
+
+    // object_definitions existence check
+    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS')) {
+      return { rows: [{ id: params[0] }] };
+    }
+
+    // Conflict check for page_layouts
+    if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO page_layout_versions
+    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
+      return { rows: [{}] };
+    }
+
+    // INSERT INTO page_layouts
+    if (s.startsWith('INSERT INTO PAGE_LAYOUTS')) {
+      const [id, tenant_id, object_id, name, role, is_default, layout, version, status, created_at, updated_at] = params as unknown[];
+      return {
+        rows: [{
+          id, tenant_id, object_id, name, role, is_default,
+          layout, published_layout: null, version, status,
+          created_at, updated_at, published_at: null,
+        }],
+      };
+    }
+
+    // SELECT * FROM page_layouts ... ORDER BY (list)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      return { rows: [] };
+    }
+
+    // SELECT from page_layouts by id (getById / existence)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT')) {
+      return {
+        rows: [{
+          id: 'pl-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default', role: null, is_default: false,
+          layout: VALID_LAYOUT, published_layout: null,
+          version: 1, status: 'draft',
+          created_at: new Date(), updated_at: new Date(), published_at: null,
+        }],
+      };
+    }
+
+    // UPDATE page_layouts
+    if (s.startsWith('UPDATE PAGE_LAYOUTS')) {
+      return {
+        rows: [{
+          id: 'pl-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default', role: null, is_default: false,
+          layout: VALID_LAYOUT, published_layout: VALID_LAYOUT,
+          version: 2, status: 'published',
+          created_at: new Date(), updated_at: new Date(), published_at: new Date(),
+        }],
+      };
+    }
+
+    // DELETE FROM page_layouts
+    if (s.startsWith('DELETE FROM PAGE_LAYOUTS')) {
+      return { rows: [] };
+    }
+
+    // SELECT from page_layout_versions
+    if (s.includes('FROM PAGE_LAYOUT_VERSIONS')) {
+      return {
+        rows: [{
+          id: 'v-1', layout_id: 'pl-1', tenant_id: TENANT_ID,
+          version: 1, layout: VALID_LAYOUT,
+          published_by: 'user-1', published_at: new Date(),
+        }],
+      };
+    }
+
+    return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+  }
+
+  return { capturedQueries, mockQuery, mockConnect, resetCapture };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createPageLayout,
+  publishPageLayout,
+  deletePageLayout,
+  updatePageLayout,
+  listPageLayouts,
+} = await import('../pageLayoutService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+function allQueries(): CapturedQuery[] {
+  return capturedQueries;
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const VALID_LAYOUT_JSON = {
+  header: { primaryField: 'name', secondaryFields: ['stage'], actions: ['edit'] },
+  tabs: [{
+    id: 'tab-1', label: 'Details',
+    sections: [{
+      id: 'sec-1', type: 'field_section', label: 'Info', columns: 2,
+      components: [{ id: 'comp-1', type: 'field', config: { fieldId: 'uuid-1', span: 1 } }],
+    }],
+  }],
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pageLayoutService Kysely SQL — createPageLayout', () => {
+  it('conflict check uses IS NULL for null role (no param binding)', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Default Page',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const conflictCheck = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID');
+    })!;
+    const s = normalise(conflictCheck.sql);
+
+    expect(s).toContain('ROLE IS NULL');
+    expect(conflictCheck.params).toContain(TENANT_ID);
+    expect(conflictCheck.params).toContain('obj-1');
+    expect(conflictCheck.params).not.toContainEqual(null);
+  });
+
+  it('conflict check binds role as parameter for non-null role', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Admin Page',
+      role: 'admin',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const conflictCheck = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID');
+    })!;
+    const s = normalise(conflictCheck.sql);
+
+    expect(s).toContain('ROLE =');
+    expect(s).not.toContain('IS NULL');
+    expect(conflictCheck.params).toContain('admin');
+  });
+
+  it('INSERT carries tenant_id and JSON-stringified layout', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Default Page',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO PAGE_LAYOUTS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('RETURNING');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('Default Page');
+    const layoutParam = insert.params.find((p) => typeof p === 'string' && p.includes('primaryField'));
+    expect(layoutParam).toBeDefined();
+  });
+});
+
+describe('pageLayoutService Kysely SQL — publishPageLayout', () => {
+  it('wraps UPDATE + INSERT version in a Kysely transaction (BEGIN/COMMIT present)', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const raw = allQueries().map((q) => normalise(q.sql));
+    expect(raw).toContain('BEGIN');
+    expect(raw).toContain('COMMIT');
+
+    const beginIdx = raw.indexOf('BEGIN');
+    const commitIdx = raw.indexOf('COMMIT');
+    expect(beginIdx).toBeLessThan(commitIdx);
+  });
+
+  it('UPDATE sets published_layout, version, status, published_at, updated_at', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const update = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE PAGE_LAYOUTS SET'),
+    )!;
+    const s = normalise(update.sql);
+
+    expect(s).toContain('PUBLISHED_LAYOUT =');
+    expect(s).toContain('VERSION =');
+    expect(s).toContain('STATUS =');
+    expect(s).toContain('PUBLISHED_AT =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).toContain('RETURNING');
+    expect(update.params).toContain(TENANT_ID);
+  });
+
+  it('INSERT INTO page_layout_versions carries tenant_id and version', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('LAYOUT_ID');
+    expect(s).toContain('VERSION');
+    expect(s).toContain('PUBLISHED_BY');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('pl-1');
+    expect(insert.params).toContain('user-123');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — deletePageLayout', () => {
+  it('DELETE scoped by id + tenant_id', async () => {
+    await deletePageLayout(TENANT_ID, 'obj-1', 'pl-1');
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM PAGE_LAYOUTS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+    expect(del.params).toContain('pl-1');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — updatePageLayout', () => {
+  it('UPDATE carries tenant_id in WHERE and RETURNING', async () => {
+    await updatePageLayout(TENANT_ID, 'obj-1', 'pl-1', { name: 'Renamed' });
+
+    const update = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE PAGE_LAYOUTS SET'),
+    )!;
+    const s = normalise(update.sql);
+
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('RETURNING');
+    expect(update.params).toContain(TENANT_ID);
+    expect(update.params).toContain('Renamed');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — listPageLayouts', () => {
+  it('SELECT ordered by name with tenant_id + object_id filter', async () => {
+    await listPageLayouts(TENANT_ID, 'obj-1');
+
+    const select = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM PAGE_LAYOUTS') && s.includes('ORDER BY');
+    })!;
+    const s = normalise(select.sql);
+
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('OBJECT_ID =');
+    expect(s).toMatch(/ORDER BY NAME/);
+    expect(select.params).toContain(TENANT_ID);
+    expect(select.params).toContain('obj-1');
+  });
+});

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -26,12 +26,23 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
   const fakePageLayouts = new Map<string, Record<string, unknown>>();
   const fakePageLayoutVersions = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
 
     // SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2
     if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
-      const id = params![0] as string;
+      const id = params[0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
       return { rows: [] };
@@ -39,10 +50,20 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
 
     // SELECT id FROM page_layouts WHERE tenant_id = ... (conflict check)
     if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID')) {
-      const tenantId = params![0] as string;
-      const objectId = params![1] as string;
-      const role = params!.length > 2 ? (params![2] as string) : null;
-      const excludeId = s.includes('ID !=') ? (params![2] as string) : undefined;
+      const tenantId = params[0] as string;
+      const objectId = params[1] as string;
+      const hasExclude = s.includes('ID !=');
+      const isNullRole = s.includes('IS NULL');
+
+      let excludeId: string | undefined;
+      let role: string | null;
+
+      if (hasExclude) {
+        excludeId = params[2] as string;
+        role = isNullRole ? null : (params[3] as string);
+      } else {
+        role = isNullRole ? null : (params[2] as string);
+      }
 
       const match = [...fakePageLayouts.values()].find((l) => {
         if (l.tenant_id !== tenantId || l.object_id !== objectId) return false;
@@ -54,6 +75,35 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       if (match) return { rows: [{ id: match.id }] };
       return { rows: [] };
     }
+
+    // ── page_layout_versions (more specific, must precede page_layouts) ──
+
+    // INSERT INTO page_layout_versions
+    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
+      const [id, layout_id, tenant_id, version, layout, published_by, published_at] = params as unknown[];
+      const row: Record<string, unknown> = {
+        id, layout_id, tenant_id, version, layout, published_by, published_at,
+      };
+      fakePageLayoutVersions.set(id as string, row);
+      return { rows: [row] };
+    }
+
+    // SELECT * FROM page_layout_versions
+    if (s.includes('FROM PAGE_LAYOUT_VERSIONS') && s.startsWith('SELECT')) {
+      const layoutId = params[0] as string;
+      const tenantId = params[1] as string;
+      const version = params.length > 2 ? (params[2] as number) : undefined;
+      const rows = [...fakePageLayoutVersions.values()]
+        .filter((v) => {
+          if (v.layout_id !== layoutId || v.tenant_id !== tenantId) return false;
+          if (version !== undefined) return v.version === version;
+          return true;
+        })
+        .sort((a, b) => (b.version as number) - (a.version as number));
+      return { rows };
+    }
+
+    // ── page_layouts ─────────────────────────────────────────────────────
 
     // INSERT INTO page_layouts
     if (s.startsWith('INSERT INTO PAGE_LAYOUTS')) {
@@ -68,120 +118,88 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       return { rows: [row] };
     }
 
-    // SELECT * FROM page_layouts WHERE tenant_id = ... ORDER BY name
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUTS WHERE TENANT_ID') && s.includes('ORDER BY')) {
-      const tenantId = params![0] as string;
-      const objectId = params![1] as string;
+    // SELECT * FROM page_layouts ... ORDER BY (list)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      const tenantId = params[0] as string;
+      const objectId = params[1] as string;
       const rows = [...fakePageLayouts.values()]
         .filter((l) => l.tenant_id === tenantId && l.object_id === objectId)
         .sort((a, b) => (a.name as string).localeCompare(b.name as string));
       return { rows };
     }
 
-    // SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
+    // SELECT ... FROM page_layouts WHERE id = ... (getById / existence check)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('WHERE ID =')) {
+      const id = params[0] as string;
       const row = fakePageLayouts.get(id);
-      if (row && row.tenant_id === params![1] && row.object_id === params![2]) {
+      if (row && row.tenant_id === params[1] && row.object_id === params[2]) {
         return { rows: [row] };
       }
       return { rows: [] };
     }
 
-    // SELECT id FROM page_layouts WHERE id = ... (for listVersions check)
-    if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
-      const row = fakePageLayouts.get(id);
-      if (row && row.tenant_id === params![1] && row.object_id === params![2]) {
-        return { rows: [{ id: row.id }] };
-      }
-      return { rows: [] };
-    }
-
-    // UPDATE page_layouts SET published_layout ... (publish)
-    if (s.startsWith('UPDATE PAGE_LAYOUTS') && s.includes('PUBLISHED_LAYOUT = LAYOUT')) {
-      const newVersion = params![0] as number;
-      const now = params![1] as Date;
-      const layoutId = params![2] as string;
-      const row = fakePageLayouts.get(layoutId);
-      if (row) {
-        row.published_layout = row.layout;
-        row.version = newVersion;
-        row.status = 'published';
-        row.published_at = now;
-        row.updated_at = now;
-        return { rows: [row] };
-      }
-      return { rows: [] };
-    }
-
-    // UPDATE page_layouts SET ... (general update)
+    // UPDATE page_layouts SET ...
     if (s.startsWith('UPDATE PAGE_LAYOUTS SET')) {
-      // Find the layout ID in params (second-to-last param)
-      const layoutId = params![params!.length - 2] as string;
-      const row = fakePageLayouts.get(layoutId);
-      if (row) {
-        // Apply updates from params based on SQL fragments
-        const sqlLower = sql.toLowerCase();
-        let paramIdx = 0;
-        if (sqlLower.includes('name =')) { row.name = params![paramIdx++]; }
-        if (sqlLower.includes('role =')) { row.role = params![paramIdx++]; }
-        if (sqlLower.includes('layout =')) {
-          const val = params![paramIdx++];
-          row.layout = typeof val === 'string' ? JSON.parse(val) : val;
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakePageLayouts.has(p)) {
+          layoutId = p;
+          break;
         }
-        if (sqlLower.includes('is_default =')) { row.is_default = params![paramIdx++]; }
-        row.updated_at = params![paramIdx] ?? new Date();
+      }
+      const row = layoutId ? fakePageLayouts.get(layoutId) : undefined;
+      if (row) {
+        if (s.includes('PUBLISHED_LAYOUT')) {
+          // Publish: SET published_layout=$1, version=$2, status=$3, published_at=$4, updated_at=$5
+          const [published_layout, version, _status, published_at, updated_at] = params;
+          row.published_layout = typeof published_layout === 'string'
+            ? JSON.parse(published_layout as string)
+            : published_layout;
+          row.version = version;
+          row.status = 'published';
+          row.published_at = published_at;
+          row.updated_at = updated_at;
+        } else {
+          // General / copy / revert update
+          let paramIdx = 0;
+          if (s.includes('NAME =')) { row.name = params[paramIdx++]; }
+          if (s.includes('ROLE =')) { row.role = params[paramIdx++]; }
+          if (s.includes('LAYOUT =')) {
+            const val = params[paramIdx++];
+            row.layout = typeof val === 'string' ? JSON.parse(val as string) : val;
+          }
+          if (s.includes('IS_DEFAULT =')) { row.is_default = params[paramIdx++]; }
+          row.updated_at = params[paramIdx] ?? new Date();
+        }
         return { rows: [row] };
       }
       return { rows: [] };
     }
 
-    // INSERT INTO page_layout_versions
-    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
-      const [id, layout_id, tenant_id, version, layout, published_by, published_at] = params as unknown[];
-      const row: Record<string, unknown> = {
-        id, layout_id, tenant_id, version, layout, published_by, published_at,
-      };
-      fakePageLayoutVersions.set(id as string, row);
-      return { rows: [row] };
-    }
-
-    // SELECT * FROM page_layout_versions WHERE layout_id = ... AND tenant_id = ... AND version = ...
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUT_VERSIONS WHERE LAYOUT_ID') && s.includes('VERSION')) {
-      const layoutId = params![0] as string;
-      const tenantId = params![1] as string;
-      const version = params!.length > 2 ? (params![2] as number) : undefined;
-      const rows = [...fakePageLayoutVersions.values()]
-        .filter((v) => {
-          if (v.layout_id !== layoutId || v.tenant_id !== tenantId) return false;
-          if (version !== undefined) return v.version === version;
-          return true;
-        })
-        .sort((a, b) => (b.version as number) - (a.version as number));
-      return { rows };
-    }
-
-    // DELETE FROM page_layouts WHERE id = $1 AND tenant_id = $2
-    if (s.startsWith('DELETE FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
-      fakePageLayouts.delete(id);
-      return { rows: [] };
-    }
-
-    // Transaction control statements (no-op in tests)
-    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+    // DELETE FROM page_layouts
+    if (s.startsWith('DELETE FROM PAGE_LAYOUTS')) {
+      for (const p of params) {
+        if (typeof p === 'string' && fakePageLayouts.has(p)) {
+          fakePageLayouts.delete(p);
+          break;
+        }
+      }
       return { rows: [] };
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  // The publish flow uses pool.connect() for transactions.  Return a fake
-  // client whose .query() delegates to the same mockQuery so the in-memory
-  // data stores stay consistent.
   const mockConnect = vi.fn(async () => ({
-    query: mockQuery,
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
     release: vi.fn(),
   }));
 

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -149,12 +149,10 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       }
       const row = layoutId ? fakePageLayouts.get(layoutId) : undefined;
       if (row) {
-        if (s.includes('PUBLISHED_LAYOUT')) {
-          // Publish: SET published_layout=$1, version=$2, status=$3, published_at=$4, updated_at=$5
-          const [published_layout, version, _status, published_at, updated_at] = params;
-          row.published_layout = typeof published_layout === 'string'
-            ? JSON.parse(published_layout as string)
-            : published_layout;
+        if (s.includes('PUBLISHED_LAYOUT = LAYOUT')) {
+          // Publish: SET published_layout=layout (column ref), version=$1, status=$2, published_at=$3, updated_at=$4
+          row.published_layout = row.layout;
+          const [version, _status, published_at, updated_at] = params;
           row.version = version;
           row.status = 'published';
           row.published_at = published_at;

--- a/apps/api/src/services/layoutDefinitionService.ts
+++ b/apps/api/src/services/layoutDefinitionService.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
-import type { LayoutDefinitions, LayoutFields } from '../db/kysely.types.js';
+import type { LayoutDefinitions } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/apps/api/src/services/layoutDefinitionService.ts
+++ b/apps/api/src/services/layoutDefinitionService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { LayoutDefinitions, LayoutFields } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -90,32 +92,47 @@ function throwDeleteBlockedError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToLayoutDefinition(row: Record<string, unknown>): LayoutDefinition {
+function rowToLayoutDefinition(row: Selectable<LayoutDefinitions>): LayoutDefinition {
   return {
-    id: row.id as string,
-    objectId: row.object_id as string,
-    name: row.name as string,
-    layoutType: row.layout_type as string,
-    isDefault: row.is_default as boolean,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    id: row.id,
+    objectId: row.object_id,
+    name: row.name,
+    layoutType: row.layout_type,
+    isDefault: row.is_default,
+    createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at as unknown as string),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at as unknown as string),
   };
 }
 
-function rowToLayoutFieldWithMetadata(row: Record<string, unknown>): LayoutFieldWithMetadata {
+interface LayoutFieldJoinedRow {
+  id: string;
+  layout_id: string;
+  field_id: string;
+  section: number;
+  section_label: string | null;
+  sort_order: number;
+  width: string | null;
+  field_api_name: string;
+  field_label: string;
+  field_type: string;
+  field_required: boolean;
+  field_options: Record<string, unknown> | null;
+}
+
+function rowToLayoutFieldWithMetadata(row: LayoutFieldJoinedRow): LayoutFieldWithMetadata {
   return {
-    id: row.id as string,
-    layoutId: row.layout_id as string,
-    fieldId: row.field_id as string,
-    section: row.section as number,
-    sectionLabel: (row.section_label as string | null) ?? undefined,
-    sortOrder: row.sort_order as number,
-    width: row.width as string,
-    fieldApiName: row.field_api_name as string,
-    fieldLabel: row.field_label as string,
-    fieldType: row.field_type as string,
-    fieldRequired: row.field_required as boolean,
-    fieldOptions: (row.field_options as Record<string, unknown>) ?? {},
+    id: row.id,
+    layoutId: row.layout_id,
+    fieldId: row.field_id,
+    section: row.section,
+    sectionLabel: row.section_label ?? undefined,
+    sortOrder: row.sort_order,
+    width: row.width ?? 'full',
+    fieldApiName: row.field_api_name,
+    fieldLabel: row.field_label,
+    fieldType: row.field_type,
+    fieldRequired: row.field_required,
+    fieldOptions: row.field_options ?? {},
   };
 }
 
@@ -144,42 +161,48 @@ export function validateLayoutType(layoutType: unknown): string | null {
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 async function assertObjectExists(tenantId: string, objectId: string): Promise<void> {
-  const result = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (result.rows.length === 0) {
+  const row = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!row) {
     throwNotFoundError('Object definition not found');
   }
 }
 
-async function fetchLayoutFields(layoutId: string): Promise<LayoutFieldWithMetadata[]> {
-  const result = await pool.query(
-    `SELECT lf.*,
-            fd.api_name  AS field_api_name,
-            fd.label     AS field_label,
-            fd.field_type AS field_type,
-            fd.required  AS field_required,
-            fd.options   AS field_options
-     FROM layout_fields lf
-     JOIN field_definitions fd ON fd.id = lf.field_id
-     WHERE lf.layout_id = $1
-     ORDER BY lf.section ASC, lf.sort_order ASC`,
-    [layoutId],
-  );
+async function fetchLayoutFields(tenantId: string, layoutId: string): Promise<LayoutFieldWithMetadata[]> {
+  const rows = await db
+    .selectFrom('layout_fields as lf')
+    .innerJoin('field_definitions as fd', (join) =>
+      join.onRef('fd.id', '=', 'lf.field_id').on('fd.tenant_id', '=', tenantId),
+    )
+    .where('lf.layout_id', '=', layoutId)
+    .where('lf.tenant_id', '=', tenantId)
+    .select([
+      'lf.id',
+      'lf.layout_id',
+      'lf.field_id',
+      'lf.section',
+      'lf.section_label',
+      'lf.sort_order',
+      'lf.width',
+      'fd.api_name as field_api_name',
+      'fd.label as field_label',
+      'fd.field_type as field_type',
+      'fd.required as field_required',
+      'fd.options as field_options',
+    ])
+    .orderBy('lf.section', 'asc')
+    .orderBy('lf.sort_order', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToLayoutFieldWithMetadata(row));
+  return rows.map((row) => rowToLayoutFieldWithMetadata(row as unknown as LayoutFieldJoinedRow));
 }
 
 // ─── Service functions ───────────────────────────────────────────────────────
 
-/**
- * Creates a new layout definition on the specified object.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout name already exists on this object
- */
 export async function createLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -187,71 +210,64 @@ export async function createLayoutDefinition(
 ): Promise<LayoutDefinition> {
   await assertObjectExists(tenantId, objectId);
 
-  // Validate
   const nameError = validateLayoutName(params.name);
   if (nameError) throwValidationError(nameError);
 
   const typeError = validateLayoutType(params.layoutType);
   if (typeError) throwValidationError(typeError);
 
-  // Check uniqueness of name within this object and tenant
-  const existing = await pool.query(
-    'SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND tenant_id = $3',
-    [objectId, params.name.trim(), tenantId],
-  );
-  if (existing.rows.length > 0) {
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .select('id')
+    .where('object_id', '=', objectId)
+    .where('name', '=', params.name.trim())
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (existing) {
     throwConflictError(`A layout with name "${params.name.trim()}" already exists on this object`);
   }
 
   const layoutId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO layout_definitions
-       (id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING *`,
-    [
-      layoutId,
-      tenantId,
-      objectId,
-      params.name.trim(),
-      params.layoutType.trim(),
-      params.isDefault ?? false,
-      now,
-      now,
-    ],
-  );
+  const row = await db
+    .insertInto('layout_definitions')
+    .values({
+      id: layoutId,
+      tenant_id: tenantId,
+      object_id: objectId,
+      name: params.name.trim(),
+      layout_type: params.layoutType.trim(),
+      is_default: params.isDefault ?? false,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, name: params.name }, 'Layout definition created');
 
-  return rowToLayoutDefinition(result.rows[0]);
+  return rowToLayoutDefinition(row);
 }
 
-/**
- * Returns all layout definitions for an object, ordered by layout_type and name.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- */
 export async function listLayoutDefinitions(
   tenantId: string,
   objectId: string,
 ): Promise<LayoutDefinition[]> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM layout_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY layout_type ASC, name ASC',
-    [objectId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('layout_type', 'asc')
+    .orderBy('name', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToLayoutDefinition(row));
+  return rows.map(rowToLayoutDefinition);
 }
 
-/**
- * Returns a single layout definition by ID with nested field metadata.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function getLayoutDefinitionById(
   tenantId: string,
   objectId: string,
@@ -259,28 +275,24 @@ export async function getLayoutDefinitionById(
 ): Promise<LayoutDefinitionDetail> {
   await assertObjectExists(tenantId, objectId);
 
-  const layoutResult = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const row = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (layoutResult.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Layout definition not found');
   }
 
-  const layout = rowToLayoutDefinition(layoutResult.rows[0]);
-  const fields = await fetchLayoutFields(layoutId);
+  const layout = rowToLayoutDefinition(row);
+  const fields = await fetchLayoutFields(tenantId, layoutId);
 
   return { ...layout, fields };
 }
 
-/**
- * Updates a layout definition's metadata (name, layout_type).
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout name already exists on this object
- */
 export async function updateLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -289,26 +301,31 @@ export async function updateLayoutDefinition(
 ): Promise<LayoutDefinition> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Layout definition not found');
   }
 
-  // Validate changed fields
   if (params.name !== undefined) {
     const nameError = validateLayoutName(params.name);
     if (nameError) throwValidationError(nameError);
 
-    // Check uniqueness of new name (excluding this layout)
-    const dup = await pool.query(
-      'SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND id != $3 AND tenant_id = $4',
-      [objectId, params.name.trim(), layoutId, tenantId],
-    );
-    if (dup.rows.length > 0) {
+    const dup = await db
+      .selectFrom('layout_definitions')
+      .select('id')
+      .where('object_id', '=', objectId)
+      .where('name', '=', params.name.trim())
+      .where('id', '!=', layoutId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (dup) {
       throwConflictError(`A layout with name "${params.name.trim()}" already exists on this object`);
     }
   }
@@ -318,49 +335,34 @@ export async function updateLayoutDefinition(
     if (typeError) throwValidationError(typeError);
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
-
+  const patch: Updateable<LayoutDefinitions> = {};
   if ('name' in params) {
-    updates.push(`name = $${paramIndex++}`);
-    values.push(params.name!.trim());
+    patch.name = params.name!.trim();
   }
   if ('layoutType' in params) {
-    updates.push(`layout_type = $${paramIndex++}`);
-    values.push(params.layoutType!.trim());
+    patch.layout_type = params.layoutType!.trim();
   }
 
-  if (updates.length === 0) {
-    return rowToLayoutDefinition(existing.rows[0]);
+  if (Object.keys(patch).length === 0) {
+    return rowToLayoutDefinition(existing);
   }
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
+  patch.updated_at = new Date();
 
-  values.push(layoutId);
-  values.push(objectId);
-
-  const result = await pool.query(
-    `UPDATE layout_definitions SET ${updates.join(', ')} WHERE id = $${paramIndex++} AND object_id = $${paramIndex} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('layout_definitions')
+    .set(patch)
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId }, 'Layout definition updated');
 
-  return rowToLayoutDefinition(result.rows[0]);
+  return rowToLayoutDefinition(row);
 }
 
-/**
- * Sets the layout field arrangement (full replacement).
- * Deletes all existing layout_fields for this layout, then inserts new ones
- * based on the provided sections.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid section/field input
- */
 export async function setLayoutFields(
   tenantId: string,
   objectId: string,
@@ -369,21 +371,22 @@ export async function setLayoutFields(
 ): Promise<LayoutDefinitionDetail> {
   await assertObjectExists(tenantId, objectId);
 
-  const layoutResult = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const layoutRow = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (layoutResult.rows.length === 0) {
+  if (!layoutRow) {
     throwNotFoundError('Layout definition not found');
   }
 
-  // Validate sections input
   if (!Array.isArray(sections)) {
     throwValidationError('sections must be an array');
   }
 
-  // Collect all field IDs and validate they belong to this object
   const allFieldIds: string[] = [];
   for (const section of sections) {
     if (!Array.isArray(section.fields)) {
@@ -399,12 +402,13 @@ export async function setLayoutFields(
   }
 
   if (allFieldIds.length > 0) {
-    // Verify all field IDs belong to this object
-    const existingFields = await pool.query(
-      'SELECT id FROM field_definitions WHERE object_id = $1 AND tenant_id = $2',
-      [objectId, tenantId],
-    );
-    const existingIds = new Set(existingFields.rows.map((r: Record<string, unknown>) => r.id as string));
+    const existingFields = await db
+      .selectFrom('field_definitions')
+      .select('id')
+      .where('object_id', '=', objectId)
+      .where('tenant_id', '=', tenantId)
+      .execute();
+    const existingIds = new Set(existingFields.map((r) => r.id));
 
     for (const fieldId of allFieldIds) {
       if (!existingIds.has(fieldId)) {
@@ -412,20 +416,18 @@ export async function setLayoutFields(
       }
     }
 
-    // Check for duplicate field IDs
     const uniqueFieldIds = new Set(allFieldIds);
     if (uniqueFieldIds.size !== allFieldIds.length) {
       throwValidationError('Duplicate field IDs are not allowed in a layout');
     }
   }
 
-  // Delete existing layout fields
-  await pool.query(
-    'DELETE FROM layout_fields WHERE layout_id = $1',
-    [layoutId],
-  );
+  await db
+    .deleteFrom('layout_fields')
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
-  // Insert new layout fields
   for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
     const section = sections[sectionIndex];
     const sectionLabel = section.label?.trim() ?? null;
@@ -434,44 +436,38 @@ export async function setLayoutFields(
       const field = section.fields[fieldIndex];
       const fieldId = field.field_id ?? field.fieldId;
 
-      await pool.query(
-        `INSERT INTO layout_fields (id, layout_id, field_id, section, section_label, sort_order, width)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-        [
-          randomUUID(),
-          layoutId,
-          fieldId,
-          sectionIndex,
-          sectionLabel,
-          fieldIndex + 1,
-          field.width ?? 'full',
-        ],
-      );
+      await db
+        .insertInto('layout_fields')
+        .values({
+          id: randomUUID(),
+          tenant_id: tenantId,
+          layout_id: layoutId,
+          field_id: fieldId!,
+          section: sectionIndex,
+          section_label: sectionLabel,
+          sort_order: fieldIndex + 1,
+          width: field.width ?? 'full',
+        })
+        .execute();
     }
   }
 
-  // Update the layout's updated_at timestamp
   const now = new Date();
-  await pool.query(
-    'UPDATE layout_definitions SET updated_at = $1 WHERE id = $2',
-    [now, layoutId],
-  );
+  await db
+    .updateTable('layout_definitions')
+    .set({ updated_at: now })
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId, sectionCount: sections.length }, 'Layout fields updated');
 
-  // Return the full layout with field metadata
-  const layout = rowToLayoutDefinition({ ...layoutResult.rows[0], updated_at: now.toISOString() });
-  const fields = await fetchLayoutFields(layoutId);
+  const layout = rowToLayoutDefinition({ ...layoutRow, updated_at: now });
+  const fields = await fetchLayoutFields(tenantId, layoutId);
 
   return { ...layout, fields };
 }
 
-/**
- * Deletes a layout definition. Default layouts cannot be deleted.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} DELETE_BLOCKED — default layout
- */
 export async function deleteLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -479,22 +475,27 @@ export async function deleteLayoutDefinition(
 ): Promise<void> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Layout definition not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
-  if (row.is_default === true) {
+  if (existing.is_default === true) {
     throwDeleteBlockedError('Cannot delete default layouts');
   }
 
-  await pool.query('DELETE FROM layout_definitions WHERE id = $1', [layoutId]);
+  await db
+    .deleteFrom('layout_definitions')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId }, 'Layout definition deleted');
 }

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { sql } from 'kysely';
 import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
@@ -533,7 +534,7 @@ export async function publishPageLayout(
     const row = await trx
       .updateTable('page_layouts')
       .set({
-        published_layout: existingRow.layout,
+        published_layout: sql`layout`,
         version: newVersion,
         status: 'published',
         published_at: now,
@@ -551,7 +552,7 @@ export async function publishPageLayout(
         layout_id: layoutId,
         tenant_id: tenantId,
         version: newVersion,
-        layout: existingRow.layout,
+        layout: row.layout,
         published_by: publishedBy,
         published_at: now,
       })

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { PageLayouts, PageLayoutVersions } from '../db/kysely.types.js';
 import { VALID_COMPONENT_TYPES } from '../lib/componentRegistry.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -126,33 +128,35 @@ function throwDeleteBlockedError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToPageLayout(row: Record<string, unknown>): PageLayout {
+function rowToPageLayout(row: Selectable<PageLayouts>): PageLayout {
   return {
-    id: row.id as string,
-    tenantId: row.tenant_id as string,
-    objectId: row.object_id as string,
-    name: row.name as string,
-    role: (row.role as string | null) ?? null,
-    isDefault: row.is_default as boolean,
-    layout: row.layout as PageLayoutJson,
-    publishedLayout: (row.published_layout as PageLayoutJson | null) ?? null,
-    version: row.version as number,
-    status: row.status as string,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
-    publishedAt: row.published_at ? new Date(row.published_at as string) : null,
+    id: row.id,
+    tenantId: row.tenant_id,
+    objectId: row.object_id,
+    name: row.name,
+    role: row.role,
+    isDefault: row.is_default,
+    layout: row.layout as unknown as PageLayoutJson,
+    publishedLayout: (row.published_layout as unknown as PageLayoutJson) ?? null,
+    version: row.version,
+    status: row.status,
+    createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at as unknown as string),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at as unknown as string),
+    publishedAt: row.published_at
+      ? (row.published_at instanceof Date ? row.published_at : new Date(row.published_at as unknown as string))
+      : null,
   };
 }
 
-function rowToPageLayoutVersion(row: Record<string, unknown>): PageLayoutVersion {
+function rowToPageLayoutVersion(row: Selectable<PageLayoutVersions>): PageLayoutVersion {
   return {
-    id: row.id as string,
-    layoutId: row.layout_id as string,
-    tenantId: row.tenant_id as string,
-    version: row.version as number,
-    layout: row.layout as PageLayoutJson,
-    publishedBy: (row.published_by as string | null) ?? null,
-    publishedAt: new Date(row.published_at as string),
+    id: row.id,
+    layoutId: row.layout_id,
+    tenantId: row.tenant_id,
+    version: row.version,
+    layout: row.layout as unknown as PageLayoutJson,
+    publishedBy: row.published_by,
+    publishedAt: row.published_at instanceof Date ? row.published_at : new Date(row.published_at as unknown as string),
   };
 }
 
@@ -208,7 +212,6 @@ export function validateLayoutJson(layout: unknown): string | null {
 
   const l = layout as Record<string, unknown>;
 
-  // Validate header
   if (typeof l.header !== 'object' || l.header === null) {
     return 'layout.header is required and must be an object';
   }
@@ -230,7 +233,6 @@ export function validateLayoutJson(layout: unknown): string | null {
     return 'layout.header.actions must be an array of strings';
   }
 
-  // Validate tabs
   if (!Array.isArray(l.tabs)) {
     return 'layout.tabs is required and must be an array';
   }
@@ -300,24 +302,19 @@ export function validateLayoutJson(layout: unknown): string | null {
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 async function assertObjectExists(tenantId: string, objectId: string): Promise<void> {
-  const result = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (result.rows.length === 0) {
+  const row = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!row) {
     throwNotFoundError('Object definition not found');
   }
 }
 
 // ─── Service functions ───────────────────────────────────────────────────────
 
-/**
- * Creates a new page layout on the specified object.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout already exists for this object/role combination
- */
 export async function createPageLayout(
   tenantId: string,
   objectId: string,
@@ -331,14 +328,22 @@ export async function createPageLayout(
   const layoutError = validateLayoutJson(params.layout);
   if (layoutError) throwValidationError(layoutError);
 
-  // Check uniqueness constraint (tenant_id, object_id, role)
   const role = params.role ?? null;
-  const existing = await pool.query(
-    `SELECT id FROM page_layouts
-     WHERE tenant_id = $1 AND object_id = $2 AND ${role === null ? 'role IS NULL' : 'role = $3'}`,
-    role === null ? [tenantId, objectId] : [tenantId, objectId, role],
-  );
-  if (existing.rows.length > 0) {
+
+  let existingQuery = db
+    .selectFrom('page_layouts')
+    .select('id')
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId);
+
+  if (role === null) {
+    existingQuery = existingQuery.where('role', 'is', null);
+  } else {
+    existingQuery = existingQuery.where('role', '=', role);
+  }
+
+  const existing = await existingQuery.executeTakeFirst();
+  if (existing) {
     throwConflictError(
       role
         ? `A page layout already exists for this object with role "${role}"`
@@ -349,55 +354,46 @@ export async function createPageLayout(
   const layoutId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO page_layouts
-       (id, tenant_id, object_id, name, role, is_default, layout, version, status, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-     RETURNING *`,
-    [
-      layoutId,
-      tenantId,
-      objectId,
-      params.name.trim(),
+  const row = await db
+    .insertInto('page_layouts')
+    .values({
+      id: layoutId,
+      tenant_id: tenantId,
+      object_id: objectId,
+      name: params.name.trim(),
       role,
-      params.isDefault ?? false,
-      JSON.stringify(params.layout),
-      1,
-      'draft',
-      now,
-      now,
-    ],
-  );
+      is_default: params.isDefault ?? false,
+      layout: JSON.stringify(params.layout),
+      version: 1,
+      status: 'draft',
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, name: params.name }, 'Page layout created');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Returns all page layouts for an object, ordered by name.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- */
 export async function listPageLayouts(
   tenantId: string,
   objectId: string,
 ): Promise<PageLayout[]> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM page_layouts WHERE tenant_id = $1 AND object_id = $2 ORDER BY name ASC',
-    [tenantId, objectId],
-  );
+  const rows = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .orderBy('name', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToPageLayout(row));
+  return rows.map(rowToPageLayout);
 }
 
-/**
- * Returns a single page layout by ID.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function getPageLayoutById(
   tenantId: string,
   objectId: string,
@@ -405,25 +401,21 @@ export async function getPageLayoutById(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const row = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Page layout not found');
   }
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Updates a page layout's metadata and/or draft layout.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — role conflict with another layout
- */
 export async function updatePageLayout(
   tenantId: string,
   objectId: string,
@@ -432,12 +424,15 @@ export async function updatePageLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existing = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Page layout not found');
   }
 
@@ -451,18 +446,24 @@ export async function updatePageLayout(
     if (layoutError) throwValidationError(layoutError);
   }
 
-  // Check role uniqueness if changing role
   if ('role' in params) {
     const newRole = params.role ?? null;
-    const dup = await pool.query(
-      `SELECT id FROM page_layouts
-       WHERE tenant_id = $1 AND object_id = $2 AND id != $3
-         AND ${newRole === null ? 'role IS NULL' : 'role = $4'}`,
-      newRole === null
-        ? [tenantId, objectId, layoutId]
-        : [tenantId, objectId, layoutId, newRole],
-    );
-    if (dup.rows.length > 0) {
+
+    let dupQuery = db
+      .selectFrom('page_layouts')
+      .select('id')
+      .where('tenant_id', '=', tenantId)
+      .where('object_id', '=', objectId)
+      .where('id', '!=', layoutId);
+
+    if (newRole === null) {
+      dupQuery = dupQuery.where('role', 'is', null);
+    } else {
+      dupQuery = dupQuery.where('role', '=', newRole);
+    }
+
+    const dup = await dupQuery.executeTakeFirst();
+    if (dup) {
       throwConflictError(
         newRole
           ? `A page layout already exists for this object with role "${newRole}"`
@@ -471,57 +472,39 @@ export async function updatePageLayout(
     }
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
-
+  const patch: Updateable<PageLayouts> = {};
   if ('name' in params) {
-    updates.push(`name = $${paramIndex++}`);
-    values.push(params.name!.trim());
+    patch.name = params.name!.trim();
   }
   if ('role' in params) {
-    updates.push(`role = $${paramIndex++}`);
-    values.push(params.role ?? null);
+    patch.role = params.role ?? null;
   }
   if ('layout' in params) {
-    updates.push(`layout = $${paramIndex++}`);
-    values.push(JSON.stringify(params.layout));
+    patch.layout = JSON.stringify(params.layout);
   }
   if ('isDefault' in params) {
-    updates.push(`is_default = $${paramIndex++}`);
-    values.push(params.isDefault);
+    patch.is_default = params.isDefault;
   }
 
-  if (updates.length === 0) {
-    return rowToPageLayout(existing.rows[0]);
+  if (Object.keys(patch).length === 0) {
+    return rowToPageLayout(existing);
   }
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
+  patch.updated_at = new Date();
 
-  values.push(layoutId);
-  const layoutIdParam = paramIndex++;
-  values.push(tenantId);
-  const tenantIdParam = paramIndex;
-
-  const result = await pool.query(
-    `UPDATE page_layouts SET ${updates.join(', ')} WHERE id = $${layoutIdParam} AND tenant_id = $${tenantIdParam} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set(patch)
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId }, 'Page layout updated');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Publishes a page layout — copies the draft layout to published_layout,
- * increments the version, and creates a version snapshot.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function publishPageLayout(
   tenantId: string,
   objectId: string,
@@ -530,74 +513,56 @@ export async function publishPageLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existingRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-  const currentVersion = row.version as number;
+  const currentVersion = existingRow.version;
   const newVersion = currentVersion + 1;
   const now = new Date();
 
-  // Wrap the layout update and version snapshot in a transaction so both
-  // succeed or neither does — prevents a partial state where the layout is
-  // marked as published but no version record exists.
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
+  return db.transaction().execute(async (trx) => {
+    const row = await trx
+      .updateTable('page_layouts')
+      .set({
+        published_layout: existingRow.layout,
+        version: newVersion,
+        status: 'published',
+        published_at: now,
+        updated_at: now,
+      })
+      .where('id', '=', layoutId)
+      .where('tenant_id', '=', tenantId)
+      .returningAll()
+      .executeTakeFirstOrThrow();
 
-    // Update the page layout: copy layout → published_layout
-    const result = await client.query(
-      `UPDATE page_layouts
-       SET published_layout = layout,
-           version = $1,
-           status = 'published',
-           published_at = $2,
-           updated_at = $2
-       WHERE id = $3 AND tenant_id = $4
-       RETURNING *`,
-      [newVersion, now, layoutId, tenantId],
-    );
-
-    // Create version snapshot
-    await client.query(
-      `INSERT INTO page_layout_versions
-         (id, layout_id, tenant_id, version, layout, published_by, published_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [
-        randomUUID(),
-        layoutId,
-        tenantId,
-        newVersion,
-        row.layout,
-        publishedBy,
-        now,
-      ],
-    );
-
-    await client.query('COMMIT');
+    await trx
+      .insertInto('page_layout_versions')
+      .values({
+        id: randomUUID(),
+        layout_id: layoutId,
+        tenant_id: tenantId,
+        version: newVersion,
+        layout: existingRow.layout,
+        published_by: publishedBy,
+        published_at: now,
+      })
+      .execute();
 
     logger.info({ layoutId, objectId, version: newVersion, publishedBy }, 'Page layout published');
 
-    return rowToPageLayout(result.rows[0]);
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
-  }
+    return rowToPageLayout(row);
+  });
 }
 
-/**
- * Returns all version snapshots for a page layout, newest first.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function listPageLayoutVersions(
   tenantId: string,
   objectId: string,
@@ -605,29 +570,28 @@ export async function listPageLayoutVersions(
 ): Promise<PageLayoutVersion[]> {
   await assertObjectExists(tenantId, objectId);
 
-  // Verify the layout exists
-  const layoutResult = await pool.query(
-    'SELECT id FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
-  if (layoutResult.rows.length === 0) {
+  const layoutRow = await db
+    .selectFrom('page_layouts')
+    .select('id')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!layoutRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  const result = await pool.query(
-    'SELECT * FROM page_layout_versions WHERE layout_id = $1 AND tenant_id = $2 ORDER BY version DESC',
-    [layoutId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('page_layout_versions')
+    .selectAll()
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('version', 'desc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToPageLayoutVersion(row));
+  return rows.map(rowToPageLayoutVersion);
 }
 
-/**
- * Deletes a page layout. Default layouts cannot be deleted.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} DELETE_BLOCKED — default layout
- */
 export async function deletePageLayout(
   tenantId: string,
   objectId: string,
@@ -635,31 +599,31 @@ export async function deletePageLayout(
 ): Promise<void> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existing = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Page layout not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
-  if (row.is_default === true) {
+  if (existing.is_default === true) {
     throwDeleteBlockedError('Cannot delete default page layouts');
   }
 
-  await pool.query('DELETE FROM page_layouts WHERE id = $1 AND tenant_id = $2', [layoutId, tenantId]);
+  await db
+    .deleteFrom('page_layouts')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId }, 'Page layout deleted');
 }
 
-/**
- * Copies the layout JSON from a source page layout into the target layout's draft.
- *
- * @throws {Error} NOT_FOUND — target layout, source layout, or parent object does not exist
- */
 export async function copyLayout(
   tenantId: string,
   objectId: string,
@@ -668,46 +632,46 @@ export async function copyLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  // Fetch source layout
-  const sourceResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [sourceLayoutId, tenantId, objectId],
-  );
-  if (sourceResult.rows.length === 0) {
+  const sourceRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', sourceLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!sourceRow) {
     throwNotFoundError('Source page layout not found');
   }
 
-  // Fetch target layout
-  const targetResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [targetLayoutId, tenantId, objectId],
-  );
-  if (targetResult.rows.length === 0) {
+  const targetRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', targetLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!targetRow) {
     throwNotFoundError('Target page layout not found');
   }
 
-  const sourceRow = sourceResult.rows[0] as Record<string, unknown>;
   const now = new Date();
 
-  // Copy the source layout JSON into the target's draft
-  const result = await pool.query(
-    `UPDATE page_layouts
-     SET layout = $1, updated_at = $2
-     WHERE id = $3 AND tenant_id = $4
-     RETURNING *`,
-    [sourceRow.layout, now, targetLayoutId, tenantId],
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set({
+      layout: sourceRow.layout,
+      updated_at: now,
+    })
+    .where('id', '=', targetLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ targetLayoutId, sourceLayoutId, objectId }, 'Page layout copied');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Reverts a page layout's draft to a specific version from page_layout_versions.
- *
- * @throws {Error} NOT_FOUND — layout, version snapshot, or parent object does not exist
- */
 export async function revertLayout(
   tenantId: string,
   objectId: string,
@@ -716,37 +680,42 @@ export async function revertLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  // Verify the layout exists
-  const layoutResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
-  if (layoutResult.rows.length === 0) {
+  const layoutRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!layoutRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  // Find the version snapshot
-  const versionResult = await pool.query(
-    'SELECT * FROM page_layout_versions WHERE layout_id = $1 AND tenant_id = $2 AND version = $3',
-    [layoutId, tenantId, version],
-  );
-  if (versionResult.rows.length === 0) {
+  const versionRow = await db
+    .selectFrom('page_layout_versions')
+    .selectAll()
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('version', '=', version)
+    .executeTakeFirst();
+  if (!versionRow) {
     throwNotFoundError(`Version ${version} not found for this layout`);
   }
 
-  const versionRow = versionResult.rows[0] as Record<string, unknown>;
   const now = new Date();
 
-  // Restore the version's layout JSON into the draft
-  const result = await pool.query(
-    `UPDATE page_layouts
-     SET layout = $1, updated_at = $2
-     WHERE id = $3 AND tenant_id = $4
-     RETURNING *`,
-    [versionRow.layout, now, layoutId, tenantId],
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set({
+      layout: versionRow.layout,
+      updated_at: now,
+    })
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, version }, 'Page layout reverted');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }


### PR DESCRIPTION
## Summary

- **layoutDefinitionService.ts**: Replace all raw `pool.query()` calls with Kysely query builder. Typed `rowToLayoutDefinition` against `Selectable<LayoutDefinitions>`, dynamic patches via `Updateable<LayoutDefinitions>`. Closes latent tenant isolation gaps: `fetchLayoutFields` JOIN now carries `fd.tenant_id` ON clause + `lf.tenant_id` WHERE filter; INSERT INTO `layout_fields` now includes `tenant_id` column (fixes latent production bug — column is NOT NULL with no default); DELETE scoped by `id + tenant_id` (was just `id`).

- **pageLayoutService.ts**: Replace all raw `pool.query()` calls with Kysely query builder. Typed `rowToPageLayout`/`rowToPageLayoutVersion` against `Selectable` types. `publishPageLayout` uses `db.transaction().execute()` instead of manual `pool.connect()` + BEGIN/COMMIT. IS NULL role handling via `.where('role', 'is', null)`. Dynamic patches via `Updateable<PageLayouts>`.

- **Test mocks updated** for both services with Kysely-compatible patterns: `normaliseCall` dual call-shape handler, `mockConnect` for Kysely's PostgresDriver, quote stripping for Kysely's quoted identifiers.

- **Regression SQL-pinning suites added**: `layoutDefinitionService.kysely-sql.test.ts` (5 tests) and `pageLayoutService.kysely-sql.test.ts` (9 tests) pin the emitted SQL to catch drift.

## Latent bugs fixed

| Bug | Service | Fix |
|-----|---------|-----|
| `layout_fields.tenant_id` omitted from INSERT (column is NOT NULL, no default) | layoutDefinitionService | Added `tenant_id` to `.values()` |
| `fetchLayoutFields` JOIN missing `fd.tenant_id` ON clause + `lf.tenant_id` WHERE | layoutDefinitionService | Added both tenant_id conditions |
| DELETE `layout_definitions` not scoped by `tenant_id` | layoutDefinitionService | Added `.where('tenant_id', '=', tenantId)` |
| DELETE `layout_fields` not scoped by `tenant_id` | layoutDefinitionService | Added `.where('tenant_id', '=', tenantId)` |

## Test plan

- [x] `layoutDefinitionService.test.ts` — 37 behavioural tests pass
- [x] `pageLayoutService.test.ts` — 51 behavioural tests pass
- [x] `layoutDefinitionService.kysely-sql.test.ts` — 5 SQL regression tests pass
- [x] `pageLayoutService.kysely-sql.test.ts` — 9 SQL regression tests pass
- [x] Full services test suite — 954 tests across 42 files pass
- [x] TypeScript typecheck clean (`tsc --noEmit`)

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf