### PR TITLE
feat(web): install @tanstack/react-query and mount provider (#470)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,12 +18,14 @@
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@tanstack/react-query-devtools": "^5.59.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from './lib/queryClient.js';
 import { TenantSettingsProvider } from './store/tenantSettings.js';
 import { SessionSync } from './components/SessionSync.js';
 import { LoginPage } from './pages/LoginPage.js';
@@ -41,6 +44,7 @@ export function App() {
   return (
     <BrowserRouter>
       <SessionSync />
+      <QueryClientProvider client={queryClient}>
       <TenantSettingsProvider>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
@@ -342,6 +346,8 @@ export function App() {
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
       </TenantSettingsProvider>
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
     </BrowserRouter>
   );
 }

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,12 +57,14 @@
                         "@dnd-kit/core": "^6.1.0",
                         "@dnd-kit/sortable": "^10.0.0",
                         "@dnd-kit/utilities": "^3.2.2",
+                        "@tanstack/react-query": "^5.59.0",
                         "react": "^18.3.1",
                         "react-dom": "^18.3.1",
                         "react-router-dom": "^7.14.0"
                   },
                   "devDependencies": {
                         "@eslint/js": "^9.39.4",
+                        "@tanstack/react-query-devtools": "^5.59.0",
                         "@testing-library/jest-dom": "^6.9.1",
                         "@testing-library/react": "^16.3.2",
                         "@testing-library/user-event": "^14.6.1",
@@ -2330,6 +2332,61 @@
                   "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
                   "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
                   "license": "MIT"
+            },
+            "node_modules/@tanstack/query-core": {
+                  "version": "5.99.1",
+                  "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.1.tgz",
+                  "integrity": "sha512-5E8xwxyWvr22yt7zvzP3KOZ5TUElOdVA45NP3/Ao1m9mvc9i18NLTDe9m3M00BH2DR5J20cv7xckMPlhKNs+vQ==",
+                  "license": "MIT",
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/tannerlinsley"
+                  }
+            },
+            "node_modules/@tanstack/query-devtools": {
+                  "version": "5.99.1",
+                  "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.1.tgz",
+                  "integrity": "sha512-6BcpadvDYgJ578xWdqoxORcGd2wgRdEll/EkCjCb4Mge04kGUVqpES+wh04s/VgBVFuGSe4ab+AwmnfDWBmNZg==",
+                  "dev": true,
+                  "license": "MIT",
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/tannerlinsley"
+                  }
+            },
+            "node_modules/@tanstack/react-query": {
+                  "version": "5.99.1",
+                  "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.1.tgz",
+                  "integrity": "sha512-akg5GdwW70lvJvCqVHZ7tizGyc+TATjUzKX9RuF1xknhEe/1leofXk7YLYbrbRsuhNbHJBAayaQUMvvOFZ5L5g==",
+                  "license": "MIT",
+                  "dependencies": {
+                        "@tanstack/query-core": "5.99.1"
+                  },
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/tannerlinsley"
+                  },
+                  "peerDependencies": {
+                        "react": "^18 || ^19"
+                  }
+            },
+            "node_modules/@tanstack/react-query-devtools": {
+                  "version": "5.99.1",
+                  "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.1.tgz",
+                  "integrity": "sha512-9HuN9qWAn8kseiFZNpGYKik0ozff5yBv2t6D6wZvKV6qncH7BAtf0N2myxioZXpOVfCVmpOtgRfNvMHH22CHgQ==",
+                  "dev": true,
+                  "license": "MIT",
+                  "dependencies": {
+                        "@tanstack/query-devtools": "5.99.1"
+                  },
+                  "funding": {
+                        "type": "github",
+                        "url": "https://github.com/sponsors/tannerlinsley"
+                  },
+                  "peerDependencies": {
+                        "@tanstack/react-query": "^5.99.1",
+                        "react": "^18 || ^19"
+                  }
             },
             "node_modules/@testing-library/dom": {
                   "version": "10.4.1",


### PR DESCRIPTION
Closes #470. Part of epic #379 (`TQ: Foundation` milestone).

## Summary
- Add `@tanstack/react-query` to `apps/web` dependencies and `@tanstack/react-query-devtools` to devDependencies (both `^5.59.0`).
- Create `apps/web/src/lib/queryClient.ts` exporting a shared `QueryClient` with `staleTime: 5 * 60_000`, `retry: 1`, `refetchOnWindowFocus: true`, `refetchOnReconnect: true`.
- Wrap the route tree in `App.tsx` with `QueryClientProvider` — inside `BrowserRouter`, outside `TenantSettingsProvider`.
- Mount `ReactQueryDevtools` guarded by `import.meta.env.DEV` so it ships only in development.

No components have been migrated to `useQuery` / `useMutation` yet — that is explicitly deferred to follow-up issues in the epic.

## Test plan
- [x] `npm --workspace @cpcrm/web run typecheck` — clean
- [x] `npm --workspace @cpcrm/web run test` — 638/638 passing
- [x] `npm --workspace @cpcrm/web run build` — succeeds; confirmed `ReactQueryDevtools` is tree-shaken from the production bundle (0 matches under `dist/`)
- [ ] `npm --workspace @cpcrm/web run dev` — devtools floating button visible in dev (manual verification)
