### PR TITLE
test(ci): DO NOT MERGE — verify Kysely types drift check fails red

### DIFF
--- a/apps/api/src/db/migrations/026_test_drift_verification_DO_NOT_MERGE.sql
+++ b/apps/api/src/db/migrations/026_test_drift_verification_DO_NOT_MERGE.sql
@@ -1,0 +1,10 @@
+-- TEST-ONLY: deliberate schema drift to verify the Phase 4 CI check (issue #446).
+--
+-- This migration adds a throwaway column to `accounts`. The PR that contains
+-- it intentionally does NOT regenerate apps/api/src/db/kysely.types.ts, so the
+-- new "Kysely types are in sync with migrations" CI job should fail red.
+--
+-- DO NOT MERGE. The branch + PR are deleted/closed once the check is proven.
+
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS drift_check_column TEXT;


### PR DESCRIPTION
## Purpose — DO NOT MERGE

Exercises the one open acceptance criterion on issue #446 that could not be proven from inside PR #468:

> An intentionally-introduced mismatch (test commit to a throwaway branch) actually fails the check — proves the job works, not just that it's green

## What this does

Adds `026_test_drift_verification_DO_NOT_MERGE.sql` — a trivial `ALTER TABLE accounts ADD COLUMN drift_check_column TEXT` — and deliberately **does not** regenerate `apps/api/src/db/kysely.types.ts`.

## Expected outcome

- ✅ `Lint, Typecheck & Test` — passes (TS compiles fine, new column just isn't in the Kysely types)
- ❌ **`Kysely types are in sync with migrations`** — **fails red** with the boxed error message pointing at `npm run db:types`

Once the failure is confirmed, this PR is closed and the branch deleted. This is a verification artifact only.

---
_Generated by [Claude Code](https://claude.ai/code)_