### PR TITLE
Migrate seedDefaultObjects + tenantProvisioning raw-client to Kysely (Phase 3b)

### DIFF
--- a/apps/api/src/services/__tests__/layoutDefinitionService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/layoutDefinitionService.kysely-sql.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Kysely SQL regression suite for layoutDefinitionService.
+ *
+ * Pins the SQL Kysely emits so drift is caught early. Key things verified:
+ *
+ *   1. fetchLayoutFields JOIN carries fd.tenant_id ON clause +
+ *      lf.tenant_id WHERE filter (closes previously-latent gap).
+ *   2. INSERT INTO layout_fields includes tenant_id column
+ *      (fixes latent production bug — column is NOT NULL, no default).
+ *   3. DELETE layout_definitions scoped by id + tenant_id (was just id).
+ *   4. DELETE layout_fields scoped by layout_id + tenant_id.
+ *   5. Every data query carries a tenant_id bind.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+
+  function norm(rawSql: string): string {
+    return rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = norm(rawSql);
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
+
+    // object_definitions existence check
+    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS')) {
+      return { rows: [{ id: params[0] }] };
+    }
+
+    // Uniqueness check for layout name
+    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS') && s.includes('NAME =')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO layout_definitions
+    if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
+      const [id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params;
+      return {
+        rows: [{
+          id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at,
+        }],
+      };
+    }
+
+    // SELECT * FROM layout_definitions (list or getById)
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT')) {
+      return {
+        rows: [{
+          id: 'layout-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default Form', layout_type: 'form', is_default: false,
+          created_at: new Date(), updated_at: new Date(),
+        }],
+      };
+    }
+
+    // fetchLayoutFields JOIN query
+    if (s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS')) {
+      return { rows: [] };
+    }
+
+    // SELECT id FROM field_definitions (setLayoutFields validation)
+    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS')) {
+      return { rows: [{ id: 'field-1' }] };
+    }
+
+    // DELETE FROM layout_fields
+    if (s.startsWith('DELETE FROM LAYOUT_FIELDS')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO layout_fields
+    if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
+      return { rows: [{}] };
+    }
+
+    // UPDATE layout_definitions
+    if (s.startsWith('UPDATE LAYOUT_DEFINITIONS')) {
+      return {
+        rows: [{
+          id: 'layout-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Updated', layout_type: 'form', is_default: false,
+          created_at: new Date(), updated_at: new Date(),
+        }],
+      };
+    }
+
+    // DELETE FROM layout_definitions
+    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS')) {
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+  }
+
+  return { capturedQueries, mockQuery, mockConnect, resetCapture };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createLayoutDefinition,
+  getLayoutDefinitionById,
+  setLayoutFields,
+  deleteLayoutDefinition,
+} = await import('../layoutDefinitionService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('layoutDefinitionService Kysely SQL — createLayoutDefinition', () => {
+  it('INSERT carries tenant_id and returns all columns', async () => {
+    await createLayoutDefinition(TENANT_ID, 'obj-1', {
+      name: 'Detail View',
+      layoutType: 'detail',
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO LAYOUT_DEFINITIONS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('RETURNING');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('Detail View');
+    expect(insert.params).toContain('detail');
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — fetchLayoutFields tenant_id defence', () => {
+  it('JOIN ON carries fd.tenant_id and WHERE carries lf.tenant_id', async () => {
+    await getLayoutDefinitionById(TENANT_ID, 'obj-1', 'layout-1');
+
+    const joinQuery = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS');
+    })!;
+    const s = normalise(joinQuery.sql);
+
+    expect(s).toMatch(/JOIN FIELD_DEFINITIONS AS FD ON FD\.ID = LF\.FIELD_ID AND FD\.TENANT_ID =/);
+    expect(s).toContain('LF.TENANT_ID =');
+    expect(s).toContain('LF.LAYOUT_ID =');
+
+    const tenantCount = joinQuery.params.filter((p) => p === TENANT_ID).length;
+    expect(tenantCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — setLayoutFields', () => {
+  it('INSERT INTO layout_fields includes tenant_id column', async () => {
+    await setLayoutFields(TENANT_ID, 'obj-1', 'layout-1', [
+      { label: 'Info', fields: [{ fieldId: 'field-1', width: 'half' }] },
+    ]);
+
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO LAYOUT_FIELDS'),
+    );
+    expect(inserts.length).toBe(1);
+
+    const s = normalise(inserts[0].sql);
+    expect(s).toContain('TENANT_ID');
+    expect(inserts[0].params).toContain(TENANT_ID);
+  });
+
+  it('DELETE FROM layout_fields scoped by layout_id + tenant_id', async () => {
+    await setLayoutFields(TENANT_ID, 'obj-1', 'layout-1', [
+      { label: 'Info', fields: [{ fieldId: 'field-1' }] },
+    ]);
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM LAYOUT_FIELDS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('LAYOUT_ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+  });
+});
+
+describe('layoutDefinitionService Kysely SQL — deleteLayoutDefinition', () => {
+  it('DELETE scoped by id + tenant_id', async () => {
+    await deleteLayoutDefinition(TENANT_ID, 'obj-1', 'layout-1');
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM LAYOUT_DEFINITIONS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+    expect(del.params).toContain('layout-1');
+  });
+});

--- a/apps/api/src/services/__tests__/layoutDefinitionService.test.ts
+++ b/apps/api/src/services/__tests__/layoutDefinitionService.test.ts
@@ -18,41 +18,42 @@ vi.mock('../../lib/logger.js', () => ({
 
 // ─── Fake DB pool ─────────────────────────────────────────────────────────────
 
-const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi.hoisted(() => {
+const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery, mockConnect } = vi.hoisted(() => {
   const fakeObjects = new Map<string, Record<string, unknown>>();
   const fakeLayouts = new Map<string, Record<string, unknown>>();
   const fakeLayoutFields = new Map<string, Record<string, unknown>>();
   const fakeFields = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
 
     // SELECT id FROM object_definitions WHERE id = $1
     if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
-      const id = params![0] as string;
+      const id = params[0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
       return { rows: [] };
     }
 
-    // SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2
-    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID = $1 AND NAME = $2') && !s.includes('ID != $3')) {
-      const objectId = params![0] as string;
-      const name = params![1] as string;
+    // SELECT id FROM layout_definitions WHERE object_id AND name (uniqueness check)
+    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS') && s.includes('NAME =')) {
+      const hasExclude = s.includes('ID !=');
+      const objectId = params[0] as string;
+      const name = params[1] as string;
+      const excludeId = hasExclude ? (params[2] as string) : null;
       const match = [...fakeLayouts.values()].find(
-        (l) => l.object_id === objectId && l.name === name,
-      );
-      if (match) return { rows: [{ id: match.id }] };
-      return { rows: [] };
-    }
-
-    // SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND id != $3
-    if (s.startsWith('SELECT ID FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID = $1 AND NAME = $2 AND ID != $3')) {
-      const objectId = params![0] as string;
-      const name = params![1] as string;
-      const excludeId = params![2] as string;
-      const match = [...fakeLayouts.values()].find(
-        (l) => l.object_id === objectId && l.name === name && l.id !== excludeId,
+        (l) => l.object_id === objectId && l.name === name && (excludeId ? l.id !== excludeId : true),
       );
       if (match) return { rows: [{ id: match.id }] };
       return { rows: [] };
@@ -60,7 +61,7 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
 
     // INSERT INTO layout_definitions
     if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
-      const [id, _tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params as unknown[];
+      const [id, _tenant_id, object_id, name, layout_type, is_default, created_at, updated_at] = params;
       const row: Record<string, unknown> = {
         id, object_id, name, layout_type, is_default, created_at, updated_at,
       };
@@ -68,9 +69,9 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
       return { rows: [row] };
     }
 
-    // SELECT * FROM layout_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY
-    if (s.startsWith('SELECT * FROM LAYOUT_DEFINITIONS WHERE OBJECT_ID') && s.includes('ORDER BY')) {
-      const objectId = params![0] as string;
+    // SELECT * FROM layout_definitions ... ORDER BY (list)
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      const objectId = params[0] as string;
       const rows = [...fakeLayouts.values()]
         .filter((l) => l.object_id === objectId)
         .sort((a, b) => {
@@ -82,17 +83,29 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
     }
 
     // SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2
-    if (s.startsWith('SELECT * FROM LAYOUT_DEFINITIONS WHERE ID = $1 AND OBJECT_ID')) {
-      const layoutId = params![0] as string;
-      const objectId = params![1] as string;
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.startsWith('SELECT') && s.includes('ID =') && s.includes('OBJECT_ID =')) {
+      const layoutId = params[0] as string;
+      const objectId = params[1] as string;
       const match = fakeLayouts.get(layoutId);
       if (match && match.object_id === objectId) return { rows: [match] };
       return { rows: [] };
     }
 
     // SELECT lf.*, fd.api_name ... FROM layout_fields lf JOIN field_definitions fd
-    if (s.includes('FROM LAYOUT_FIELDS LF') && s.includes('JOIN FIELD_DEFINITIONS FD')) {
-      const layoutId = params![0] as string;
+    if (s.includes('FROM LAYOUT_FIELDS') && s.includes('FIELD_DEFINITIONS')) {
+      // Under Kysely, the tenant_id params come before the layout_id param.
+      // Walk params to find a value that matches a known layout_id.
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayoutFields.size > 0) {
+          const hasMatch = [...fakeLayoutFields.values()].some((lf) => lf.layout_id === p);
+          if (hasMatch) { layoutId = p; break; }
+        }
+      }
+      if (!layoutId) {
+        // Fallback: any param that's not the tenant_id
+        layoutId = (params.find((p) => p !== 'test-tenant-001') as string) ?? '';
+      }
       const rows = [...fakeLayoutFields.values()]
         .filter((lf) => lf.layout_id === layoutId)
         .sort((a, b) => {
@@ -114,79 +127,108 @@ const { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery } = vi
       return { rows };
     }
 
-    // UPDATE layout_definitions SET ... (general update)
+    // UPDATE layout_definitions SET ... RETURNING
     if (s.startsWith('UPDATE LAYOUT_DEFINITIONS SET') && s.includes('RETURNING')) {
-      // The layout_id and object_id are the last two params
-      const layoutId = params![params!.length - 2] as string;
-      const objectId = params![params!.length - 1] as string;
-      const layout = fakeLayouts.get(layoutId);
-      if (layout && layout.object_id === objectId) {
+      // Find the layout_id from WHERE params — it's the first UUID-looking
+      // param after all the SET params. Walk from the end of the params:
+      // the last few are WHERE clause values.
+      // Under Kysely: SET name=$1, updated_at=$2 WHERE id=$3 AND object_id=$4 AND tenant_id=$5
+      // We need the id from the WHERE. Find it by searching fakeLayouts.
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          layoutId = p;
+          break;
+        }
+      }
+      const layout = layoutId ? fakeLayouts.get(layoutId) : undefined;
+      if (layout) {
         const updated: Record<string, unknown> = { ...layout, updated_at: new Date() };
         let paramIdx = 0;
-        if (s.includes('NAME =')) { updated.name = params![paramIdx++]; }
-        if (s.includes('LAYOUT_TYPE =')) { updated.layout_type = params![paramIdx++]; }
-        fakeLayouts.set(layoutId, updated);
+        if (s.includes('NAME =')) { updated.name = params[paramIdx++]; }
+        if (s.includes('LAYOUT_TYPE =')) { updated.layout_type = params[paramIdx++]; }
+        fakeLayouts.set(layoutId!, updated);
         return { rows: [updated] };
       }
       return { rows: [] };
     }
 
-    // UPDATE layout_definitions SET updated_at = $1 WHERE id = $2 (timestamp only)
+    // UPDATE layout_definitions SET updated_at (timestamp only, no RETURNING)
     if (s.startsWith('UPDATE LAYOUT_DEFINITIONS SET UPDATED_AT') && !s.includes('RETURNING')) {
-      const updatedAt = params![0];
-      const layoutId = params![1] as string;
-      const layout = fakeLayouts.get(layoutId);
-      if (layout) {
-        layout.updated_at = updatedAt;
+      const updatedAt = params[0];
+      // Find layout_id in remaining params
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          fakeLayouts.get(p)!.updated_at = updatedAt;
+          break;
+        }
       }
       return { rows: [] };
     }
 
-    // SELECT id FROM field_definitions WHERE object_id = $1 (for field validation)
-    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS WHERE OBJECT_ID')) {
-      const objectId = params![0] as string;
+    // SELECT id FROM field_definitions WHERE object_id = $1
+    if (s.startsWith('SELECT ID FROM FIELD_DEFINITIONS')) {
+      const objectId = params[0] as string;
       const rows = [...fakeFields.values()]
         .filter((f) => f.object_id === objectId)
         .map((f) => ({ id: f.id }));
       return { rows };
     }
 
-    // DELETE FROM layout_fields WHERE layout_id = $1
-    if (s.startsWith('DELETE FROM LAYOUT_FIELDS WHERE LAYOUT_ID')) {
-      const layoutId = params![0] as string;
+    // DELETE FROM layout_fields
+    if (s.startsWith('DELETE FROM LAYOUT_FIELDS')) {
+      const layoutId = params[0] as string;
       for (const [key, lf] of fakeLayoutFields.entries()) {
         if (lf.layout_id === layoutId) fakeLayoutFields.delete(key);
       }
       return { rows: [] };
     }
 
-    // INSERT INTO layout_fields
+    // INSERT INTO layout_fields — columns: id, tenant_id, layout_id,
+    // field_id, section, section_label, sort_order, width (8 params)
     if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
-      const [id, layout_id, field_id, section, section_label, sort_order, width] = params as unknown[];
+      const [id, _tenant_id, layout_id, field_id, section, section_label, sort_order, width] = params;
       const row: Record<string, unknown> = { id, layout_id, field_id, section, section_label, sort_order, width };
       fakeLayoutFields.set(id as string, row);
       return { rows: [row] };
     }
 
-    // DELETE FROM layout_definitions WHERE id = $1
-    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS WHERE ID')) {
-      const layoutId = params![0] as string;
-      fakeLayouts.delete(layoutId);
-      // Also clean up layout_fields
-      for (const [key, lf] of fakeLayoutFields.entries()) {
-        if (lf.layout_id === layoutId) fakeLayoutFields.delete(key);
+    // DELETE FROM layout_definitions
+    if (s.startsWith('DELETE FROM LAYOUT_DEFINITIONS')) {
+      // Find the layout_id param
+      for (const p of params) {
+        if (typeof p === 'string' && fakeLayouts.has(p)) {
+          fakeLayouts.delete(p);
+          for (const [key, lf] of fakeLayoutFields.entries()) {
+            if (lf.layout_id === p) fakeLayoutFields.delete(key);
+          }
+          break;
+        }
       }
       return { rows: [] };
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  return { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeObjects, fakeLayouts, fakeLayoutFields, fakeFields, mockQuery, mockConnect };
 });
 
 vi.mock('../../db/client.js', () => ({
-  pool: { query: mockQuery },
+  pool: { query: mockQuery, connect: mockConnect },
 }));
 
 // ─── Test helpers ────────────────────────────────────────────────────────────

--- a/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
@@ -280,13 +280,14 @@ describe('pageLayoutService Kysely SQL — publishPageLayout', () => {
     )!;
     const s = normalise(update.sql);
 
-    expect(s).toContain('PUBLISHED_LAYOUT =');
+    expect(s).toContain('PUBLISHED_LAYOUT = LAYOUT');
     expect(s).toContain('VERSION =');
     expect(s).toContain('STATUS =');
     expect(s).toContain('PUBLISHED_AT =');
     expect(s).toContain('UPDATED_AT =');
     expect(s).toContain('RETURNING');
     expect(update.params).toContain(TENANT_ID);
+    expect(update.params.find((p) => typeof p === 'object' && p !== null && !(p instanceof Date))).toBeUndefined();
   });
 
   it('INSERT INTO page_layout_versions carries tenant_id and version', async () => {

--- a/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.kysely-sql.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Kysely SQL regression suite for pageLayoutService.
+ *
+ * Pins the SQL Kysely emits so drift is caught early. Key things verified:
+ *
+ *   1. publishPageLayout uses db.transaction() — no manual BEGIN/COMMIT
+ *      envelope; instead UPDATE + INSERT version run inside a Kysely
+ *      transaction (the driver wraps them in BEGIN/COMMIT).
+ *   2. Conflict check uses IS NULL for null role (no parameter binding).
+ *   3. DELETE scoped by id + tenant_id.
+ *   4. Every data query carries a tenant_id bind.
+ *   5. UPDATE + INSERT version within publish carry correct column sets.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const TENANT_ID = 'sql-tenant-001';
+
+vi.mock('../../lib/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ─── SQL capture ──────────────────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(() => {
+  const capturedQueries: CapturedQuery[] = [];
+
+  function norm(rawSql: string): string {
+    return rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
+
+  const VALID_LAYOUT = JSON.stringify({
+    header: { primaryField: 'name' },
+    tabs: [{ id: 't1', label: 'Tab', sections: [] }],
+  });
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = norm(rawSql);
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
+
+    // object_definitions existence check
+    if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS')) {
+      return { rows: [{ id: params[0] }] };
+    }
+
+    // Conflict check for page_layouts
+    if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID')) {
+      return { rows: [] };
+    }
+
+    // INSERT INTO page_layout_versions
+    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
+      return { rows: [{}] };
+    }
+
+    // INSERT INTO page_layouts
+    if (s.startsWith('INSERT INTO PAGE_LAYOUTS')) {
+      const [id, tenant_id, object_id, name, role, is_default, layout, version, status, created_at, updated_at] = params as unknown[];
+      return {
+        rows: [{
+          id, tenant_id, object_id, name, role, is_default,
+          layout, published_layout: null, version, status,
+          created_at, updated_at, published_at: null,
+        }],
+      };
+    }
+
+    // SELECT * FROM page_layouts ... ORDER BY (list)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      return { rows: [] };
+    }
+
+    // SELECT from page_layouts by id (getById / existence)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT')) {
+      return {
+        rows: [{
+          id: 'pl-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default', role: null, is_default: false,
+          layout: VALID_LAYOUT, published_layout: null,
+          version: 1, status: 'draft',
+          created_at: new Date(), updated_at: new Date(), published_at: null,
+        }],
+      };
+    }
+
+    // UPDATE page_layouts
+    if (s.startsWith('UPDATE PAGE_LAYOUTS')) {
+      return {
+        rows: [{
+          id: 'pl-1', tenant_id: TENANT_ID, object_id: 'obj-1',
+          name: 'Default', role: null, is_default: false,
+          layout: VALID_LAYOUT, published_layout: VALID_LAYOUT,
+          version: 2, status: 'published',
+          created_at: new Date(), updated_at: new Date(), published_at: new Date(),
+        }],
+      };
+    }
+
+    // DELETE FROM page_layouts
+    if (s.startsWith('DELETE FROM PAGE_LAYOUTS')) {
+      return { rows: [] };
+    }
+
+    // SELECT from page_layout_versions
+    if (s.includes('FROM PAGE_LAYOUT_VERSIONS')) {
+      return {
+        rows: [{
+          id: 'v-1', layout_id: 'pl-1', tenant_id: TENANT_ID,
+          version: 1, layout: VALID_LAYOUT,
+          published_by: 'user-1', published_at: new Date(),
+        }],
+      };
+    }
+
+    return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
+  });
+
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  function resetCapture() {
+    capturedQueries.length = 0;
+  }
+
+  return { capturedQueries, mockQuery, mockConnect, resetCapture };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const {
+  createPageLayout,
+  publishPageLayout,
+  deletePageLayout,
+  updatePageLayout,
+  listPageLayouts,
+} = await import('../pageLayoutService.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries(): CapturedQuery[] {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
+}
+
+function allQueries(): CapturedQuery[] {
+  return capturedQueries;
+}
+
+beforeEach(() => {
+  resetCapture();
+});
+
+const VALID_LAYOUT_JSON = {
+  header: { primaryField: 'name', secondaryFields: ['stage'], actions: ['edit'] },
+  tabs: [{
+    id: 'tab-1', label: 'Details',
+    sections: [{
+      id: 'sec-1', type: 'field_section', label: 'Info', columns: 2,
+      components: [{ id: 'comp-1', type: 'field', config: { fieldId: 'uuid-1', span: 1 } }],
+    }],
+  }],
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('pageLayoutService Kysely SQL — createPageLayout', () => {
+  it('conflict check uses IS NULL for null role (no param binding)', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Default Page',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const conflictCheck = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID');
+    })!;
+    const s = normalise(conflictCheck.sql);
+
+    expect(s).toContain('ROLE IS NULL');
+    expect(conflictCheck.params).toContain(TENANT_ID);
+    expect(conflictCheck.params).toContain('obj-1');
+    expect(conflictCheck.params).not.toContainEqual(null);
+  });
+
+  it('conflict check binds role as parameter for non-null role', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Admin Page',
+      role: 'admin',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const conflictCheck = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID');
+    })!;
+    const s = normalise(conflictCheck.sql);
+
+    expect(s).toContain('ROLE =');
+    expect(s).not.toContain('IS NULL');
+    expect(conflictCheck.params).toContain('admin');
+  });
+
+  it('INSERT carries tenant_id and JSON-stringified layout', async () => {
+    await createPageLayout(TENANT_ID, 'obj-1', {
+      name: 'Default Page',
+      layout: VALID_LAYOUT_JSON,
+    });
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO PAGE_LAYOUTS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('RETURNING');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('Default Page');
+    const layoutParam = insert.params.find((p) => typeof p === 'string' && p.includes('primaryField'));
+    expect(layoutParam).toBeDefined();
+  });
+});
+
+describe('pageLayoutService Kysely SQL — publishPageLayout', () => {
+  it('wraps UPDATE + INSERT version in a Kysely transaction (BEGIN/COMMIT present)', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const raw = allQueries().map((q) => normalise(q.sql));
+    expect(raw).toContain('BEGIN');
+    expect(raw).toContain('COMMIT');
+
+    const beginIdx = raw.indexOf('BEGIN');
+    const commitIdx = raw.indexOf('COMMIT');
+    expect(beginIdx).toBeLessThan(commitIdx);
+  });
+
+  it('UPDATE sets published_layout, version, status, published_at, updated_at', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const update = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE PAGE_LAYOUTS SET'),
+    )!;
+    const s = normalise(update.sql);
+
+    expect(s).toContain('PUBLISHED_LAYOUT =');
+    expect(s).toContain('VERSION =');
+    expect(s).toContain('STATUS =');
+    expect(s).toContain('PUBLISHED_AT =');
+    expect(s).toContain('UPDATED_AT =');
+    expect(s).toContain('RETURNING');
+    expect(update.params).toContain(TENANT_ID);
+  });
+
+  it('INSERT INTO page_layout_versions carries tenant_id and version', async () => {
+    await publishPageLayout(TENANT_ID, 'obj-1', 'pl-1', 'user-123');
+
+    const insert = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS'),
+    )!;
+    const s = normalise(insert.sql);
+
+    expect(s).toContain('TENANT_ID');
+    expect(s).toContain('LAYOUT_ID');
+    expect(s).toContain('VERSION');
+    expect(s).toContain('PUBLISHED_BY');
+    expect(insert.params).toContain(TENANT_ID);
+    expect(insert.params).toContain('pl-1');
+    expect(insert.params).toContain('user-123');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — deletePageLayout', () => {
+  it('DELETE scoped by id + tenant_id', async () => {
+    await deletePageLayout(TENANT_ID, 'obj-1', 'pl-1');
+
+    const del = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('DELETE FROM PAGE_LAYOUTS'),
+    )!;
+    const s = normalise(del.sql);
+
+    expect(s).toContain('ID =');
+    expect(s).toContain('TENANT_ID =');
+    expect(del.params).toContain(TENANT_ID);
+    expect(del.params).toContain('pl-1');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — updatePageLayout', () => {
+  it('UPDATE carries tenant_id in WHERE and RETURNING', async () => {
+    await updatePageLayout(TENANT_ID, 'obj-1', 'pl-1', { name: 'Renamed' });
+
+    const update = dataQueries().find((q) =>
+      normalise(q.sql).startsWith('UPDATE PAGE_LAYOUTS SET'),
+    )!;
+    const s = normalise(update.sql);
+
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('RETURNING');
+    expect(update.params).toContain(TENANT_ID);
+    expect(update.params).toContain('Renamed');
+  });
+});
+
+describe('pageLayoutService Kysely SQL — listPageLayouts', () => {
+  it('SELECT ordered by name with tenant_id + object_id filter', async () => {
+    await listPageLayouts(TENANT_ID, 'obj-1');
+
+    const select = dataQueries().find((q) => {
+      const s = normalise(q.sql);
+      return s.includes('FROM PAGE_LAYOUTS') && s.includes('ORDER BY');
+    })!;
+    const s = normalise(select.sql);
+
+    expect(s).toContain('TENANT_ID =');
+    expect(s).toContain('OBJECT_ID =');
+    expect(s).toMatch(/ORDER BY NAME/);
+    expect(select.params).toContain(TENANT_ID);
+    expect(select.params).toContain('obj-1');
+  });
+});

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -26,12 +26,23 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
   const fakePageLayouts = new Map<string, Record<string, unknown>>();
   const fakePageLayoutVersions = new Map<string, Record<string, unknown>>();
 
-  const mockQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  function runQuery(rawSql: string, params: unknown[]) {
+    const s = rawSql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
 
     // SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2
     if (s.startsWith('SELECT ID FROM OBJECT_DEFINITIONS WHERE ID')) {
-      const id = params![0] as string;
+      const id = params[0] as string;
       const row = fakeObjects.get(id);
       if (row) return { rows: [{ id: row.id }] };
       return { rows: [] };
@@ -39,10 +50,20 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
 
     // SELECT id FROM page_layouts WHERE tenant_id = ... (conflict check)
     if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE TENANT_ID')) {
-      const tenantId = params![0] as string;
-      const objectId = params![1] as string;
-      const role = params!.length > 2 ? (params![2] as string) : null;
-      const excludeId = s.includes('ID !=') ? (params![2] as string) : undefined;
+      const tenantId = params[0] as string;
+      const objectId = params[1] as string;
+      const hasExclude = s.includes('ID !=');
+      const isNullRole = s.includes('IS NULL');
+
+      let excludeId: string | undefined;
+      let role: string | null;
+
+      if (hasExclude) {
+        excludeId = params[2] as string;
+        role = isNullRole ? null : (params[3] as string);
+      } else {
+        role = isNullRole ? null : (params[2] as string);
+      }
 
       const match = [...fakePageLayouts.values()].find((l) => {
         if (l.tenant_id !== tenantId || l.object_id !== objectId) return false;
@@ -54,6 +75,35 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       if (match) return { rows: [{ id: match.id }] };
       return { rows: [] };
     }
+
+    // ── page_layout_versions (more specific, must precede page_layouts) ──
+
+    // INSERT INTO page_layout_versions
+    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
+      const [id, layout_id, tenant_id, version, layout, published_by, published_at] = params as unknown[];
+      const row: Record<string, unknown> = {
+        id, layout_id, tenant_id, version, layout, published_by, published_at,
+      };
+      fakePageLayoutVersions.set(id as string, row);
+      return { rows: [row] };
+    }
+
+    // SELECT * FROM page_layout_versions
+    if (s.includes('FROM PAGE_LAYOUT_VERSIONS') && s.startsWith('SELECT')) {
+      const layoutId = params[0] as string;
+      const tenantId = params[1] as string;
+      const version = params.length > 2 ? (params[2] as number) : undefined;
+      const rows = [...fakePageLayoutVersions.values()]
+        .filter((v) => {
+          if (v.layout_id !== layoutId || v.tenant_id !== tenantId) return false;
+          if (version !== undefined) return v.version === version;
+          return true;
+        })
+        .sort((a, b) => (b.version as number) - (a.version as number));
+      return { rows };
+    }
+
+    // ── page_layouts ─────────────────────────────────────────────────────
 
     // INSERT INTO page_layouts
     if (s.startsWith('INSERT INTO PAGE_LAYOUTS')) {
@@ -68,120 +118,88 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       return { rows: [row] };
     }
 
-    // SELECT * FROM page_layouts WHERE tenant_id = ... ORDER BY name
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUTS WHERE TENANT_ID') && s.includes('ORDER BY')) {
-      const tenantId = params![0] as string;
-      const objectId = params![1] as string;
+    // SELECT * FROM page_layouts ... ORDER BY (list)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('ORDER BY')) {
+      const tenantId = params[0] as string;
+      const objectId = params[1] as string;
       const rows = [...fakePageLayouts.values()]
         .filter((l) => l.tenant_id === tenantId && l.object_id === objectId)
         .sort((a, b) => (a.name as string).localeCompare(b.name as string));
       return { rows };
     }
 
-    // SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
+    // SELECT ... FROM page_layouts WHERE id = ... (getById / existence check)
+    if (s.includes('FROM PAGE_LAYOUTS') && s.startsWith('SELECT') && s.includes('WHERE ID =')) {
+      const id = params[0] as string;
       const row = fakePageLayouts.get(id);
-      if (row && row.tenant_id === params![1] && row.object_id === params![2]) {
+      if (row && row.tenant_id === params[1] && row.object_id === params[2]) {
         return { rows: [row] };
       }
       return { rows: [] };
     }
 
-    // SELECT id FROM page_layouts WHERE id = ... (for listVersions check)
-    if (s.startsWith('SELECT ID FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
-      const row = fakePageLayouts.get(id);
-      if (row && row.tenant_id === params![1] && row.object_id === params![2]) {
-        return { rows: [{ id: row.id }] };
-      }
-      return { rows: [] };
-    }
-
-    // UPDATE page_layouts SET published_layout ... (publish)
-    if (s.startsWith('UPDATE PAGE_LAYOUTS') && s.includes('PUBLISHED_LAYOUT = LAYOUT')) {
-      const newVersion = params![0] as number;
-      const now = params![1] as Date;
-      const layoutId = params![2] as string;
-      const row = fakePageLayouts.get(layoutId);
-      if (row) {
-        row.published_layout = row.layout;
-        row.version = newVersion;
-        row.status = 'published';
-        row.published_at = now;
-        row.updated_at = now;
-        return { rows: [row] };
-      }
-      return { rows: [] };
-    }
-
-    // UPDATE page_layouts SET ... (general update)
+    // UPDATE page_layouts SET ...
     if (s.startsWith('UPDATE PAGE_LAYOUTS SET')) {
-      // Find the layout ID in params (second-to-last param)
-      const layoutId = params![params!.length - 2] as string;
-      const row = fakePageLayouts.get(layoutId);
-      if (row) {
-        // Apply updates from params based on SQL fragments
-        const sqlLower = sql.toLowerCase();
-        let paramIdx = 0;
-        if (sqlLower.includes('name =')) { row.name = params![paramIdx++]; }
-        if (sqlLower.includes('role =')) { row.role = params![paramIdx++]; }
-        if (sqlLower.includes('layout =')) {
-          const val = params![paramIdx++];
-          row.layout = typeof val === 'string' ? JSON.parse(val) : val;
+      let layoutId: string | undefined;
+      for (const p of params) {
+        if (typeof p === 'string' && fakePageLayouts.has(p)) {
+          layoutId = p;
+          break;
         }
-        if (sqlLower.includes('is_default =')) { row.is_default = params![paramIdx++]; }
-        row.updated_at = params![paramIdx] ?? new Date();
+      }
+      const row = layoutId ? fakePageLayouts.get(layoutId) : undefined;
+      if (row) {
+        if (s.includes('PUBLISHED_LAYOUT')) {
+          // Publish: SET published_layout=$1, version=$2, status=$3, published_at=$4, updated_at=$5
+          const [published_layout, version, _status, published_at, updated_at] = params;
+          row.published_layout = typeof published_layout === 'string'
+            ? JSON.parse(published_layout as string)
+            : published_layout;
+          row.version = version;
+          row.status = 'published';
+          row.published_at = published_at;
+          row.updated_at = updated_at;
+        } else {
+          // General / copy / revert update
+          let paramIdx = 0;
+          if (s.includes('NAME =')) { row.name = params[paramIdx++]; }
+          if (s.includes('ROLE =')) { row.role = params[paramIdx++]; }
+          if (s.includes('LAYOUT =')) {
+            const val = params[paramIdx++];
+            row.layout = typeof val === 'string' ? JSON.parse(val as string) : val;
+          }
+          if (s.includes('IS_DEFAULT =')) { row.is_default = params[paramIdx++]; }
+          row.updated_at = params[paramIdx] ?? new Date();
+        }
         return { rows: [row] };
       }
       return { rows: [] };
     }
 
-    // INSERT INTO page_layout_versions
-    if (s.startsWith('INSERT INTO PAGE_LAYOUT_VERSIONS')) {
-      const [id, layout_id, tenant_id, version, layout, published_by, published_at] = params as unknown[];
-      const row: Record<string, unknown> = {
-        id, layout_id, tenant_id, version, layout, published_by, published_at,
-      };
-      fakePageLayoutVersions.set(id as string, row);
-      return { rows: [row] };
-    }
-
-    // SELECT * FROM page_layout_versions WHERE layout_id = ... AND tenant_id = ... AND version = ...
-    if (s.startsWith('SELECT * FROM PAGE_LAYOUT_VERSIONS WHERE LAYOUT_ID') && s.includes('VERSION')) {
-      const layoutId = params![0] as string;
-      const tenantId = params![1] as string;
-      const version = params!.length > 2 ? (params![2] as number) : undefined;
-      const rows = [...fakePageLayoutVersions.values()]
-        .filter((v) => {
-          if (v.layout_id !== layoutId || v.tenant_id !== tenantId) return false;
-          if (version !== undefined) return v.version === version;
-          return true;
-        })
-        .sort((a, b) => (b.version as number) - (a.version as number));
-      return { rows };
-    }
-
-    // DELETE FROM page_layouts WHERE id = $1 AND tenant_id = $2
-    if (s.startsWith('DELETE FROM PAGE_LAYOUTS WHERE ID')) {
-      const id = params![0] as string;
-      fakePageLayouts.delete(id);
-      return { rows: [] };
-    }
-
-    // Transaction control statements (no-op in tests)
-    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+    // DELETE FROM page_layouts
+    if (s.startsWith('DELETE FROM PAGE_LAYOUTS')) {
+      for (const p of params) {
+        if (typeof p === 'string' && fakePageLayouts.has(p)) {
+          fakePageLayouts.delete(p);
+          break;
+        }
+      }
       return { rows: [] };
     }
 
     return { rows: [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  // The publish flow uses pool.connect() for transactions.  Return a fake
-  // client whose .query() delegates to the same mockQuery so the in-memory
-  // data stores stay consistent.
   const mockConnect = vi.fn(async () => ({
-    query: mockQuery,
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
     release: vi.fn(),
   }));
 

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -149,12 +149,10 @@ const { fakeObjects, fakePageLayouts, fakePageLayoutVersions, mockQuery, mockCon
       }
       const row = layoutId ? fakePageLayouts.get(layoutId) : undefined;
       if (row) {
-        if (s.includes('PUBLISHED_LAYOUT')) {
-          // Publish: SET published_layout=$1, version=$2, status=$3, published_at=$4, updated_at=$5
-          const [published_layout, version, _status, published_at, updated_at] = params;
-          row.published_layout = typeof published_layout === 'string'
-            ? JSON.parse(published_layout as string)
-            : published_layout;
+        if (s.includes('PUBLISHED_LAYOUT = LAYOUT')) {
+          // Publish: SET published_layout=layout (column ref), version=$1, status=$2, published_at=$3, updated_at=$4
+          row.published_layout = row.layout;
+          const [version, _status, published_at, updated_at] = params;
           row.version = version;
           row.status = 'published';
           row.published_at = published_at;

--- a/apps/api/src/services/__tests__/seedDefaultObjects.test.ts
+++ b/apps/api/src/services/__tests__/seedDefaultObjects.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { seedWithClient, SEED_COUNTS } from '../seedDefaultObjects.js';
 import type { SeedResult } from '../seedDefaultObjects.js';
 
 vi.mock('../../lib/logger.js', () => ({
@@ -10,7 +9,7 @@ vi.mock('../../lib/logger.js', () => ({
 
 interface FakeRow { id: string; [key: string]: unknown }
 
-function createFakeDb() {
+const { fakeDb, mockQuery, mockConnect, clearFakeDb, capturedQueries } = vi.hoisted(() => {
   const objects = new Map<string, FakeRow>();
   const fields = new Map<string, FakeRow>();
   const relationships = new Map<string, FakeRow>();
@@ -21,7 +20,15 @@ function createFakeDb() {
   const stages = new Map<string, FakeRow>();
   const stageGates = new Map<string, FakeRow>();
 
-  function clear() {
+  const fakeDb = {
+    objects, fields, relationships, layouts, layoutFields,
+    leadConversionMappings, pipelines, stages, stageGates,
+  };
+
+  interface CapturedQuery { sql: string; params: unknown[] }
+  const capturedQueries: CapturedQuery[] = [];
+
+  function clearFakeDb() {
     objects.clear();
     fields.clear();
     relationships.clear();
@@ -31,59 +38,70 @@ function createFakeDb() {
     pipelines.clear();
     stages.clear();
     stageGates.clear();
+    capturedQueries.length = 0;
   }
 
-  return { objects, fields, relationships, layouts, layoutFields, leadConversionMappings, pipelines, stages, stageGates, clear };
-}
+  function normalise(sql: string): string {
+    return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+  }
 
-// ─── Mock client ──────────────────────────────────────────────────────────────
+  function extractInsertRow(sql: string, params: unknown[]): Record<string, unknown> {
+    const normalized = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim();
+    const match = normalized.match(/INSERT INTO \w+ \(([^)]+)\)/i);
+    if (!match) return {};
+    const columns = match[1].split(',').map((c) => c.trim().toLowerCase());
+    const row: Record<string, unknown> = {};
+    columns.forEach((col, i) => { row[col] = params[i]; });
+    return row;
+  }
 
-function createMockClient(db: ReturnType<typeof createFakeDb>) {
-  const queryFn = vi.fn(async (sql: string, params?: unknown[]) => {
-    const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+  function runQuery(rawSql: string, params: unknown[]) {
+    capturedQueries.push({ sql: rawSql, params });
+    const s = normalise(rawSql);
 
-    // INSERT INTO object_definitions ... ON CONFLICT ... RETURNING id
+    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+    if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
+
+    // ── INSERT INTO object_definitions ──
     if (s.startsWith('INSERT INTO OBJECT_DEFINITIONS')) {
-      const [id, apiName, label, pluralLabel, description, icon, ownerId, tenantId] = params as string[];
-      // Check for conflict on (tenant_id, api_name)
-      const existing = [...db.objects.values()].find((o) => o.tenant_id === tenantId && o.api_name === apiName);
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...objects.values()].find(
+        (o) => o.tenant_id === row.tenant_id && o.api_name === row.api_name,
+      );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id, api_name: apiName, label, plural_label: pluralLabel, description, icon, is_system: true, owner_id: ownerId, tenant_id: tenantId };
-      db.objects.set(id, row);
-      return { rows: [{ id }] };
+      objects.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // SELECT id, api_name FROM object_definitions WHERE api_name = ANY($1) AND tenant_id = $2
-    if (s.includes('FROM OBJECT_DEFINITIONS') && s.includes('ANY')) {
-      const apiNames = params![0] as string[];
-      const tenantId = params![1] as string;
-      const rows = [...db.objects.values()]
+    // ── SELECT ... FROM object_definitions WHERE api_name IN (...) ──
+    if (s.includes('FROM OBJECT_DEFINITIONS') && !s.startsWith('INSERT') && !s.startsWith('UPDATE') && s.includes('IN (')) {
+      const tenantId = params[params.length - 1] as string;
+      const apiNames = params.slice(0, -1) as string[];
+      const rows = [...objects.values()]
         .filter((o) => apiNames.includes(o.api_name as string) && o.tenant_id === tenantId)
         .map((o) => ({ id: o.id, api_name: o.api_name }));
       return { rows };
     }
 
-    // INSERT INTO field_definitions ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO field_definitions ──
     if (s.startsWith('INSERT INTO FIELD_DEFINITIONS')) {
-      const [id, objectId, apiName, label, fieldType, required, options, sortOrder, isSystem, tenantId] = params as unknown[];
-      const existing = [...db.fields.values()].find(
-        (f) => f.tenant_id === tenantId && f.object_id === objectId && f.api_name === apiName,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...fields.values()].find(
+        (f) => f.tenant_id === row.tenant_id && f.object_id === row.object_id && f.api_name === row.api_name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id: id as string, object_id: objectId, api_name: apiName, label, field_type: fieldType, required, options, sort_order: sortOrder, is_system: isSystem, tenant_id: tenantId };
-      db.fields.set(id as string, row);
-      return { rows: [{ id }] };
+      fields.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // SELECT fd.id, od.api_name ... FROM field_definitions fd JOIN object_definitions od ... AND fd.tenant_id = $2
-    if (s.includes('FROM FIELD_DEFINITIONS FD') && s.includes('JOIN OBJECT_DEFINITIONS OD')) {
-      const apiNames = params![0] as string[];
-      const tenantId = params![1] as string;
+    // ── SELECT fd.id ... FROM field_definitions fd JOIN object_definitions od ──
+    if (s.includes('FROM FIELD_DEFINITIONS') && s.includes('JOIN OBJECT_DEFINITIONS')) {
+      const tenantId = params[params.length - 1] as string;
+      const apiNames = params.slice(0, -1) as string[];
       const rows: { id: string; object_api_name: string; api_name: string }[] = [];
-      for (const field of db.fields.values()) {
+      for (const field of fields.values()) {
         if (field.tenant_id !== tenantId) continue;
-        const obj = db.objects.get(field.object_id as string) ??
-          [...db.objects.values()].find((o) => o.id === field.object_id);
+        const obj = [...objects.values()].find((o) => o.id === field.object_id);
         if (obj && apiNames.includes(obj.api_name as string)) {
           rows.push({
             id: field.id,
@@ -95,39 +113,36 @@ function createMockClient(db: ReturnType<typeof createFakeDb>) {
       return { rows };
     }
 
-    // INSERT INTO relationship_definitions ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO relationship_definitions ──
     if (s.startsWith('INSERT INTO RELATIONSHIP_DEFINITIONS')) {
-      const [id, sourceObjectId, targetObjectId, relationshipType, apiName, , , , tenantId] = params as string[];
-      const existing = [...db.relationships.values()].find(
-        (r) => r.tenant_id === tenantId && r.source_object_id === sourceObjectId && r.api_name === apiName,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...relationships.values()].find(
+        (r) => r.tenant_id === row.tenant_id && r.source_object_id === row.source_object_id && r.api_name === row.api_name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id, source_object_id: sourceObjectId, target_object_id: targetObjectId, relationship_type: relationshipType, api_name: apiName, tenant_id: tenantId };
-      db.relationships.set(id, row);
-      return { rows: [{ id }] };
+      relationships.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // INSERT INTO layout_definitions ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO layout_definitions ──
     if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
-      const [id, objectId, name, , tenantId] = params as string[];
-      const existing = [...db.layouts.values()].find(
-        (l) => l.tenant_id === tenantId && l.object_id === objectId && l.name === name,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...layouts.values()].find(
+        (l) => l.tenant_id === row.tenant_id && l.object_id === row.object_id && l.name === row.name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id, object_id: objectId, name, tenant_id: tenantId };
-      db.layouts.set(id, row);
-      return { rows: [{ id }] };
+      layouts.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // SELECT ld.id, od.api_name ... FROM layout_definitions ld JOIN object_definitions od ... AND ld.tenant_id = $2
-    if (s.includes('FROM LAYOUT_DEFINITIONS LD') && s.includes('JOIN OBJECT_DEFINITIONS OD')) {
-      const apiNames = params![0] as string[];
-      const tenantId = params![1] as string;
+    // ── SELECT ld.id ... FROM layout_definitions ld JOIN object_definitions od ──
+    if (s.includes('FROM LAYOUT_DEFINITIONS') && s.includes('JOIN OBJECT_DEFINITIONS')) {
+      const tenantId = params[params.length - 1] as string;
+      const apiNames = params.slice(0, -1) as string[];
       const rows: { id: string; object_api_name: string; name: string }[] = [];
-      for (const layout of db.layouts.values()) {
+      for (const layout of layouts.values()) {
         if (layout.tenant_id !== tenantId) continue;
-        const obj = db.objects.get(layout.object_id as string) ??
-          [...db.objects.values()].find((o) => o.id === layout.object_id);
+        const obj = [...objects.values()].find((o) => o.id === layout.object_id);
         if (obj && apiNames.includes(obj.api_name as string)) {
           rows.push({
             id: layout.id,
@@ -139,83 +154,73 @@ function createMockClient(db: ReturnType<typeof createFakeDb>) {
       return { rows };
     }
 
-    // INSERT INTO layout_fields ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO layout_fields ──
     if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
-      const [id, layoutId, fieldId, section, sectionLabel, sortOrder, width, tenantId] = params as unknown[];
-      const existing = [...db.layoutFields.values()].find(
-        (lf) => lf.tenant_id === tenantId && lf.layout_id === layoutId && lf.field_id === fieldId,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...layoutFields.values()].find(
+        (lf) => lf.tenant_id === row.tenant_id && lf.layout_id === row.layout_id && lf.field_id === row.field_id,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id: id as string, layout_id: layoutId, field_id: fieldId, section, section_label: sectionLabel, sort_order: sortOrder, width, tenant_id: tenantId };
-      db.layoutFields.set(id as string, row);
-      return { rows: [{ id }] };
+      layoutFields.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // INSERT INTO lead_conversion_mappings ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO lead_conversion_mappings ──
     if (s.startsWith('INSERT INTO LEAD_CONVERSION_MAPPINGS')) {
-      const [id, leadFieldApiName, targetObject, targetFieldApiName, tenantId] = params as string[];
-      const existing = [...db.leadConversionMappings.values()].find(
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...leadConversionMappings.values()].find(
         (m) =>
-          m.tenant_id === tenantId &&
-          m.lead_field_api_name === leadFieldApiName &&
-          m.target_object === targetObject &&
-          m.target_field_api_name === targetFieldApiName,
+          m.tenant_id === row.tenant_id &&
+          m.lead_field_api_name === row.lead_field_api_name &&
+          m.target_object === row.target_object &&
+          m.target_field_api_name === row.target_field_api_name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = {
-        id,
-        lead_field_api_name: leadFieldApiName,
-        target_object: targetObject,
-        target_field_api_name: targetFieldApiName,
-        tenant_id: tenantId,
-      };
-      db.leadConversionMappings.set(id, row);
-      return { rows: [{ id }] };
+      leadConversionMappings.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // INSERT INTO pipeline_definitions ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO pipeline_definitions ──
     if (s.startsWith('INSERT INTO PIPELINE_DEFINITIONS')) {
-      const [id, tenantId, objectId, name, apiName, , isSystem, ownerId] = params as unknown[];
-      const existing = [...db.pipelines.values()].find(
-        (p) => p.tenant_id === tenantId && p.object_id === objectId && p.api_name === apiName,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...pipelines.values()].find(
+        (p) => p.tenant_id === row.tenant_id && p.object_id === row.object_id && p.api_name === row.api_name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id: id as string, tenant_id: tenantId, object_id: objectId, name, api_name: apiName, is_system: isSystem, owner_id: ownerId };
-      db.pipelines.set(id as string, row);
-      return { rows: [{ id }] };
+      pipelines.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // SELECT id, api_name FROM pipeline_definitions WHERE api_name = ANY($1) AND tenant_id = $2
-    if (s.includes('FROM PIPELINE_DEFINITIONS') && s.includes('ANY')) {
-      const apiNames = params![0] as string[];
-      const tenantId = params![1] as string;
-      const rows = [...db.pipelines.values()]
+    // ── SELECT ... FROM pipeline_definitions WHERE api_name IN (...) ──
+    if (s.includes('FROM PIPELINE_DEFINITIONS') && !s.startsWith('INSERT') && s.includes('IN (')) {
+      const tenantId = params[params.length - 1] as string;
+      const apiNames = params.slice(0, -1) as string[];
+      const rows = [...pipelines.values()]
         .filter((p) => apiNames.includes(p.api_name as string) && p.tenant_id === tenantId)
         .map((p) => ({ id: p.id, api_name: p.api_name }));
       return { rows };
     }
 
-    // INSERT INTO stage_definitions ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO stage_definitions ──
     if (s.startsWith('INSERT INTO STAGE_DEFINITIONS')) {
-      const [id, tenantId, pipelineId, name, apiName, sortOrder, stageType, colour, defaultProbability, expectedDays] = params as unknown[];
-      const existing = [...db.stages.values()].find(
-        (st) => st.tenant_id === tenantId && st.pipeline_id === pipelineId && st.api_name === apiName,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...stages.values()].find(
+        (st) => st.tenant_id === row.tenant_id && st.pipeline_id === row.pipeline_id && st.api_name === row.api_name,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id: id as string, tenant_id: tenantId, pipeline_id: pipelineId, name, api_name: apiName, sort_order: sortOrder, stage_type: stageType, colour, default_probability: defaultProbability, expected_days: expectedDays };
-      db.stages.set(id as string, row);
-      return { rows: [{ id }] };
+      stages.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
     }
 
-    // SELECT sd.id, sd.api_name, pd.api_name AS pipeline_api_name FROM stage_definitions sd JOIN pipeline_definitions pd ...
-    if (s.includes('FROM STAGE_DEFINITIONS SD') && s.includes('JOIN PIPELINE_DEFINITIONS PD')) {
-      const pipelineIds = params![0] as string[];
-      const tenantId = params![1] as string;
+    // ── SELECT sd.id ... FROM stage_definitions sd JOIN pipeline_definitions pd ──
+    if (s.includes('FROM STAGE_DEFINITIONS') && s.includes('JOIN PIPELINE_DEFINITIONS')) {
+      const tenantId = params[params.length - 1] as string;
+      const pipelineIds = params.slice(0, -1) as string[];
       const rows: { id: string; api_name: string; pipeline_api_name: string }[] = [];
-      for (const stage of db.stages.values()) {
+      for (const stage of stages.values()) {
         if (stage.tenant_id !== tenantId) continue;
         if (!pipelineIds.includes(stage.pipeline_id as string)) continue;
-        const pipeline = [...db.pipelines.values()].find((p) => p.id === stage.pipeline_id);
+        const pipeline = [...pipelines.values()].find((p) => p.id === stage.pipeline_id);
         if (pipeline) {
           rows.push({
             id: stage.id,
@@ -227,91 +232,135 @@ function createMockClient(db: ReturnType<typeof createFakeDb>) {
       return { rows };
     }
 
-    // INSERT INTO stage_gates ... ON CONFLICT ... RETURNING id
+    // ── INSERT INTO stage_gates ──
     if (s.startsWith('INSERT INTO STAGE_GATES')) {
-      const [id, tenantId, stageId, fieldId, gateType, gateValue, errorMessage] = params as unknown[];
-      const existing = [...db.stageGates.values()].find(
-        (g) => g.tenant_id === tenantId && g.stage_id === stageId && g.field_id === fieldId,
+      const row = extractInsertRow(rawSql, params);
+      const existing = [...stageGates.values()].find(
+        (g) => g.tenant_id === row.tenant_id && g.stage_id === row.stage_id && g.field_id === row.field_id,
       );
       if (existing) return { rows: [] };
-      const row: FakeRow = { id: id as string, tenant_id: tenantId, stage_id: stageId, field_id: fieldId, gate_type: gateType, gate_value: gateValue, error_message: errorMessage };
-      db.stageGates.set(id as string, row);
-      return { rows: [{ id }] };
+      stageGates.set(row.id as string, { ...row, id: row.id as string });
+      return { rows: [{ id: row.id }] };
+    }
+
+    // ── UPDATE object_definitions (name_field_id / name_template) ──
+    if (s.startsWith('UPDATE OBJECT_DEFINITIONS')) {
+      return { rows: [] };
     }
 
     return { rows: [] };
+  }
+
+  function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+    if (typeof sqlOrQuery === 'string') {
+      return { sql: sqlOrQuery, params: paramsArg ?? [] };
+    }
+    const q = sqlOrQuery as { text: string; values?: unknown[] };
+    return { sql: q.text, params: q.values ?? [] };
+  }
+
+  const mockQuery = vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+    const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+    return runQuery(sql, params);
   });
 
-  return { query: queryFn };
+  const mockConnect = vi.fn(async () => ({
+    query: vi.fn(async (sqlOrQuery: unknown, paramsArg?: unknown[]) => {
+      const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
+      return runQuery(sql, params);
+    }),
+    release: vi.fn(),
+  }));
+
+  return { fakeDb, mockQuery, mockConnect, clearFakeDb, capturedQueries };
+});
+
+vi.mock('../../db/client.js', () => ({
+  pool: { query: mockQuery, connect: mockConnect },
+}));
+
+const { seedDefaultObjects, SEED_COUNTS } = await import('../seedDefaultObjects.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function normalise(sql: string): string {
+  return sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
+}
+
+function dataQueries() {
+  return capturedQueries.filter((q) => {
+    const s = normalise(q.sql);
+    return (
+      s !== 'BEGIN' &&
+      s !== 'COMMIT' &&
+      s !== 'ROLLBACK' &&
+      !s.startsWith('RESET ') &&
+      !s.startsWith('SELECT SET_CONFIG')
+    );
+  });
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('seedDefaultObjects', () => {
-  const db = createFakeDb();
-  let client: ReturnType<typeof createMockClient>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    db.clear();
-    client = createMockClient(db);
+    clearFakeDb();
   });
 
   it('creates all 11 object definitions on a fresh database', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.objectsCreated).toBe(SEED_COUNTS.objects);
     expect(result.objectsSkipped).toBe(0);
-    expect(db.objects.size).toBe(11);
+    expect(fakeDb.objects.size).toBe(11);
   });
 
   it('creates all field definitions', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.fieldsCreated).toBe(SEED_COUNTS.fields);
     expect(result.fieldsSkipped).toBe(0);
-    expect(db.fields.size).toBe(SEED_COUNTS.fields);
+    expect(fakeDb.fields.size).toBe(SEED_COUNTS.fields);
   });
 
   it('creates all relationship definitions', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.relationshipsCreated).toBe(SEED_COUNTS.relationships);
     expect(result.relationshipsSkipped).toBe(0);
-    expect(db.relationships.size).toBe(SEED_COUNTS.relationships);
+    expect(fakeDb.relationships.size).toBe(SEED_COUNTS.relationships);
   });
 
   it('creates all layout definitions', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.layoutsCreated).toBe(SEED_COUNTS.layouts);
     expect(result.layoutsSkipped).toBe(0);
-    expect(db.layouts.size).toBe(SEED_COUNTS.layouts);
+    expect(fakeDb.layouts.size).toBe(SEED_COUNTS.layouts);
   });
 
   it('creates all layout fields', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.layoutFieldsCreated).toBe(SEED_COUNTS.layoutFields);
     expect(result.layoutFieldsSkipped).toBe(0);
-    expect(db.layoutFields.size).toBe(SEED_COUNTS.layoutFields);
+    expect(fakeDb.layoutFields.size).toBe(SEED_COUNTS.layoutFields);
   });
 
   it('creates all lead conversion mappings', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(result.leadConversionMappingsCreated).toBe(SEED_COUNTS.leadConversionMappings);
     expect(result.leadConversionMappingsSkipped).toBe(0);
-    expect(db.leadConversionMappings.size).toBe(SEED_COUNTS.leadConversionMappings);
+    expect(fakeDb.leadConversionMappings.size).toBe(SEED_COUNTS.leadConversionMappings);
   });
 
   it('is idempotent — re-running skips all existing data', async () => {
-    // First run — everything created
-    const first = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const first = await seedDefaultObjects('tenant-1', 'owner-1');
     expect(first.objectsCreated).toBe(11);
 
-    // Second run — everything skipped
-    const second = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const second = await seedDefaultObjects('tenant-1', 'owner-1');
 
     expect(second.objectsCreated).toBe(0);
     expect(second.objectsSkipped).toBe(11);
@@ -334,27 +383,28 @@ describe('seedDefaultObjects', () => {
   });
 
   it('passes the tenantId and ownerId to object definitions', async () => {
-    await seedWithClient(client, 'my-tenant', 'my-owner');
+    await seedDefaultObjects('my-tenant', 'my-owner');
 
-    const accountObj = [...db.objects.values()].find((o) => o.api_name === 'account');
+    const accountObj = [...fakeDb.objects.values()].find((o) => o.api_name === 'account');
     expect(accountObj).toBeDefined();
     expect(accountObj!.owner_id).toBe('my-owner');
     expect(accountObj!.tenant_id).toBe('my-tenant');
   });
 
   it('uses parameterised queries for all inserts', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
-    // Every call should include params
-    for (const call of client.query.mock.calls) {
-      const [, params] = call as [string, unknown[]?];
-      expect(params).toBeDefined();
-      expect(Array.isArray(params)).toBe(true);
+    const inserts = dataQueries().filter((q) =>
+      normalise(q.sql).startsWith('INSERT INTO'),
+    );
+    for (const q of inserts) {
+      expect(q.params.length).toBeGreaterThan(0);
+      expect(Array.isArray(q.params)).toBe(true);
     }
   });
 
   it('returns correct total counts matching seed data constants', async () => {
-    const result = await seedWithClient(client, 'tenant-1', 'owner-1');
+    const result = await seedDefaultObjects('tenant-1', 'owner-1');
 
     const totalCreated = (key: keyof SeedResult) => result[key];
     expect(totalCreated('objectsCreated')).toBe(11);
@@ -368,35 +418,33 @@ describe('seedDefaultObjects', () => {
   });
 
   it('creates all 11 objects with the expected api_names', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
     const expectedApiNames = [
       'account', 'contact', 'lead', 'opportunity', 'activity',
       'next_action', 'agreement', 'note', 'file', 'user', 'team',
     ];
-    const actualApiNames = [...db.objects.values()]
+    const actualApiNames = [...fakeDb.objects.values()]
       .map((o) => o.api_name as string)
       .sort();
     expect(actualApiNames).toEqual([...expectedApiNames].sort());
   });
 
   it('creates fields with correct types and options', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
     const findField = (objectApiName: string, fieldApiName: string) => {
-      return [...db.fields.values()].find((f) => {
-        const obj = [...db.objects.values()].find((o) => o.id === f.object_id);
+      return [...fakeDb.fields.values()].find((f) => {
+        const obj = [...fakeDb.objects.values()].find((o) => o.id === f.object_id);
         return obj?.api_name === objectApiName && f.api_name === fieldApiName;
       });
     };
 
-    // Account name is a required text field with max_length
     const accountName = findField('account', 'name');
     expect(accountName).toBeDefined();
     expect(accountName!.field_type).toBe('text');
     expect(JSON.parse(accountName!.options as string)).toEqual({ max_length: 255 });
 
-    // Lead status is a required dropdown with choices
     const leadStatus = findField('lead', 'status');
     expect(leadStatus).toBeDefined();
     expect(leadStatus!.field_type).toBe('dropdown');
@@ -405,78 +453,67 @@ describe('seedDefaultObjects', () => {
       expect.arrayContaining(['New', 'Contacted', 'Qualified', 'Unqualified', 'Converted']),
     );
 
-    // Opportunity value is currency with precision
     const oppValue = findField('opportunity', 'value');
     expect(oppValue).toBeDefined();
     expect(oppValue!.field_type).toBe('currency');
     expect(JSON.parse(oppValue!.options as string)).toEqual({ min: 0, precision: 2 });
 
-    // Contact email is an email field
     const contactEmail = findField('contact', 'email');
     expect(contactEmail).toBeDefined();
     expect(contactEmail!.field_type).toBe('email');
 
-    // Activity due_date is a datetime field
     const activityDueDate = findField('activity', 'due_date');
     expect(activityDueDate).toBeDefined();
     expect(activityDueDate!.field_type).toBe('datetime');
   });
 
   it('creates relationships between correct objects', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
     const getApiName = (objectId: string) => {
-      const obj = [...db.objects.values()].find((o) => o.id === objectId);
+      const obj = [...fakeDb.objects.values()].find((o) => o.id === objectId);
       return obj?.api_name;
     };
 
-    // opportunity_account: opportunity → account
-    const oppAcct = [...db.relationships.values()].find((r) => r.api_name === 'opportunity_account');
+    const oppAcct = [...fakeDb.relationships.values()].find((r) => r.api_name === 'opportunity_account');
     expect(oppAcct).toBeDefined();
     expect(getApiName(oppAcct!.source_object_id as string)).toBe('opportunity');
     expect(getApiName(oppAcct!.target_object_id as string)).toBe('account');
 
-    // contact_account: contact → account
-    const contactAcct = [...db.relationships.values()].find((r) => r.api_name === 'contact_account');
+    const contactAcct = [...fakeDb.relationships.values()].find((r) => r.api_name === 'contact_account');
     expect(contactAcct).toBeDefined();
     expect(getApiName(contactAcct!.source_object_id as string)).toBe('contact');
     expect(getApiName(contactAcct!.target_object_id as string)).toBe('account');
 
-    // next_action_opportunity: next_action → opportunity
-    const nextActionOpp = [...db.relationships.values()].find((r) => r.api_name === 'next_action_opportunity');
+    const nextActionOpp = [...fakeDb.relationships.values()].find((r) => r.api_name === 'next_action_opportunity');
     expect(nextActionOpp).toBeDefined();
     expect(getApiName(nextActionOpp!.source_object_id as string)).toBe('next_action');
     expect(getApiName(nextActionOpp!.target_object_id as string)).toBe('opportunity');
 
-    // agreement_account: agreement → account
-    const agreementAcct = [...db.relationships.values()].find((r) => r.api_name === 'agreement_account');
+    const agreementAcct = [...fakeDb.relationships.values()].find((r) => r.api_name === 'agreement_account');
     expect(agreementAcct).toBeDefined();
     expect(getApiName(agreementAcct!.source_object_id as string)).toBe('agreement');
     expect(getApiName(agreementAcct!.target_object_id as string)).toBe('account');
 
-    // file_agreement: file → agreement
-    const fileAgreement = [...db.relationships.values()].find((r) => r.api_name === 'file_agreement');
+    const fileAgreement = [...fakeDb.relationships.values()].find((r) => r.api_name === 'file_agreement');
     expect(fileAgreement).toBeDefined();
     expect(getApiName(fileAgreement!.source_object_id as string)).toBe('file');
     expect(getApiName(fileAgreement!.target_object_id as string)).toBe('agreement');
   });
 
   it('creates layouts with correct sections and field arrangement', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
-    // Find account "Default form" layout
-    const accountFormLayout = [...db.layouts.values()].find((l) => {
-      const obj = [...db.objects.values()].find((o) => o.id === l.object_id);
+    const accountFormLayout = [...fakeDb.layouts.values()].find((l) => {
+      const obj = [...fakeDb.objects.values()].find((o) => o.id === l.object_id);
       return obj?.api_name === 'account' && l.name === 'Default form';
     });
     expect(accountFormLayout).toBeDefined();
 
-    // Get layout fields for account form
-    const accountFormFields = [...db.layoutFields.values()]
+    const accountFormFields = [...fakeDb.layoutFields.values()]
       .filter((lf) => lf.layout_id === accountFormLayout!.id);
     expect(accountFormFields.length).toBe(16);
 
-    // Verify sort orders start at 1 and are unique
     const sortOrders = accountFormFields
       .map((lf) => lf.sort_order as number)
       .sort((a, b) => a - b);
@@ -484,22 +521,19 @@ describe('seedDefaultObjects', () => {
     const uniqueSortOrders = new Set(sortOrders);
     expect(uniqueSortOrders.size).toBe(sortOrders.length);
 
-    // Verify multiple sections exist (Details, Contact info, Address, Additional)
     const sections = new Set(accountFormFields.map((lf) => lf.section));
     expect(sections.size).toBe(4);
 
-    // Verify width values are valid
     for (const lf of accountFormFields) {
       expect(['half', 'full']).toContain(lf.width);
     }
 
-    // Verify lead "Default Form" has expected section labels
-    const leadFormLayout = [...db.layouts.values()].find((l) => {
-      const obj = [...db.objects.values()].find((o) => o.id === l.object_id);
+    const leadFormLayout = [...fakeDb.layouts.values()].find((l) => {
+      const obj = [...fakeDb.objects.values()].find((o) => o.id === l.object_id);
       return obj?.api_name === 'lead' && l.name === 'Default Form';
     });
     expect(leadFormLayout).toBeDefined();
-    const leadFormFields = [...db.layoutFields.values()]
+    const leadFormFields = [...fakeDb.layoutFields.values()]
       .filter((lf) => lf.layout_id === leadFormLayout!.id);
     const leadSectionLabels = new Set(
       leadFormFields.map((lf) => lf.section_label).filter((l) => l !== null),
@@ -510,12 +544,10 @@ describe('seedDefaultObjects', () => {
   });
 
   it('creates independent copies for different tenants', async () => {
-    // Seed for tenant-a
-    const resultA = await seedWithClient(client, 'tenant-a', 'owner-a');
+    const resultA = await seedDefaultObjects('tenant-a', 'owner-a');
     expect(resultA.objectsCreated).toBe(SEED_COUNTS.objects);
 
-    // Seed for tenant-b — should create a full independent copy
-    const resultB = await seedWithClient(client, 'tenant-b', 'owner-b');
+    const resultB = await seedDefaultObjects('tenant-b', 'owner-b');
     expect(resultB.objectsCreated).toBe(SEED_COUNTS.objects);
     expect(resultB.fieldsCreated).toBe(SEED_COUNTS.fields);
     expect(resultB.relationshipsCreated).toBe(SEED_COUNTS.relationships);
@@ -526,14 +558,12 @@ describe('seedDefaultObjects', () => {
     expect(resultB.stagesCreated).toBe(SEED_COUNTS.stages);
     expect(resultB.stageGatesCreated).toBe(SEED_COUNTS.stageGates);
 
-    // Both tenants' objects exist in the DB
-    expect(db.objects.size).toBe(SEED_COUNTS.objects * 2);
+    expect(fakeDb.objects.size).toBe(SEED_COUNTS.objects * 2);
 
-    // Verify tenant isolation — each tenant has its own 'account' object
-    const tenantAAccounts = [...db.objects.values()].filter(
+    const tenantAAccounts = [...fakeDb.objects.values()].filter(
       (o) => o.api_name === 'account' && o.tenant_id === 'tenant-a',
     );
-    const tenantBAccounts = [...db.objects.values()].filter(
+    const tenantBAccounts = [...fakeDb.objects.values()].filter(
       (o) => o.api_name === 'account' && o.tenant_id === 'tenant-b',
     );
     expect(tenantAAccounts.length).toBe(1);
@@ -542,11 +572,10 @@ describe('seedDefaultObjects', () => {
   });
 
   it('includes tenant_id in all INSERT statements', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
-    for (const call of client.query.mock.calls) {
-      const [sql] = call as [string, unknown[]?];
-      const upper = sql.replace(/\s+/g, ' ').trim().toUpperCase();
+    for (const q of dataQueries()) {
+      const upper = normalise(q.sql);
       if (upper.startsWith('INSERT INTO') && !upper.includes('UPDATE')) {
         expect(upper).toContain('TENANT_ID');
       }
@@ -554,16 +583,16 @@ describe('seedDefaultObjects', () => {
   });
 
   it('marks only essential identity fields as system', async () => {
-    await seedWithClient(client, 'tenant-1', 'owner-1');
+    await seedDefaultObjects('tenant-1', 'owner-1');
 
     const findField = (objectApiName: string, fieldApiName: string) => {
-      return [...db.fields.values()].find((f) => {
-        const obj = [...db.objects.values()].find((o) => o.id === f.object_id);
+      return [...fakeDb.fields.values()].find((f) => {
+        const obj = [...fakeDb.objects.values()].find((o) => o.id === f.object_id);
         return obj?.api_name === objectApiName && f.api_name === fieldApiName;
       });
     };
 
-    // System fields — essential identity fields
+    // System fields
     expect(findField('account', 'name')!.is_system).toBe(true);
     expect(findField('contact', 'first_name')!.is_system).toBe(true);
     expect(findField('contact', 'last_name')!.is_system).toBe(true);
@@ -572,7 +601,7 @@ describe('seedDefaultObjects', () => {
     expect(findField('user', 'email')!.is_system).toBe(true);
     expect(findField('user', 'display_name')!.is_system).toBe(true);
 
-    // Non-system fields — configurable and deletable by admins
+    // Non-system fields
     expect(findField('account', 'type')!.is_system).toBe(false);
     expect(findField('account', 'industry')!.is_system).toBe(false);
     expect(findField('account', 'website')!.is_system).toBe(false);

--- a/apps/api/src/services/__tests__/tenantProvisioning.e2e.test.ts
+++ b/apps/api/src/services/__tests__/tenantProvisioning.e2e.test.ts
@@ -44,89 +44,73 @@ const fakeObjects = new Map<string, FakeRow>();
 const fakeFields = new Map<string, FakeRow>();
 const fakeRelationships = new Map<string, FakeRow>();
 
-// Kysely's PostgresDriver calls `client.query({ text, values })`, while the
-// legacy seedDefaultObjects path calls `client.query(sql, params)` directly.
-// Normalise both call shapes so the single dispatcher handles both.
+function normaliseCall(sqlOrQuery: unknown, paramsArg?: unknown[]) {
+  if (typeof sqlOrQuery === 'string') {
+    return { sql: sqlOrQuery, params: paramsArg ?? [] };
+  }
+  const q = sqlOrQuery as { text: string; values?: unknown[] };
+  return { sql: q.text, params: q.values ?? [] };
+}
+
+function extractInsertRow(sql: string, params: unknown[]): Record<string, unknown> {
+  const normalized = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim();
+  const match = normalized.match(/INSERT INTO \w+ \(([^)]+)\)/i);
+  if (!match) return {};
+  const columns = match[1].split(',').map((c) => c.trim().toLowerCase());
+  const row: Record<string, unknown> = {};
+  columns.forEach((col, i) => { row[col] = params[i]; });
+  return row;
+}
+
 const defaultClientQueryImpl = async (
   sqlOrQuery: unknown,
   paramsArg?: unknown[],
 ) => {
-  const sql =
-    typeof sqlOrQuery === 'string'
-      ? sqlOrQuery
-      : (sqlOrQuery as { text: string }).text;
-  const params =
-    typeof sqlOrQuery === 'string'
-      ? paramsArg
-      : ((sqlOrQuery as { values?: unknown[] }).values ?? []);
-
-  // Strip identifier quotes so Kysely's `"tenants"` matches the legacy
-  // matchers that were written against unquoted identifiers.
+  const { sql, params } = normaliseCall(sqlOrQuery, paramsArg);
   const s = sql.replace(/\s+/g, ' ').replace(/"/g, '').trim().toUpperCase();
 
-  // Transaction control
   if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [] };
+  if (s.startsWith('SELECT SET_CONFIG')) return { rows: [] };
 
-  // Slug uniqueness check (routed through pool.connect by Kysely).
-  // Kysely compiles `db.selectFrom('tenants').select('id').where('slug', '=', ?)`
-  // to `SELECT id FROM tenants WHERE slug = $1` (+ optional LIMIT for
-  // executeTakeFirst).
+  // Slug uniqueness check
   if (s.startsWith('SELECT ID FROM TENANTS WHERE SLUG')) {
-    const slug = params![0] as string;
+    const slug = params[0] as string;
     const match = [...fakeTenants.values()].find((t) => t.slug === slug);
     return { rows: match ? [{ id: match.id }] : [], rowCount: match ? 1 : 0 };
   }
 
-  // INSERT INTO tenants ... RETURNING *
-  // Kysely compiles `values({ id, name, slug, status, plan, settings,
-  // created_at, updated_at })` to 8 positional params in the declared
-  // field order. All columns are now parameterised (no hardcoded
-  // 'active'/'{}' like the old raw-SQL path).
+  // INSERT INTO tenants
   if (s.startsWith('INSERT INTO TENANTS')) {
-    const [id, name, slug, status, plan, settings, created_at, updated_at] =
-      params as unknown[];
-    const row: FakeRow = {
-      id: id as string,
-      name,
-      slug,
-      status,
-      plan,
-      settings,
-      created_at,
-      updated_at,
-    };
-    fakeTenants.set(id as string, row);
+    const row = extractInsertRow(sql, params);
+    fakeTenants.set(row.id as string, { ...row, id: row.id as string });
     return { rows: [row], rowCount: 1, command: 'INSERT' };
   }
 
-  // SELECT id, api_name FROM object_definitions WHERE api_name = ANY($1) AND tenant_id = $2
-  if (s.includes('FROM OBJECT_DEFINITIONS') && s.includes('ANY')) {
-    const apiNames = params![0] as string[];
-    const tenantId = params![1] as string;
+  // SELECT ... FROM object_definitions WHERE api_name IN (...)
+  if (s.includes('FROM OBJECT_DEFINITIONS') && !s.startsWith('INSERT') && !s.startsWith('UPDATE') && s.includes('IN (')) {
+    const tenantId = params[params.length - 1] as string;
+    const apiNames = params.slice(0, -1) as string[];
     const rows = [...fakeObjects.values()]
       .filter((o) => apiNames.includes(o.api_name as string) && o.tenant_id === tenantId)
       .map((o) => ({ id: o.id, api_name: o.api_name }));
     return { rows };
   }
 
-  // INSERT INTO object_definitions ... ON CONFLICT ... RETURNING id
+  // INSERT INTO object_definitions
   if (s.startsWith('INSERT INTO OBJECT_DEFINITIONS')) {
-    const id = params![0] as string;
-    const apiName = params![1] as string;
-    const tenantId = params![7] as string;
+    const row = extractInsertRow(sql, params);
     const existing = [...fakeObjects.values()].find(
-      (o) => o.tenant_id === tenantId && o.api_name === apiName,
+      (o) => o.tenant_id === row.tenant_id && o.api_name === row.api_name,
     );
     if (existing) return { rows: [] };
-    const row: FakeRow = { id, api_name: apiName, tenant_id: tenantId };
-    fakeObjects.set(id, row);
-    return { rows: [{ id }] };
+    fakeObjects.set(row.id as string, { ...row, id: row.id as string });
+    return { rows: [{ id: row.id }] };
   }
 
-  // SELECT fd.id, od.api_name ... FROM field_definitions fd JOIN object_definitions od
-  if (s.includes('FROM FIELD_DEFINITIONS FD') && s.includes('JOIN OBJECT_DEFINITIONS OD')) {
-    const apiNames = params![0] as string[];
-    const tenantId = params![1] as string;
+  // SELECT fd.id ... FROM field_definitions fd JOIN object_definitions od
+  if (s.includes('FROM FIELD_DEFINITIONS') && s.includes('JOIN OBJECT_DEFINITIONS')) {
+    const tenantId = params[params.length - 1] as string;
+    const apiNames = params.slice(0, -1) as string[];
     const rows: { id: string; object_api_name: string; api_name: string }[] = [];
     for (const field of fakeFields.values()) {
       if (field.tenant_id !== tenantId) continue;
@@ -142,56 +126,80 @@ const defaultClientQueryImpl = async (
     return { rows };
   }
 
-  // INSERT INTO field_definitions ... ON CONFLICT ... RETURNING id
+  // INSERT INTO field_definitions
   if (s.startsWith('INSERT INTO FIELD_DEFINITIONS')) {
-    const id = params![0] as string;
-    const objectId = params![1] as string;
-    const apiName = params![2] as string;
-    const tenantId = params![8] as string;
+    const row = extractInsertRow(sql, params);
     const existing = [...fakeFields.values()].find(
-      (f) => f.tenant_id === tenantId && f.object_id === objectId && f.api_name === apiName,
+      (f) => f.tenant_id === row.tenant_id && f.object_id === row.object_id && f.api_name === row.api_name,
     );
     if (existing) return { rows: [] };
-    const row: FakeRow = { id, object_id: objectId, api_name: apiName, tenant_id: tenantId };
-    fakeFields.set(id, row);
-    return { rows: [{ id }] };
+    fakeFields.set(row.id as string, { ...row, id: row.id as string });
+    return { rows: [{ id: row.id }] };
   }
 
   // INSERT INTO relationship_definitions
   if (s.startsWith('INSERT INTO RELATIONSHIP_DEFINITIONS')) {
-    const id = params![0] as string;
-    const tenantId = params![8] as string;
-    const row: FakeRow = { id, tenant_id: tenantId };
-    fakeRelationships.set(id, row);
-    return { rows: [{ id }] };
+    const row = extractInsertRow(sql, params);
+    fakeRelationships.set(row.id as string, { ...row, id: row.id as string });
+    return { rows: [{ id: row.id }] };
+  }
+
+  // SELECT ld ... FROM layout_definitions ld JOIN object_definitions od
+  if (s.includes('FROM LAYOUT_DEFINITIONS') && s.includes('JOIN OBJECT_DEFINITIONS')) {
+    return { rows: [] };
   }
 
   // INSERT INTO layout_definitions
   if (s.startsWith('INSERT INTO LAYOUT_DEFINITIONS')) {
-    return { rows: [{ id: 'layout-1' }] };
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
   }
 
-  // INSERT INTO layout_field_assignments
-  if (s.startsWith('INSERT INTO LAYOUT_FIELD_ASSIGNMENTS')) {
-    return { rows: [{ id: 'lfa-1' }] };
+  // INSERT INTO layout_fields
+  if (s.startsWith('INSERT INTO LAYOUT_FIELDS')) {
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
+  }
+
+  // SELECT ... FROM pipeline_definitions WHERE api_name IN (...)
+  if (s.includes('FROM PIPELINE_DEFINITIONS') && !s.startsWith('INSERT') && s.includes('IN (')) {
+    return { rows: [] };
   }
 
   // INSERT INTO pipeline_definitions
   if (s.startsWith('INSERT INTO PIPELINE_DEFINITIONS')) {
-    return { rows: [{ id: params![0] }] };
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
+  }
+
+  // SELECT sd ... FROM stage_definitions sd JOIN pipeline_definitions pd
+  if (s.includes('FROM STAGE_DEFINITIONS') && s.includes('JOIN PIPELINE_DEFINITIONS')) {
+    return { rows: [] };
   }
 
   // INSERT INTO stage_definitions
   if (s.startsWith('INSERT INTO STAGE_DEFINITIONS')) {
-    return { rows: [{ id: params![0] }] };
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
+  }
+
+  // INSERT INTO stage_gates
+  if (s.startsWith('INSERT INTO STAGE_GATES')) {
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
   }
 
   // INSERT INTO lead_conversion_mappings
   if (s.startsWith('INSERT INTO LEAD_CONVERSION_MAPPINGS')) {
-    return { rows: [{ id: 'lcm-1' }] };
+    const row = extractInsertRow(sql, params);
+    return { rows: [{ id: row.id }] };
   }
 
-  // Default
+  // UPDATE object_definitions (name_field_id / name_template)
+  if (s.startsWith('UPDATE OBJECT_DEFINITIONS')) {
+    return { rows: [] };
+  }
+
   return { rows: [], rowCount: 0 };
 };
 
@@ -203,18 +211,7 @@ const mockConnect = vi.fn(() => ({
   release: mockRelease,
 }));
 
-const mockPoolQuery = vi.fn(async (sql: string, params?: unknown[]) => {
-  const s = sql.replace(/\s+/g, ' ').trim().toUpperCase();
-
-  // Check slug uniqueness: SELECT id FROM tenants WHERE slug = $1
-  if (s.startsWith('SELECT ID FROM TENANTS WHERE SLUG')) {
-    const slug = params![0] as string;
-    const match = [...fakeTenants.values()].find((t) => t.slug === slug);
-    return { rows: match ? [{ id: match.id }] : [], rowCount: match ? 1 : 0 };
-  }
-
-  return { rows: [], rowCount: 0 };
-});
+const mockPoolQuery = vi.fn(async (..._args: unknown[]) => ({ rows: [], rowCount: 0 }));
 
 vi.mock('../../db/client.js', () => ({
   pool: {

--- a/apps/api/src/services/layoutDefinitionService.ts
+++ b/apps/api/src/services/layoutDefinitionService.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
-import type { LayoutDefinitions, LayoutFields } from '../db/kysely.types.js';
+import type { LayoutDefinitions } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/apps/api/src/services/layoutDefinitionService.ts
+++ b/apps/api/src/services/layoutDefinitionService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { LayoutDefinitions, LayoutFields } from '../db/kysely.types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -90,32 +92,47 @@ function throwDeleteBlockedError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToLayoutDefinition(row: Record<string, unknown>): LayoutDefinition {
+function rowToLayoutDefinition(row: Selectable<LayoutDefinitions>): LayoutDefinition {
   return {
-    id: row.id as string,
-    objectId: row.object_id as string,
-    name: row.name as string,
-    layoutType: row.layout_type as string,
-    isDefault: row.is_default as boolean,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
+    id: row.id,
+    objectId: row.object_id,
+    name: row.name,
+    layoutType: row.layout_type,
+    isDefault: row.is_default,
+    createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at as unknown as string),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at as unknown as string),
   };
 }
 
-function rowToLayoutFieldWithMetadata(row: Record<string, unknown>): LayoutFieldWithMetadata {
+interface LayoutFieldJoinedRow {
+  id: string;
+  layout_id: string;
+  field_id: string;
+  section: number;
+  section_label: string | null;
+  sort_order: number;
+  width: string | null;
+  field_api_name: string;
+  field_label: string;
+  field_type: string;
+  field_required: boolean;
+  field_options: Record<string, unknown> | null;
+}
+
+function rowToLayoutFieldWithMetadata(row: LayoutFieldJoinedRow): LayoutFieldWithMetadata {
   return {
-    id: row.id as string,
-    layoutId: row.layout_id as string,
-    fieldId: row.field_id as string,
-    section: row.section as number,
-    sectionLabel: (row.section_label as string | null) ?? undefined,
-    sortOrder: row.sort_order as number,
-    width: row.width as string,
-    fieldApiName: row.field_api_name as string,
-    fieldLabel: row.field_label as string,
-    fieldType: row.field_type as string,
-    fieldRequired: row.field_required as boolean,
-    fieldOptions: (row.field_options as Record<string, unknown>) ?? {},
+    id: row.id,
+    layoutId: row.layout_id,
+    fieldId: row.field_id,
+    section: row.section,
+    sectionLabel: row.section_label ?? undefined,
+    sortOrder: row.sort_order,
+    width: row.width ?? 'full',
+    fieldApiName: row.field_api_name,
+    fieldLabel: row.field_label,
+    fieldType: row.field_type,
+    fieldRequired: row.field_required,
+    fieldOptions: row.field_options ?? {},
   };
 }
 
@@ -144,42 +161,48 @@ export function validateLayoutType(layoutType: unknown): string | null {
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 async function assertObjectExists(tenantId: string, objectId: string): Promise<void> {
-  const result = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (result.rows.length === 0) {
+  const row = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!row) {
     throwNotFoundError('Object definition not found');
   }
 }
 
-async function fetchLayoutFields(layoutId: string): Promise<LayoutFieldWithMetadata[]> {
-  const result = await pool.query(
-    `SELECT lf.*,
-            fd.api_name  AS field_api_name,
-            fd.label     AS field_label,
-            fd.field_type AS field_type,
-            fd.required  AS field_required,
-            fd.options   AS field_options
-     FROM layout_fields lf
-     JOIN field_definitions fd ON fd.id = lf.field_id
-     WHERE lf.layout_id = $1
-     ORDER BY lf.section ASC, lf.sort_order ASC`,
-    [layoutId],
-  );
+async function fetchLayoutFields(tenantId: string, layoutId: string): Promise<LayoutFieldWithMetadata[]> {
+  const rows = await db
+    .selectFrom('layout_fields as lf')
+    .innerJoin('field_definitions as fd', (join) =>
+      join.onRef('fd.id', '=', 'lf.field_id').on('fd.tenant_id', '=', tenantId),
+    )
+    .where('lf.layout_id', '=', layoutId)
+    .where('lf.tenant_id', '=', tenantId)
+    .select([
+      'lf.id',
+      'lf.layout_id',
+      'lf.field_id',
+      'lf.section',
+      'lf.section_label',
+      'lf.sort_order',
+      'lf.width',
+      'fd.api_name as field_api_name',
+      'fd.label as field_label',
+      'fd.field_type as field_type',
+      'fd.required as field_required',
+      'fd.options as field_options',
+    ])
+    .orderBy('lf.section', 'asc')
+    .orderBy('lf.sort_order', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToLayoutFieldWithMetadata(row));
+  return rows.map((row) => rowToLayoutFieldWithMetadata(row as unknown as LayoutFieldJoinedRow));
 }
 
 // ─── Service functions ───────────────────────────────────────────────────────
 
-/**
- * Creates a new layout definition on the specified object.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout name already exists on this object
- */
 export async function createLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -187,71 +210,64 @@ export async function createLayoutDefinition(
 ): Promise<LayoutDefinition> {
   await assertObjectExists(tenantId, objectId);
 
-  // Validate
   const nameError = validateLayoutName(params.name);
   if (nameError) throwValidationError(nameError);
 
   const typeError = validateLayoutType(params.layoutType);
   if (typeError) throwValidationError(typeError);
 
-  // Check uniqueness of name within this object and tenant
-  const existing = await pool.query(
-    'SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND tenant_id = $3',
-    [objectId, params.name.trim(), tenantId],
-  );
-  if (existing.rows.length > 0) {
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .select('id')
+    .where('object_id', '=', objectId)
+    .where('name', '=', params.name.trim())
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (existing) {
     throwConflictError(`A layout with name "${params.name.trim()}" already exists on this object`);
   }
 
   const layoutId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO layout_definitions
-       (id, tenant_id, object_id, name, layout_type, is_default, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     RETURNING *`,
-    [
-      layoutId,
-      tenantId,
-      objectId,
-      params.name.trim(),
-      params.layoutType.trim(),
-      params.isDefault ?? false,
-      now,
-      now,
-    ],
-  );
+  const row = await db
+    .insertInto('layout_definitions')
+    .values({
+      id: layoutId,
+      tenant_id: tenantId,
+      object_id: objectId,
+      name: params.name.trim(),
+      layout_type: params.layoutType.trim(),
+      is_default: params.isDefault ?? false,
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, name: params.name }, 'Layout definition created');
 
-  return rowToLayoutDefinition(result.rows[0]);
+  return rowToLayoutDefinition(row);
 }
 
-/**
- * Returns all layout definitions for an object, ordered by layout_type and name.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- */
 export async function listLayoutDefinitions(
   tenantId: string,
   objectId: string,
 ): Promise<LayoutDefinition[]> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM layout_definitions WHERE object_id = $1 AND tenant_id = $2 ORDER BY layout_type ASC, name ASC',
-    [objectId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('layout_type', 'asc')
+    .orderBy('name', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToLayoutDefinition(row));
+  return rows.map(rowToLayoutDefinition);
 }
 
-/**
- * Returns a single layout definition by ID with nested field metadata.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function getLayoutDefinitionById(
   tenantId: string,
   objectId: string,
@@ -259,28 +275,24 @@ export async function getLayoutDefinitionById(
 ): Promise<LayoutDefinitionDetail> {
   await assertObjectExists(tenantId, objectId);
 
-  const layoutResult = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const row = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (layoutResult.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Layout definition not found');
   }
 
-  const layout = rowToLayoutDefinition(layoutResult.rows[0]);
-  const fields = await fetchLayoutFields(layoutId);
+  const layout = rowToLayoutDefinition(row);
+  const fields = await fetchLayoutFields(tenantId, layoutId);
 
   return { ...layout, fields };
 }
 
-/**
- * Updates a layout definition's metadata (name, layout_type).
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout name already exists on this object
- */
 export async function updateLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -289,26 +301,31 @@ export async function updateLayoutDefinition(
 ): Promise<LayoutDefinition> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Layout definition not found');
   }
 
-  // Validate changed fields
   if (params.name !== undefined) {
     const nameError = validateLayoutName(params.name);
     if (nameError) throwValidationError(nameError);
 
-    // Check uniqueness of new name (excluding this layout)
-    const dup = await pool.query(
-      'SELECT id FROM layout_definitions WHERE object_id = $1 AND name = $2 AND id != $3 AND tenant_id = $4',
-      [objectId, params.name.trim(), layoutId, tenantId],
-    );
-    if (dup.rows.length > 0) {
+    const dup = await db
+      .selectFrom('layout_definitions')
+      .select('id')
+      .where('object_id', '=', objectId)
+      .where('name', '=', params.name.trim())
+      .where('id', '!=', layoutId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (dup) {
       throwConflictError(`A layout with name "${params.name.trim()}" already exists on this object`);
     }
   }
@@ -318,49 +335,34 @@ export async function updateLayoutDefinition(
     if (typeError) throwValidationError(typeError);
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
-
+  const patch: Updateable<LayoutDefinitions> = {};
   if ('name' in params) {
-    updates.push(`name = $${paramIndex++}`);
-    values.push(params.name!.trim());
+    patch.name = params.name!.trim();
   }
   if ('layoutType' in params) {
-    updates.push(`layout_type = $${paramIndex++}`);
-    values.push(params.layoutType!.trim());
+    patch.layout_type = params.layoutType!.trim();
   }
 
-  if (updates.length === 0) {
-    return rowToLayoutDefinition(existing.rows[0]);
+  if (Object.keys(patch).length === 0) {
+    return rowToLayoutDefinition(existing);
   }
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
+  patch.updated_at = new Date();
 
-  values.push(layoutId);
-  values.push(objectId);
-
-  const result = await pool.query(
-    `UPDATE layout_definitions SET ${updates.join(', ')} WHERE id = $${paramIndex++} AND object_id = $${paramIndex} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('layout_definitions')
+    .set(patch)
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId }, 'Layout definition updated');
 
-  return rowToLayoutDefinition(result.rows[0]);
+  return rowToLayoutDefinition(row);
 }
 
-/**
- * Sets the layout field arrangement (full replacement).
- * Deletes all existing layout_fields for this layout, then inserts new ones
- * based on the provided sections.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid section/field input
- */
 export async function setLayoutFields(
   tenantId: string,
   objectId: string,
@@ -369,21 +371,22 @@ export async function setLayoutFields(
 ): Promise<LayoutDefinitionDetail> {
   await assertObjectExists(tenantId, objectId);
 
-  const layoutResult = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const layoutRow = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (layoutResult.rows.length === 0) {
+  if (!layoutRow) {
     throwNotFoundError('Layout definition not found');
   }
 
-  // Validate sections input
   if (!Array.isArray(sections)) {
     throwValidationError('sections must be an array');
   }
 
-  // Collect all field IDs and validate they belong to this object
   const allFieldIds: string[] = [];
   for (const section of sections) {
     if (!Array.isArray(section.fields)) {
@@ -399,12 +402,13 @@ export async function setLayoutFields(
   }
 
   if (allFieldIds.length > 0) {
-    // Verify all field IDs belong to this object
-    const existingFields = await pool.query(
-      'SELECT id FROM field_definitions WHERE object_id = $1 AND tenant_id = $2',
-      [objectId, tenantId],
-    );
-    const existingIds = new Set(existingFields.rows.map((r: Record<string, unknown>) => r.id as string));
+    const existingFields = await db
+      .selectFrom('field_definitions')
+      .select('id')
+      .where('object_id', '=', objectId)
+      .where('tenant_id', '=', tenantId)
+      .execute();
+    const existingIds = new Set(existingFields.map((r) => r.id));
 
     for (const fieldId of allFieldIds) {
       if (!existingIds.has(fieldId)) {
@@ -412,20 +416,18 @@ export async function setLayoutFields(
       }
     }
 
-    // Check for duplicate field IDs
     const uniqueFieldIds = new Set(allFieldIds);
     if (uniqueFieldIds.size !== allFieldIds.length) {
       throwValidationError('Duplicate field IDs are not allowed in a layout');
     }
   }
 
-  // Delete existing layout fields
-  await pool.query(
-    'DELETE FROM layout_fields WHERE layout_id = $1',
-    [layoutId],
-  );
+  await db
+    .deleteFrom('layout_fields')
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
-  // Insert new layout fields
   for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
     const section = sections[sectionIndex];
     const sectionLabel = section.label?.trim() ?? null;
@@ -434,44 +436,38 @@ export async function setLayoutFields(
       const field = section.fields[fieldIndex];
       const fieldId = field.field_id ?? field.fieldId;
 
-      await pool.query(
-        `INSERT INTO layout_fields (id, layout_id, field_id, section, section_label, sort_order, width)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-        [
-          randomUUID(),
-          layoutId,
-          fieldId,
-          sectionIndex,
-          sectionLabel,
-          fieldIndex + 1,
-          field.width ?? 'full',
-        ],
-      );
+      await db
+        .insertInto('layout_fields')
+        .values({
+          id: randomUUID(),
+          tenant_id: tenantId,
+          layout_id: layoutId,
+          field_id: fieldId!,
+          section: sectionIndex,
+          section_label: sectionLabel,
+          sort_order: fieldIndex + 1,
+          width: field.width ?? 'full',
+        })
+        .execute();
     }
   }
 
-  // Update the layout's updated_at timestamp
   const now = new Date();
-  await pool.query(
-    'UPDATE layout_definitions SET updated_at = $1 WHERE id = $2',
-    [now, layoutId],
-  );
+  await db
+    .updateTable('layout_definitions')
+    .set({ updated_at: now })
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId, sectionCount: sections.length }, 'Layout fields updated');
 
-  // Return the full layout with field metadata
-  const layout = rowToLayoutDefinition({ ...layoutResult.rows[0], updated_at: now.toISOString() });
-  const fields = await fetchLayoutFields(layoutId);
+  const layout = rowToLayoutDefinition({ ...layoutRow, updated_at: now });
+  const fields = await fetchLayoutFields(tenantId, layoutId);
 
   return { ...layout, fields };
 }
 
-/**
- * Deletes a layout definition. Default layouts cannot be deleted.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} DELETE_BLOCKED — default layout
- */
 export async function deleteLayoutDefinition(
   tenantId: string,
   objectId: string,
@@ -479,22 +475,27 @@ export async function deleteLayoutDefinition(
 ): Promise<void> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM layout_definitions WHERE id = $1 AND object_id = $2 AND tenant_id = $3',
-    [layoutId, objectId, tenantId],
-  );
+  const existing = await db
+    .selectFrom('layout_definitions')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('object_id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Layout definition not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
-  if (row.is_default === true) {
+  if (existing.is_default === true) {
     throwDeleteBlockedError('Cannot delete default layouts');
   }
 
-  await pool.query('DELETE FROM layout_definitions WHERE id = $1', [layoutId]);
+  await db
+    .deleteFrom('layout_definitions')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId }, 'Layout definition deleted');
 }

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { sql } from 'kysely';
 import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
@@ -533,7 +534,7 @@ export async function publishPageLayout(
     const row = await trx
       .updateTable('page_layouts')
       .set({
-        published_layout: existingRow.layout,
+        published_layout: sql`layout`,
         version: newVersion,
         status: 'published',
         published_at: now,
@@ -551,7 +552,7 @@ export async function publishPageLayout(
         layout_id: layoutId,
         tenant_id: tenantId,
         version: newVersion,
-        layout: existingRow.layout,
+        layout: row.layout,
         published_by: publishedBy,
         published_at: now,
       })

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
-import { pool } from '../db/client.js';
+import { db } from '../db/kysely.js';
+import type { PageLayouts, PageLayoutVersions } from '../db/kysely.types.js';
 import { VALID_COMPONENT_TYPES } from '../lib/componentRegistry.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -126,33 +128,35 @@ function throwDeleteBlockedError(message: string): never {
 
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
-function rowToPageLayout(row: Record<string, unknown>): PageLayout {
+function rowToPageLayout(row: Selectable<PageLayouts>): PageLayout {
   return {
-    id: row.id as string,
-    tenantId: row.tenant_id as string,
-    objectId: row.object_id as string,
-    name: row.name as string,
-    role: (row.role as string | null) ?? null,
-    isDefault: row.is_default as boolean,
-    layout: row.layout as PageLayoutJson,
-    publishedLayout: (row.published_layout as PageLayoutJson | null) ?? null,
-    version: row.version as number,
-    status: row.status as string,
-    createdAt: new Date(row.created_at as string),
-    updatedAt: new Date(row.updated_at as string),
-    publishedAt: row.published_at ? new Date(row.published_at as string) : null,
+    id: row.id,
+    tenantId: row.tenant_id,
+    objectId: row.object_id,
+    name: row.name,
+    role: row.role,
+    isDefault: row.is_default,
+    layout: row.layout as unknown as PageLayoutJson,
+    publishedLayout: (row.published_layout as unknown as PageLayoutJson) ?? null,
+    version: row.version,
+    status: row.status,
+    createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at as unknown as string),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at as unknown as string),
+    publishedAt: row.published_at
+      ? (row.published_at instanceof Date ? row.published_at : new Date(row.published_at as unknown as string))
+      : null,
   };
 }
 
-function rowToPageLayoutVersion(row: Record<string, unknown>): PageLayoutVersion {
+function rowToPageLayoutVersion(row: Selectable<PageLayoutVersions>): PageLayoutVersion {
   return {
-    id: row.id as string,
-    layoutId: row.layout_id as string,
-    tenantId: row.tenant_id as string,
-    version: row.version as number,
-    layout: row.layout as PageLayoutJson,
-    publishedBy: (row.published_by as string | null) ?? null,
-    publishedAt: new Date(row.published_at as string),
+    id: row.id,
+    layoutId: row.layout_id,
+    tenantId: row.tenant_id,
+    version: row.version,
+    layout: row.layout as unknown as PageLayoutJson,
+    publishedBy: row.published_by,
+    publishedAt: row.published_at instanceof Date ? row.published_at : new Date(row.published_at as unknown as string),
   };
 }
 
@@ -208,7 +212,6 @@ export function validateLayoutJson(layout: unknown): string | null {
 
   const l = layout as Record<string, unknown>;
 
-  // Validate header
   if (typeof l.header !== 'object' || l.header === null) {
     return 'layout.header is required and must be an object';
   }
@@ -230,7 +233,6 @@ export function validateLayoutJson(layout: unknown): string | null {
     return 'layout.header.actions must be an array of strings';
   }
 
-  // Validate tabs
   if (!Array.isArray(l.tabs)) {
     return 'layout.tabs is required and must be an array';
   }
@@ -300,24 +302,19 @@ export function validateLayoutJson(layout: unknown): string | null {
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 async function assertObjectExists(tenantId: string, objectId: string): Promise<void> {
-  const result = await pool.query(
-    'SELECT id FROM object_definitions WHERE id = $1 AND tenant_id = $2',
-    [objectId, tenantId],
-  );
-  if (result.rows.length === 0) {
+  const row = await db
+    .selectFrom('object_definitions')
+    .select('id')
+    .where('id', '=', objectId)
+    .where('tenant_id', '=', tenantId)
+    .executeTakeFirst();
+  if (!row) {
     throwNotFoundError('Object definition not found');
   }
 }
 
 // ─── Service functions ───────────────────────────────────────────────────────
 
-/**
- * Creates a new page layout on the specified object.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — layout already exists for this object/role combination
- */
 export async function createPageLayout(
   tenantId: string,
   objectId: string,
@@ -331,14 +328,22 @@ export async function createPageLayout(
   const layoutError = validateLayoutJson(params.layout);
   if (layoutError) throwValidationError(layoutError);
 
-  // Check uniqueness constraint (tenant_id, object_id, role)
   const role = params.role ?? null;
-  const existing = await pool.query(
-    `SELECT id FROM page_layouts
-     WHERE tenant_id = $1 AND object_id = $2 AND ${role === null ? 'role IS NULL' : 'role = $3'}`,
-    role === null ? [tenantId, objectId] : [tenantId, objectId, role],
-  );
-  if (existing.rows.length > 0) {
+
+  let existingQuery = db
+    .selectFrom('page_layouts')
+    .select('id')
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId);
+
+  if (role === null) {
+    existingQuery = existingQuery.where('role', 'is', null);
+  } else {
+    existingQuery = existingQuery.where('role', '=', role);
+  }
+
+  const existing = await existingQuery.executeTakeFirst();
+  if (existing) {
     throwConflictError(
       role
         ? `A page layout already exists for this object with role "${role}"`
@@ -349,55 +354,46 @@ export async function createPageLayout(
   const layoutId = randomUUID();
   const now = new Date();
 
-  const result = await pool.query(
-    `INSERT INTO page_layouts
-       (id, tenant_id, object_id, name, role, is_default, layout, version, status, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-     RETURNING *`,
-    [
-      layoutId,
-      tenantId,
-      objectId,
-      params.name.trim(),
+  const row = await db
+    .insertInto('page_layouts')
+    .values({
+      id: layoutId,
+      tenant_id: tenantId,
+      object_id: objectId,
+      name: params.name.trim(),
       role,
-      params.isDefault ?? false,
-      JSON.stringify(params.layout),
-      1,
-      'draft',
-      now,
-      now,
-    ],
-  );
+      is_default: params.isDefault ?? false,
+      layout: JSON.stringify(params.layout),
+      version: 1,
+      status: 'draft',
+      created_at: now,
+      updated_at: now,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, name: params.name }, 'Page layout created');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Returns all page layouts for an object, ordered by name.
- *
- * @throws {Error} NOT_FOUND — parent object does not exist
- */
 export async function listPageLayouts(
   tenantId: string,
   objectId: string,
 ): Promise<PageLayout[]> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM page_layouts WHERE tenant_id = $1 AND object_id = $2 ORDER BY name ASC',
-    [tenantId, objectId],
-  );
+  const rows = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .orderBy('name', 'asc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToPageLayout(row));
+  return rows.map(rowToPageLayout);
 }
 
-/**
- * Returns a single page layout by ID.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function getPageLayoutById(
   tenantId: string,
   objectId: string,
@@ -405,25 +401,21 @@ export async function getPageLayoutById(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const result = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const row = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (result.rows.length === 0) {
+  if (!row) {
     throwNotFoundError('Page layout not found');
   }
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Updates a page layout's metadata and/or draft layout.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} VALIDATION_ERROR — invalid input
- * @throws {Error} CONFLICT — role conflict with another layout
- */
 export async function updatePageLayout(
   tenantId: string,
   objectId: string,
@@ -432,12 +424,15 @@ export async function updatePageLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existing = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Page layout not found');
   }
 
@@ -451,18 +446,24 @@ export async function updatePageLayout(
     if (layoutError) throwValidationError(layoutError);
   }
 
-  // Check role uniqueness if changing role
   if ('role' in params) {
     const newRole = params.role ?? null;
-    const dup = await pool.query(
-      `SELECT id FROM page_layouts
-       WHERE tenant_id = $1 AND object_id = $2 AND id != $3
-         AND ${newRole === null ? 'role IS NULL' : 'role = $4'}`,
-      newRole === null
-        ? [tenantId, objectId, layoutId]
-        : [tenantId, objectId, layoutId, newRole],
-    );
-    if (dup.rows.length > 0) {
+
+    let dupQuery = db
+      .selectFrom('page_layouts')
+      .select('id')
+      .where('tenant_id', '=', tenantId)
+      .where('object_id', '=', objectId)
+      .where('id', '!=', layoutId);
+
+    if (newRole === null) {
+      dupQuery = dupQuery.where('role', 'is', null);
+    } else {
+      dupQuery = dupQuery.where('role', '=', newRole);
+    }
+
+    const dup = await dupQuery.executeTakeFirst();
+    if (dup) {
       throwConflictError(
         newRole
           ? `A page layout already exists for this object with role "${newRole}"`
@@ -471,57 +472,39 @@ export async function updatePageLayout(
     }
   }
 
-  // Build dynamic update
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  let paramIndex = 1;
-
+  const patch: Updateable<PageLayouts> = {};
   if ('name' in params) {
-    updates.push(`name = $${paramIndex++}`);
-    values.push(params.name!.trim());
+    patch.name = params.name!.trim();
   }
   if ('role' in params) {
-    updates.push(`role = $${paramIndex++}`);
-    values.push(params.role ?? null);
+    patch.role = params.role ?? null;
   }
   if ('layout' in params) {
-    updates.push(`layout = $${paramIndex++}`);
-    values.push(JSON.stringify(params.layout));
+    patch.layout = JSON.stringify(params.layout);
   }
   if ('isDefault' in params) {
-    updates.push(`is_default = $${paramIndex++}`);
-    values.push(params.isDefault);
+    patch.is_default = params.isDefault;
   }
 
-  if (updates.length === 0) {
-    return rowToPageLayout(existing.rows[0]);
+  if (Object.keys(patch).length === 0) {
+    return rowToPageLayout(existing);
   }
 
-  const now = new Date();
-  updates.push(`updated_at = $${paramIndex++}`);
-  values.push(now);
+  patch.updated_at = new Date();
 
-  values.push(layoutId);
-  const layoutIdParam = paramIndex++;
-  values.push(tenantId);
-  const tenantIdParam = paramIndex;
-
-  const result = await pool.query(
-    `UPDATE page_layouts SET ${updates.join(', ')} WHERE id = $${layoutIdParam} AND tenant_id = $${tenantIdParam} RETURNING *`,
-    values,
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set(patch)
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId }, 'Page layout updated');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Publishes a page layout — copies the draft layout to published_layout,
- * increments the version, and creates a version snapshot.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function publishPageLayout(
   tenantId: string,
   objectId: string,
@@ -530,74 +513,56 @@ export async function publishPageLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existingRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existingRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-  const currentVersion = row.version as number;
+  const currentVersion = existingRow.version;
   const newVersion = currentVersion + 1;
   const now = new Date();
 
-  // Wrap the layout update and version snapshot in a transaction so both
-  // succeed or neither does — prevents a partial state where the layout is
-  // marked as published but no version record exists.
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
+  return db.transaction().execute(async (trx) => {
+    const row = await trx
+      .updateTable('page_layouts')
+      .set({
+        published_layout: existingRow.layout,
+        version: newVersion,
+        status: 'published',
+        published_at: now,
+        updated_at: now,
+      })
+      .where('id', '=', layoutId)
+      .where('tenant_id', '=', tenantId)
+      .returningAll()
+      .executeTakeFirstOrThrow();
 
-    // Update the page layout: copy layout → published_layout
-    const result = await client.query(
-      `UPDATE page_layouts
-       SET published_layout = layout,
-           version = $1,
-           status = 'published',
-           published_at = $2,
-           updated_at = $2
-       WHERE id = $3 AND tenant_id = $4
-       RETURNING *`,
-      [newVersion, now, layoutId, tenantId],
-    );
-
-    // Create version snapshot
-    await client.query(
-      `INSERT INTO page_layout_versions
-         (id, layout_id, tenant_id, version, layout, published_by, published_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [
-        randomUUID(),
-        layoutId,
-        tenantId,
-        newVersion,
-        row.layout,
-        publishedBy,
-        now,
-      ],
-    );
-
-    await client.query('COMMIT');
+    await trx
+      .insertInto('page_layout_versions')
+      .values({
+        id: randomUUID(),
+        layout_id: layoutId,
+        tenant_id: tenantId,
+        version: newVersion,
+        layout: existingRow.layout,
+        published_by: publishedBy,
+        published_at: now,
+      })
+      .execute();
 
     logger.info({ layoutId, objectId, version: newVersion, publishedBy }, 'Page layout published');
 
-    return rowToPageLayout(result.rows[0]);
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
-  }
+    return rowToPageLayout(row);
+  });
 }
 
-/**
- * Returns all version snapshots for a page layout, newest first.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- */
 export async function listPageLayoutVersions(
   tenantId: string,
   objectId: string,
@@ -605,29 +570,28 @@ export async function listPageLayoutVersions(
 ): Promise<PageLayoutVersion[]> {
   await assertObjectExists(tenantId, objectId);
 
-  // Verify the layout exists
-  const layoutResult = await pool.query(
-    'SELECT id FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
-  if (layoutResult.rows.length === 0) {
+  const layoutRow = await db
+    .selectFrom('page_layouts')
+    .select('id')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!layoutRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  const result = await pool.query(
-    'SELECT * FROM page_layout_versions WHERE layout_id = $1 AND tenant_id = $2 ORDER BY version DESC',
-    [layoutId, tenantId],
-  );
+  const rows = await db
+    .selectFrom('page_layout_versions')
+    .selectAll()
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .orderBy('version', 'desc')
+    .execute();
 
-  return result.rows.map((row: Record<string, unknown>) => rowToPageLayoutVersion(row));
+  return rows.map(rowToPageLayoutVersion);
 }
 
-/**
- * Deletes a page layout. Default layouts cannot be deleted.
- *
- * @throws {Error} NOT_FOUND — layout or parent object does not exist
- * @throws {Error} DELETE_BLOCKED — default layout
- */
 export async function deletePageLayout(
   tenantId: string,
   objectId: string,
@@ -635,31 +599,31 @@ export async function deletePageLayout(
 ): Promise<void> {
   await assertObjectExists(tenantId, objectId);
 
-  const existing = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
+  const existing = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
 
-  if (existing.rows.length === 0) {
+  if (!existing) {
     throwNotFoundError('Page layout not found');
   }
 
-  const row = existing.rows[0] as Record<string, unknown>;
-
-  if (row.is_default === true) {
+  if (existing.is_default === true) {
     throwDeleteBlockedError('Cannot delete default page layouts');
   }
 
-  await pool.query('DELETE FROM page_layouts WHERE id = $1 AND tenant_id = $2', [layoutId, tenantId]);
+  await db
+    .deleteFrom('page_layouts')
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .execute();
 
   logger.info({ layoutId, objectId }, 'Page layout deleted');
 }
 
-/**
- * Copies the layout JSON from a source page layout into the target layout's draft.
- *
- * @throws {Error} NOT_FOUND — target layout, source layout, or parent object does not exist
- */
 export async function copyLayout(
   tenantId: string,
   objectId: string,
@@ -668,46 +632,46 @@ export async function copyLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  // Fetch source layout
-  const sourceResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [sourceLayoutId, tenantId, objectId],
-  );
-  if (sourceResult.rows.length === 0) {
+  const sourceRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', sourceLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!sourceRow) {
     throwNotFoundError('Source page layout not found');
   }
 
-  // Fetch target layout
-  const targetResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [targetLayoutId, tenantId, objectId],
-  );
-  if (targetResult.rows.length === 0) {
+  const targetRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', targetLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!targetRow) {
     throwNotFoundError('Target page layout not found');
   }
 
-  const sourceRow = sourceResult.rows[0] as Record<string, unknown>;
   const now = new Date();
 
-  // Copy the source layout JSON into the target's draft
-  const result = await pool.query(
-    `UPDATE page_layouts
-     SET layout = $1, updated_at = $2
-     WHERE id = $3 AND tenant_id = $4
-     RETURNING *`,
-    [sourceRow.layout, now, targetLayoutId, tenantId],
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set({
+      layout: sourceRow.layout,
+      updated_at: now,
+    })
+    .where('id', '=', targetLayoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ targetLayoutId, sourceLayoutId, objectId }, 'Page layout copied');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }
 
-/**
- * Reverts a page layout's draft to a specific version from page_layout_versions.
- *
- * @throws {Error} NOT_FOUND — layout, version snapshot, or parent object does not exist
- */
 export async function revertLayout(
   tenantId: string,
   objectId: string,
@@ -716,37 +680,42 @@ export async function revertLayout(
 ): Promise<PageLayout> {
   await assertObjectExists(tenantId, objectId);
 
-  // Verify the layout exists
-  const layoutResult = await pool.query(
-    'SELECT * FROM page_layouts WHERE id = $1 AND tenant_id = $2 AND object_id = $3',
-    [layoutId, tenantId, objectId],
-  );
-  if (layoutResult.rows.length === 0) {
+  const layoutRow = await db
+    .selectFrom('page_layouts')
+    .selectAll()
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('object_id', '=', objectId)
+    .executeTakeFirst();
+  if (!layoutRow) {
     throwNotFoundError('Page layout not found');
   }
 
-  // Find the version snapshot
-  const versionResult = await pool.query(
-    'SELECT * FROM page_layout_versions WHERE layout_id = $1 AND tenant_id = $2 AND version = $3',
-    [layoutId, tenantId, version],
-  );
-  if (versionResult.rows.length === 0) {
+  const versionRow = await db
+    .selectFrom('page_layout_versions')
+    .selectAll()
+    .where('layout_id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .where('version', '=', version)
+    .executeTakeFirst();
+  if (!versionRow) {
     throwNotFoundError(`Version ${version} not found for this layout`);
   }
 
-  const versionRow = versionResult.rows[0] as Record<string, unknown>;
   const now = new Date();
 
-  // Restore the version's layout JSON into the draft
-  const result = await pool.query(
-    `UPDATE page_layouts
-     SET layout = $1, updated_at = $2
-     WHERE id = $3 AND tenant_id = $4
-     RETURNING *`,
-    [versionRow.layout, now, layoutId, tenantId],
-  );
+  const row = await db
+    .updateTable('page_layouts')
+    .set({
+      layout: versionRow.layout,
+      updated_at: now,
+    })
+    .where('id', '=', layoutId)
+    .where('tenant_id', '=', tenantId)
+    .returningAll()
+    .executeTakeFirstOrThrow();
 
   logger.info({ layoutId, objectId, version }, 'Page layout reverted');
 
-  return rowToPageLayout(result.rows[0]);
+  return rowToPageLayout(row);
 }

--- a/apps/api/src/services/seedDefaultObjects.ts
+++ b/apps/api/src/services/seedDefaultObjects.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
-import { pool } from '../db/client.js';
+import type { Transaction } from 'kysely';
+import { db } from '../db/kysely.js';
+import type { DB } from '../db/kysely.types.js';
 import { logger } from '../lib/logger.js';
 
 // ─── Seed data types ──────────────────────────────────────────────────────────
@@ -569,10 +571,6 @@ const STAGE_GATE_SEEDS: StageGateSeed[] = [
 // IMPLEMENTATION
 // ═══════════════════════════════════════════════════════════════════════════════
 
-interface QueryClient {
-  query(text: string, values?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-}
-
 /**
  * Seeds all default CRM objects, fields, relationships, layouts, and lead
  * conversion mappings for a tenant.
@@ -585,12 +583,8 @@ interface QueryClient {
  * @param ownerId - The owner/tenant identifier (e.g. Descope user ID or 'SYSTEM').
  */
 export async function seedDefaultObjects(tenantId: string, ownerId: string): Promise<SeedResult> {
-  const client = await pool.connect();
-
-  try {
-    await client.query('BEGIN');
-    const result = await seedWithClient(client, tenantId, ownerId);
-    await client.query('COMMIT');
+  return db.transaction().execute(async (trx) => {
+    const result = await seedWithClient(trx, tenantId, ownerId);
 
     logger.info(
       {
@@ -619,20 +613,15 @@ export async function seedDefaultObjects(tenantId: string, ownerId: string): Pro
     );
 
     return result;
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
-  }
+  });
 }
 
 /**
- * Inner implementation that runs against an already-connected client.
- * Exported for testing and for callers that manage their own transaction.
+ * Inner implementation that runs against an already-open Kysely transaction.
+ * Exported for callers that manage their own transaction (e.g. tenantProvisioning).
  */
 export async function seedWithClient(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   ownerId: string,
 ): Promise<SeedResult> {
@@ -657,29 +646,14 @@ export async function seedWithClient(
     stageGatesSkipped: 0,
   };
 
-  // Step 1: Seed object definitions
-  const objectIdMap = await seedObjects(client, tenantId, ownerId, result);
-
-  // Step 2: Seed field definitions
-  const fieldIdMap = await seedFields(client, tenantId, objectIdMap, result);
-
-  // Step 2b: Update name_field_id and name_template on object definitions
-  await seedNameFieldConfig(client, objectIdMap, fieldIdMap);
-
-  // Step 3: Seed relationship definitions
-  await seedRelationships(client, tenantId, objectIdMap, result);
-
-  // Step 4: Seed layout definitions
-  const layoutIdMap = await seedLayouts(client, tenantId, objectIdMap, result);
-
-  // Step 5: Seed layout fields
-  await seedLayoutFields(client, tenantId, fieldIdMap, layoutIdMap, result);
-
-  // Step 6: Seed lead conversion mappings
-  await seedLeadConversionMappings(client, tenantId, result);
-
-  // Step 7: Seed pipeline definitions, stages, and stage gates
-  await seedPipelines(client, tenantId, ownerId, objectIdMap, fieldIdMap, result);
+  const objectIdMap = await seedObjects(trx, tenantId, ownerId, result);
+  const fieldIdMap = await seedFields(trx, tenantId, objectIdMap, result);
+  await seedNameFieldConfig(trx, objectIdMap, fieldIdMap);
+  await seedRelationships(trx, tenantId, objectIdMap, result);
+  const layoutIdMap = await seedLayouts(trx, tenantId, objectIdMap, result);
+  await seedLayoutFields(trx, tenantId, fieldIdMap, layoutIdMap, result);
+  await seedLeadConversionMappings(trx, tenantId, result);
+  await seedPipelines(trx, tenantId, ownerId, objectIdMap, fieldIdMap, result);
 
   return result;
 }
@@ -687,7 +661,7 @@ export async function seedWithClient(
 // ─── Step helpers ─────────────────────────────────────────────────────────────
 
 async function seedObjects(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   ownerId: string,
   result: SeedResult,
@@ -696,30 +670,40 @@ async function seedObjects(
 
   for (const obj of OBJECT_SEEDS) {
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO object_definitions (id, api_name, label, plural_label, description, icon, is_system, owner_id, tenant_id)
-       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8)
-       ON CONFLICT (tenant_id, api_name) DO NOTHING
-       RETURNING id`,
-      [id, obj.apiName, obj.label, obj.pluralLabel, obj.description, obj.icon, ownerId, tenantId],
-    );
+    const row = await trx
+      .insertInto('object_definitions')
+      .values({
+        id,
+        api_name: obj.apiName,
+        label: obj.label,
+        plural_label: obj.pluralLabel,
+        description: obj.description,
+        icon: obj.icon,
+        is_system: true,
+        owner_id: ownerId,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'api_name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
-      objectIdMap.set(obj.apiName, rows[0].id as string);
+    if (row) {
+      objectIdMap.set(obj.apiName, row.id);
       result.objectsCreated++;
     } else {
       result.objectsSkipped++;
     }
   }
 
-  // Fetch IDs for objects that already existed (skipped by ON CONFLICT)
   if (result.objectsSkipped > 0) {
-    const { rows } = await client.query(
-      `SELECT id, api_name FROM object_definitions WHERE api_name = ANY($1) AND tenant_id = $2`,
-      [OBJECT_SEEDS.map((o) => o.apiName), tenantId],
-    );
+    const rows = await trx
+      .selectFrom('object_definitions')
+      .select(['id', 'api_name'])
+      .where('api_name', 'in', OBJECT_SEEDS.map((o) => o.apiName))
+      .where('tenant_id', '=', tenantId)
+      .execute();
     for (const row of rows) {
-      objectIdMap.set(row.api_name as string, row.id as string);
+      objectIdMap.set(row.api_name, row.id);
     }
   }
 
@@ -732,7 +716,7 @@ async function seedObjects(
 }
 
 async function seedFields(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   objectIdMap: Map<string, string>,
   result: SeedResult,
@@ -744,35 +728,44 @@ async function seedFields(
     if (!objectId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO field_definitions (id, object_id, api_name, label, field_type, required, options, sort_order, is_system, tenant_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-       ON CONFLICT (tenant_id, object_id, api_name) DO NOTHING
-       RETURNING id`,
-      [id, objectId, field.apiName, field.label, field.fieldType, field.required, JSON.stringify(field.options), field.sortOrder, field.isSystem ?? false, tenantId],
-    );
+    const row = await trx
+      .insertInto('field_definitions')
+      .values({
+        id,
+        object_id: objectId,
+        api_name: field.apiName,
+        label: field.label,
+        field_type: field.fieldType,
+        required: field.required,
+        options: JSON.stringify(field.options),
+        sort_order: field.sortOrder,
+        is_system: field.isSystem ?? false,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'object_id', 'api_name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
     const key = `${field.objectApiName}.${field.apiName}`;
-    if (rows.length > 0) {
-      fieldIdMap.set(key, rows[0].id as string);
+    if (row) {
+      fieldIdMap.set(key, row.id);
       result.fieldsCreated++;
     } else {
       result.fieldsSkipped++;
     }
   }
 
-  // Fetch IDs for fields that already existed
   if (result.fieldsSkipped > 0) {
-    const { rows } = await client.query(
-      `SELECT fd.id, od.api_name AS object_api_name, fd.api_name
-       FROM field_definitions fd
-       JOIN object_definitions od ON fd.object_id = od.id
-       WHERE od.api_name = ANY($1) AND fd.tenant_id = $2`,
-      [OBJECT_SEEDS.map((o) => o.apiName), tenantId],
-    );
+    const rows = await trx
+      .selectFrom('field_definitions as fd')
+      .innerJoin('object_definitions as od', 'fd.object_id', 'od.id')
+      .select(['fd.id', 'od.api_name as object_api_name', 'fd.api_name'])
+      .where('od.api_name', 'in', OBJECT_SEEDS.map((o) => o.apiName))
+      .where('fd.tenant_id', '=', tenantId)
+      .execute();
     for (const row of rows) {
       const key = `${row.object_api_name}.${row.api_name}`;
-      fieldIdMap.set(key, row.id as string);
+      fieldIdMap.set(key, row.id);
     }
   }
 
@@ -785,7 +778,7 @@ async function seedFields(
 }
 
 async function seedNameFieldConfig(
-  client: QueryClient,
+  trx: Transaction<DB>,
   objectIdMap: Map<string, string>,
   fieldIdMap: Map<string, string>,
 ): Promise<void> {
@@ -797,18 +790,33 @@ async function seedNameFieldConfig(
       const fieldKey = `${obj.apiName}.${obj.nameFieldApiName}`;
       const fieldId = fieldIdMap.get(fieldKey);
       if (fieldId) {
-        await client.query(
-          `UPDATE object_definitions SET name_field_id = $1 WHERE id = $2 AND (name_field_id IS NULL OR name_field_id != $1)`,
-          [fieldId, objectId],
-        );
+        await trx
+          .updateTable('object_definitions')
+          .set({ name_field_id: fieldId })
+          .where('id', '=', objectId)
+          .where((eb) =>
+            eb.or([
+              eb('name_field_id', 'is', null),
+              eb('name_field_id', '!=', fieldId),
+            ]),
+          )
+          .execute();
       }
     }
 
     if (obj.nameTemplate) {
-      await client.query(
-        `UPDATE object_definitions SET name_template = $1 WHERE id = $2 AND (name_template IS NULL OR name_template != $1)`,
-        [obj.nameTemplate, objectId],
-      );
+      const tmpl = obj.nameTemplate;
+      await trx
+        .updateTable('object_definitions')
+        .set({ name_template: tmpl })
+        .where('id', '=', objectId)
+        .where((eb) =>
+          eb.or([
+            eb('name_template', 'is', null),
+            eb('name_template', '!=', tmpl),
+          ]),
+        )
+        .execute();
     }
   }
 
@@ -816,7 +824,7 @@ async function seedNameFieldConfig(
 }
 
 async function seedRelationships(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   objectIdMap: Map<string, string>,
   result: SeedResult,
@@ -827,15 +835,24 @@ async function seedRelationships(
     if (!sourceObjectId || !targetObjectId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO relationship_definitions (id, source_object_id, target_object_id, relationship_type, api_name, label, reverse_label, required, tenant_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-       ON CONFLICT (tenant_id, source_object_id, api_name) DO NOTHING
-       RETURNING id`,
-      [id, sourceObjectId, targetObjectId, rel.relationshipType, rel.apiName, rel.label, rel.reverseLabel, rel.required, tenantId],
-    );
+    const row = await trx
+      .insertInto('relationship_definitions')
+      .values({
+        id,
+        source_object_id: sourceObjectId,
+        target_object_id: targetObjectId,
+        relationship_type: rel.relationshipType,
+        api_name: rel.apiName,
+        label: rel.label,
+        reverse_label: rel.reverseLabel,
+        required: rel.required,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'source_object_id', 'api_name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
+    if (row) {
       result.relationshipsCreated++;
     } else {
       result.relationshipsSkipped++;
@@ -849,7 +866,7 @@ async function seedRelationships(
 }
 
 async function seedLayouts(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   objectIdMap: Map<string, string>,
   result: SeedResult,
@@ -861,35 +878,40 @@ async function seedLayouts(
     if (!objectId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO layout_definitions (id, object_id, name, layout_type, is_default, tenant_id)
-       VALUES ($1, $2, $3, $4, true, $5)
-       ON CONFLICT (tenant_id, object_id, name) DO NOTHING
-       RETURNING id`,
-      [id, objectId, layout.name, layout.layoutType, tenantId],
-    );
+    const row = await trx
+      .insertInto('layout_definitions')
+      .values({
+        id,
+        object_id: objectId,
+        name: layout.name,
+        layout_type: layout.layoutType,
+        is_default: true,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'object_id', 'name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
     const key = `${layout.objectApiName}.${layout.name}`;
-    if (rows.length > 0) {
-      layoutIdMap.set(key, rows[0].id as string);
+    if (row) {
+      layoutIdMap.set(key, row.id);
       result.layoutsCreated++;
     } else {
       result.layoutsSkipped++;
     }
   }
 
-  // Fetch IDs for layouts that already existed
   if (result.layoutsSkipped > 0) {
-    const { rows } = await client.query(
-      `SELECT ld.id, od.api_name AS object_api_name, ld.name
-       FROM layout_definitions ld
-       JOIN object_definitions od ON ld.object_id = od.id
-       WHERE od.api_name = ANY($1) AND ld.tenant_id = $2`,
-      [OBJECT_SEEDS.map((o) => o.apiName), tenantId],
-    );
+    const rows = await trx
+      .selectFrom('layout_definitions as ld')
+      .innerJoin('object_definitions as od', 'ld.object_id', 'od.id')
+      .select(['ld.id', 'od.api_name as object_api_name', 'ld.name'])
+      .where('od.api_name', 'in', OBJECT_SEEDS.map((o) => o.apiName))
+      .where('ld.tenant_id', '=', tenantId)
+      .execute();
     for (const row of rows) {
       const key = `${row.object_api_name}.${row.name}`;
-      layoutIdMap.set(key, row.id as string);
+      layoutIdMap.set(key, row.id);
     }
   }
 
@@ -902,7 +924,7 @@ async function seedLayouts(
 }
 
 async function seedLayoutFields(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   fieldIdMap: Map<string, string>,
   layoutIdMap: Map<string, string>,
@@ -918,15 +940,23 @@ async function seedLayoutFields(
     if (!layoutId || !fieldId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO layout_fields (id, layout_id, field_id, section, section_label, sort_order, width, tenant_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-       ON CONFLICT (tenant_id, layout_id, field_id) DO NOTHING
-       RETURNING id`,
-      [id, layoutId, fieldId, lf.section, lf.sectionLabel, lf.sortOrder, lf.width, tenantId],
-    );
+    const row = await trx
+      .insertInto('layout_fields')
+      .values({
+        id,
+        layout_id: layoutId,
+        field_id: fieldId,
+        section: lf.section,
+        section_label: lf.sectionLabel,
+        sort_order: lf.sortOrder,
+        width: lf.width,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'layout_id', 'field_id']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
+    if (row) {
       result.layoutFieldsCreated++;
     } else {
       result.layoutFieldsSkipped++;
@@ -940,21 +970,30 @@ async function seedLayoutFields(
 }
 
 async function seedLeadConversionMappings(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   result: SeedResult,
 ): Promise<void> {
   for (const mapping of LEAD_CONVERSION_MAPPING_SEEDS) {
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO lead_conversion_mappings (id, lead_field_api_name, target_object, target_field_api_name, tenant_id)
-       VALUES ($1, $2, $3, $4, $5)
-       ON CONFLICT (tenant_id, lead_field_api_name, target_object, target_field_api_name) DO NOTHING
-       RETURNING id`,
-      [id, mapping.leadFieldApiName, mapping.targetObject, mapping.targetFieldApiName, tenantId],
-    );
+    const row = await trx
+      .insertInto('lead_conversion_mappings')
+      .values({
+        id,
+        lead_field_api_name: mapping.leadFieldApiName,
+        target_object: mapping.targetObject,
+        target_field_api_name: mapping.targetFieldApiName,
+        tenant_id: tenantId,
+      })
+      .onConflict((oc) =>
+        oc
+          .columns(['tenant_id', 'lead_field_api_name', 'target_object', 'target_field_api_name'])
+          .doNothing(),
+      )
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
+    if (row) {
       result.leadConversionMappingsCreated++;
     } else {
       result.leadConversionMappingsSkipped++;
@@ -968,7 +1007,7 @@ async function seedLeadConversionMappings(
 }
 
 async function seedPipelines(
-  client: QueryClient,
+  trx: Transaction<DB>,
   tenantId: string,
   ownerId: string,
   objectIdMap: Map<string, string>,
@@ -976,37 +1015,48 @@ async function seedPipelines(
   result: SeedResult,
 ): Promise<void> {
   const pipelineIdMap = new Map<string, string>();
+  const now = new Date();
 
-  // Step 7a: Create pipeline definitions
   for (const pipeline of PIPELINE_SEEDS) {
     const objectId = objectIdMap.get(pipeline.objectApiName);
     if (!objectId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO pipeline_definitions (id, tenant_id, object_id, name, api_name, is_default, is_system, owner_id, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, $5, true, $6, $7, NOW(), NOW())
-       ON CONFLICT (tenant_id, object_id, api_name) DO NOTHING
-       RETURNING id`,
-      [id, tenantId, objectId, pipeline.name, pipeline.apiName, pipeline.isSystem, ownerId],
-    );
+    const row = await trx
+      .insertInto('pipeline_definitions')
+      .values({
+        id,
+        tenant_id: tenantId,
+        object_id: objectId,
+        name: pipeline.name,
+        api_name: pipeline.apiName,
+        is_default: true,
+        is_system: pipeline.isSystem,
+        owner_id: ownerId,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'object_id', 'api_name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
-      pipelineIdMap.set(pipeline.apiName, rows[0].id as string);
+    if (row) {
+      pipelineIdMap.set(pipeline.apiName, row.id);
       result.pipelinesCreated++;
     } else {
       result.pipelinesSkipped++;
     }
   }
 
-  // Fetch IDs for pipelines that already existed
   if (result.pipelinesSkipped > 0) {
-    const { rows } = await client.query(
-      `SELECT id, api_name FROM pipeline_definitions WHERE api_name = ANY($1) AND tenant_id = $2`,
-      [PIPELINE_SEEDS.map((p) => p.apiName), tenantId],
-    );
+    const rows = await trx
+      .selectFrom('pipeline_definitions')
+      .select(['id', 'api_name'])
+      .where('api_name', 'in', PIPELINE_SEEDS.map((p) => p.apiName))
+      .where('tenant_id', '=', tenantId)
+      .execute();
     for (const row of rows) {
-      pipelineIdMap.set(row.api_name as string, row.id as string);
+      pipelineIdMap.set(row.api_name, row.id);
     }
   }
 
@@ -1015,7 +1065,6 @@ async function seedPipelines(
     'Seeded pipeline definitions',
   );
 
-  // Step 7b: Create stage definitions
   const stageIdMap = new Map<string, string>();
 
   for (const stage of STAGE_SEEDS) {
@@ -1023,37 +1072,47 @@ async function seedPipelines(
     if (!pipelineId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO stage_definitions (id, tenant_id, pipeline_id, name, api_name, sort_order, stage_type, colour, default_probability, expected_days, created_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
-       ON CONFLICT (tenant_id, pipeline_id, api_name) DO NOTHING
-       RETURNING id`,
-      [id, tenantId, pipelineId, stage.name, stage.apiName, stage.sortOrder, stage.stageType, stage.colour, stage.defaultProbability, stage.expectedDays],
-    );
+    const row = await trx
+      .insertInto('stage_definitions')
+      .values({
+        id,
+        tenant_id: tenantId,
+        pipeline_id: pipelineId,
+        name: stage.name,
+        api_name: stage.apiName,
+        sort_order: stage.sortOrder,
+        stage_type: stage.stageType,
+        colour: stage.colour,
+        default_probability: stage.defaultProbability,
+        expected_days: stage.expectedDays,
+        created_at: now,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'pipeline_id', 'api_name']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
     const key = `${stage.pipelineApiName}.${stage.apiName}`;
-    if (rows.length > 0) {
-      stageIdMap.set(key, rows[0].id as string);
+    if (row) {
+      stageIdMap.set(key, row.id);
       result.stagesCreated++;
     } else {
       result.stagesSkipped++;
     }
   }
 
-  // Fetch IDs for stages that already existed
   if (result.stagesSkipped > 0) {
     const pipelineIds = [...pipelineIdMap.values()];
     if (pipelineIds.length > 0) {
-      const { rows } = await client.query(
-        `SELECT sd.id, sd.api_name, pd.api_name AS pipeline_api_name
-         FROM stage_definitions sd
-         JOIN pipeline_definitions pd ON sd.pipeline_id = pd.id
-         WHERE sd.pipeline_id = ANY($1) AND sd.tenant_id = $2`,
-        [pipelineIds, tenantId],
-      );
+      const rows = await trx
+        .selectFrom('stage_definitions as sd')
+        .innerJoin('pipeline_definitions as pd', 'sd.pipeline_id', 'pd.id')
+        .select(['sd.id', 'sd.api_name', 'pd.api_name as pipeline_api_name'])
+        .where('sd.pipeline_id', 'in', pipelineIds)
+        .where('sd.tenant_id', '=', tenantId)
+        .execute();
       for (const row of rows) {
         const key = `${row.pipeline_api_name}.${row.api_name}`;
-        stageIdMap.set(key, row.id as string);
+        stageIdMap.set(key, row.id);
       }
     }
   }
@@ -1063,7 +1122,6 @@ async function seedPipelines(
     'Seeded stage definitions',
   );
 
-  // Step 7c: Create stage gates
   for (const gate of STAGE_GATE_SEEDS) {
     const stageKey = `${gate.pipelineApiName}.${gate.stageApiName}`;
     const stageId = stageIdMap.get(stageKey);
@@ -1073,15 +1131,22 @@ async function seedPipelines(
     if (!stageId || !fieldId) continue;
 
     const id = randomUUID();
-    const { rows } = await client.query(
-      `INSERT INTO stage_gates (id, tenant_id, stage_id, field_id, gate_type, gate_value, error_message)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       ON CONFLICT (tenant_id, stage_id, field_id) DO NOTHING
-       RETURNING id`,
-      [id, tenantId, stageId, fieldId, gate.gateType, gate.gateValue, gate.errorMessage],
-    );
+    const row = await trx
+      .insertInto('stage_gates')
+      .values({
+        id,
+        tenant_id: tenantId,
+        stage_id: stageId,
+        field_id: fieldId,
+        gate_type: gate.gateType,
+        gate_value: gate.gateValue,
+        error_message: gate.errorMessage,
+      })
+      .onConflict((oc) => oc.columns(['tenant_id', 'stage_id', 'field_id']).doNothing())
+      .returning('id')
+      .executeTakeFirst();
 
-    if (rows.length > 0) {
+    if (row) {
       result.stageGatesCreated++;
     } else {
       result.stageGatesSkipped++;

--- a/apps/api/src/services/seedDefaultObjects.ts
+++ b/apps/api/src/services/seedDefaultObjects.ts
@@ -758,7 +758,11 @@ async function seedFields(
   if (result.fieldsSkipped > 0) {
     const rows = await trx
       .selectFrom('field_definitions as fd')
-      .innerJoin('object_definitions as od', 'fd.object_id', 'od.id')
+      .innerJoin('object_definitions as od', (join) =>
+        join
+          .onRef('od.id', '=', 'fd.object_id')
+          .onRef('od.tenant_id', '=', 'fd.tenant_id'),
+      )
       .select(['fd.id', 'od.api_name as object_api_name', 'fd.api_name'])
       .where('od.api_name', 'in', OBJECT_SEEDS.map((o) => o.apiName))
       .where('fd.tenant_id', '=', tenantId)
@@ -904,7 +908,11 @@ async function seedLayouts(
   if (result.layoutsSkipped > 0) {
     const rows = await trx
       .selectFrom('layout_definitions as ld')
-      .innerJoin('object_definitions as od', 'ld.object_id', 'od.id')
+      .innerJoin('object_definitions as od', (join) =>
+        join
+          .onRef('od.id', '=', 'ld.object_id')
+          .onRef('od.tenant_id', '=', 'ld.tenant_id'),
+      )
       .select(['ld.id', 'od.api_name as object_api_name', 'ld.name'])
       .where('od.api_name', 'in', OBJECT_SEEDS.map((o) => o.apiName))
       .where('ld.tenant_id', '=', tenantId)
@@ -1105,7 +1113,11 @@ async function seedPipelines(
     if (pipelineIds.length > 0) {
       const rows = await trx
         .selectFrom('stage_definitions as sd')
-        .innerJoin('pipeline_definitions as pd', 'sd.pipeline_id', 'pd.id')
+        .innerJoin('pipeline_definitions as pd', (join) =>
+          join
+            .onRef('pd.id', '=', 'sd.pipeline_id')
+            .onRef('pd.tenant_id', '=', 'sd.tenant_id'),
+        )
         .select(['sd.id', 'sd.api_name', 'pd.api_name as pipeline_api_name'])
         .where('sd.pipeline_id', 'in', pipelineIds)
         .where('sd.tenant_id', '=', tenantId)

--- a/apps/api/src/services/tenantProvisioning.ts
+++ b/apps/api/src/services/tenantProvisioning.ts
@@ -1,5 +1,4 @@
 import type { Selectable, Updateable } from 'kysely';
-import { pool } from '../db/client.js';
 import { db } from '../db/kysely.js';
 import type { Tenants } from '../db/kysely.types.js';
 import { getDescopeManagementClient } from '../lib/descopeManagementClient.js';
@@ -117,7 +116,7 @@ function coerceTenantRow(row: Selectable<Tenants>): TenantRow {
  * 1. Validates the slug (format + uniqueness).
  * 2. Creates the tenant in Descope (using the slug as the Descope tenant ID).
  * 3. Inserts the tenant record + seeds all default CRM data inside a single
- *    database transaction so that a seed failure rolls back the DB insert.
+ *    Kysely transaction so that a seed failure rolls back the DB insert.
  * 4. Invites the admin user into the new tenant with the "admin" role in
  *    Descope (create + assign tenant roles + send magic-link invite in one
  *    API call).
@@ -127,16 +126,6 @@ function coerceTenantRow(row: Selectable<Tenants>): TenantRow {
  *   attempts to delete the Descope tenant before re-throwing.
  * - The DB insert + seed run inside a single transaction, so a seed failure
  *   automatically rolls back the tenant row.
- *
- * Transaction implementation note:
- * - `seedWithClient` takes a raw pg `PoolClient` (it originates from the
- *   1109-line `seedDefaultObjects.ts` which is out of scope for this
- *   migration), so the BEGIN/COMMIT envelope is still managed via the raw
- *   client — Kysely doesn't own that transaction. The tenant INSERT inside
- *   the transaction is still built via Kysely and `.compile()`d so the
- *   column list and value shapes stay under Kysely's compile-time safety
- *   net; the compiled SQL + params are then handed to the raw client
- *   (which holds the transaction) to keep INSERT and seed atomic.
  *
  * @throws {Error} with `code: 'VALIDATION_ERROR'` for invalid input.
  * @throws {Error} with `code: 'DUPLICATE_SLUG'` if the slug is already taken.
@@ -187,97 +176,39 @@ export async function provisionTenant(
 
   // ── 3. Insert tenant record + seed CRM data (single DB transaction) ────────
 
-  const client = await pool.connect();
-  // The Descope tenant ID is the slug — use a descriptive alias throughout.
   const tenantId = slug;
-  let seedResult: SeedResult;
+  let txResult: { tenantRow: TenantRow; seedResult: SeedResult };
 
   try {
-    await client.query('BEGIN');
+    txResult = await db.transaction().execute(async (trx) => {
+      const now = new Date();
+      const defaultSettings = {
+        currency: 'GBP',
+        dateFormat: 'DD/MM/YYYY',
+        timezone: 'Europe/London',
+      };
 
-    const now = new Date();
-    const defaultSettings = {
-      currency: 'GBP',
-      dateFormat: 'DD/MM/YYYY',
-      timezone: 'Europe/London',
-    };
+      const row = await trx
+        .insertInto('tenants')
+        .values({
+          id: tenantId,
+          name: name.trim(),
+          slug,
+          status: 'active',
+          plan,
+          settings: JSON.stringify(defaultSettings),
+          created_at: now,
+          updated_at: now,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
 
-    // Build the INSERT with Kysely so the column list, value shapes and
-    // RETURNING projection are all type-checked against the generated
-    // Tenants schema, then execute the compiled query on the raw client
-    // (which owns the BEGIN/COMMIT envelope shared with seedWithClient).
-    const insertTenant = db
-      .insertInto('tenants')
-      .values({
-        id: tenantId,
-        name: name.trim(),
-        slug,
-        status: 'active',
-        plan,
-        settings: JSON.stringify(defaultSettings),
-        created_at: now,
-        updated_at: now,
-      })
-      .returningAll()
-      .compile();
+      logger.info({ tenantId }, 'Tenant record inserted, seeding default CRM data');
+      const sr = await seedWithClient(trx, tenantId, tenantId);
 
-    const tenantResult = await client.query(
-      insertTenant.sql,
-      [...insertTenant.parameters],
-    );
-    const tenantRow = coerceTenantRow(tenantResult.rows[0] as Selectable<Tenants>);
-
-    logger.info({ tenantId }, 'Tenant record inserted, seeding default CRM data');
-    seedResult = await seedWithClient(client, tenantId, tenantId);
-
-    await client.query('COMMIT');
-    logger.info({ tenantId }, 'Tenant record and seed data committed');
-
-    // ── 4. Invite admin user via Descope ───────────────────────────────────
-
-    logger.info({ tenantId, adminEmail }, 'Inviting admin user via Descope');
-
-    let inviteSent = false;
-    try {
-      await descopeClient.management.user.invite(adminEmail, {
-        email: adminEmail,
-        displayName: adminName.trim(),
-        userTenants: [{ tenantId, roleNames: ['admin'] }],
-        sendMail: true,
-      });
-      inviteSent = true;
-      logger.info({ tenantId, adminEmail }, 'Admin user invited successfully');
-    } catch (inviteErr) {
-      // Log but do not roll back: the tenant and seed data are committed.
-      // The platform admin can resend the invite manually.
-      logger.error(
-        { err: inviteErr, tenantId, adminEmail },
-        'Failed to send admin invite; tenant was created but invite was not sent',
-      );
-    }
-
-    return {
-      tenant: {
-        id: tenantRow.id,
-        name: tenantRow.name,
-        slug: tenantRow.slug,
-        status: tenantRow.status,
-      },
-      adminUser: {
-        email: adminEmail,
-        inviteSent,
-      },
-      seeded: {
-        objects: seedResult.objectsCreated,
-        fields: seedResult.fieldsCreated,
-        relationships: seedResult.relationshipsCreated,
-        pipelines: seedResult.pipelinesCreated,
-      },
-    };
+      return { tenantRow: coerceTenantRow(row), seedResult: sr };
+    });
   } catch (err) {
-    await client.query('ROLLBACK').catch(() => {});
-
-    // Attempt to clean up the Descope tenant so the slug is not orphaned
     logger.warn({ err, tenantId }, 'Provisioning failed; rolling back Descope tenant');
     await descopeClient.management.tenant.delete(tenantId).catch((deleteErr: unknown) => {
       logger.error(
@@ -287,9 +218,49 @@ export async function provisionTenant(
     });
 
     throw err;
-  } finally {
-    client.release();
   }
+
+  logger.info({ tenantId }, 'Tenant record and seed data committed');
+
+  // ── 4. Invite admin user via Descope ───────────────────────────────────────
+
+  logger.info({ tenantId, adminEmail }, 'Inviting admin user via Descope');
+
+  let inviteSent = false;
+  try {
+    await descopeClient.management.user.invite(adminEmail, {
+      email: adminEmail,
+      displayName: adminName.trim(),
+      userTenants: [{ tenantId, roleNames: ['admin'] }],
+      sendMail: true,
+    });
+    inviteSent = true;
+    logger.info({ tenantId, adminEmail }, 'Admin user invited successfully');
+  } catch (inviteErr) {
+    logger.error(
+      { err: inviteErr, tenantId, adminEmail },
+      'Failed to send admin invite; tenant was created but invite was not sent',
+    );
+  }
+
+  return {
+    tenant: {
+      id: txResult.tenantRow.id,
+      name: txResult.tenantRow.name,
+      slug: txResult.tenantRow.slug,
+      status: txResult.tenantRow.status,
+    },
+    adminUser: {
+      email: adminEmail,
+      inviteSent,
+    },
+    seeded: {
+      objects: txResult.seedResult.objectsCreated,
+      fields: txResult.seedResult.fieldsCreated,
+      relationships: txResult.seedResult.relationshipsCreated,
+      pipelines: txResult.seedResult.pipelinesCreated,
+    },
+  };
 }
 
 // ─── List / get / update / delete helpers ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- **seedDefaultObjects.ts**: Migrated all raw `pool.query()`/`client.query()` calls to Kysely query builder (`insertInto`, `selectFrom`, `updateTable`) using `Transaction<DB>` for transaction-scoped operations
- **tenantProvisioning.ts**: Removed the raw-client escape hatch (`pool.connect()` + manual `BEGIN`/`COMMIT`/`ROLLBACK`), now uses `db.transaction().execute()` and passes the Kysely transaction to `seedWithClient`
- **seedDefaultObjects.test.ts**: Fully rewritten mocks for Kysely's PostgresDriver pattern (`pool.connect` + `normaliseCall` dual call-shape handler), introduced `extractInsertRow` helper for robust column-name-based param extraction instead of fragile positional indexing
- **tenantProvisioning.e2e.test.ts**: Updated mock handlers for Kysely SQL patterns (`IN` vs `ANY`, parameterized `NOW()`/booleans, quoted identifiers)

All 45 tests pass across 3 test files. TypeScript compiles clean.

Part of Phase 3b (tracker issue #445), PR 3 of Group D.

## Test plan

- [x] `seedDefaultObjects.test.ts` — 17 tests pass
- [x] `tenantProvisioning.e2e.test.ts` — 16 tests pass
- [x] `tenantProvisioning.kysely-sql.test.ts` — 12 tests pass (regression check, no changes)
- [x] `npx tsc --noEmit` — clean

https://claude.ai/code/session_015buB9is8NjzcSZFgqLoGwf