### PR TITLE
feat(web): query-key factory + shared types (#471)

### DIFF
--- a/apps/web/src/lib/__tests__/queryKeys.test.ts
+++ b/apps/web/src/lib/__tests__/queryKeys.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  queryKeys,
+  recordsKeys,
+  objectDefinitionsKeys,
+  fieldDefinitionsKeys,
+  pipelinesKeys,
+  pageLayoutsKeys,
+} from '../queryKeys.js';
+
+describe('queryKeys factory', () => {
+  it('records keys are hierarchical so partial invalidation works', () => {
+    const list = recordsKeys.list('account', { limit: 25, offset: 0 });
+    const detail = recordsKeys.detail('account', 'rec-1');
+
+    expect(list[0]).toBe('records');
+    expect(list[1]).toBe('account');
+    expect(list[2]).toBe('list');
+    expect(list[3]).toEqual({ limit: 25, offset: 0 });
+
+    expect(detail).toEqual(['records', 'account', 'detail', 'rec-1']);
+
+    // Both share the per-object prefix, so invalidating that prefix nukes both.
+    expect(list.slice(0, 2)).toEqual(recordsKeys.byObject('account'));
+    expect(detail.slice(0, 2)).toEqual(recordsKeys.byObject('account'));
+  });
+
+  it('records.list defaults params to an empty object for stable keys', () => {
+    expect(recordsKeys.list('account')).toEqual(['records', 'account', 'list', {}]);
+  });
+
+  it('object definitions expose root, all, and detail', () => {
+    expect(objectDefinitionsKeys.root()).toEqual(['objectDefinitions']);
+    expect(objectDefinitionsKeys.all()).toEqual(['objectDefinitions', 'all']);
+    expect(objectDefinitionsKeys.detail('obj-1')).toEqual(['objectDefinitions', 'detail', 'obj-1']);
+  });
+
+  it('field definitions are scoped under their owning object', () => {
+    expect(fieldDefinitionsKeys.list('obj-1')).toEqual(['fieldDefinitions', 'obj-1', 'list']);
+    expect(fieldDefinitionsKeys.byObject('obj-1')).toEqual(['fieldDefinitions', 'obj-1']);
+  });
+
+  it('pipelines expose detail keyed by pipeline id', () => {
+    expect(pipelinesKeys.detail('pipe-1')).toEqual(['pipelines', 'detail', 'pipe-1']);
+  });
+
+  it('page layouts cover both per-object lists and individual layouts', () => {
+    expect(pageLayoutsKeys.list('obj-1')).toEqual(['pageLayouts', 'object', 'obj-1', 'list']);
+    expect(pageLayoutsKeys.detail('layout-1')).toEqual(['pageLayouts', 'detail', 'layout-1']);
+  });
+
+  it('aggregate `queryKeys` re-exports each factory', () => {
+    expect(queryKeys.records).toBe(recordsKeys);
+    expect(queryKeys.objectDefinitions).toBe(objectDefinitionsKeys);
+    expect(queryKeys.fieldDefinitions).toBe(fieldDefinitionsKeys);
+    expect(queryKeys.pipelines).toBe(pipelinesKeys);
+    expect(queryKeys.pageLayouts).toBe(pageLayoutsKeys);
+  });
+});

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -1,0 +1,150 @@
+/**
+ * Centralised TanStack Query key factory.
+ *
+ * Every `useQuery` / `useMutation` hook in the web app **must** source its
+ * `queryKey` from this module. Hand-rolled string arrays drift over time and
+ * make targeted invalidation a guessing game; a single hierarchical factory
+ * keeps keys typed, discoverable, and trivial to invalidate at the right
+ * scope.
+ *
+ * See `docs/adr/0001-query-key-factory.md` for the convention.
+ */
+
+// ─── Domain primitives ──────────────────────────────────────────────────────
+
+/**
+ * Object API name (e.g. `'account'`, `'opportunity'`). The string the
+ * `/api/v1/objects/:apiName/...` routes use as the path parameter.
+ */
+export type ObjectApiName = string;
+
+/** Opaque identifier for a single record. */
+export type RecordId = string;
+
+/** Opaque identifier for an object definition. */
+export type ObjectDefinitionId = string;
+
+/** Opaque identifier for a pipeline. */
+export type PipelineId = string;
+
+/** Opaque identifier for a page layout. */
+export type PageLayoutId = string;
+
+/**
+ * Parameters that materially affect the response of a list endpoint.
+ *
+ * Kept open-ended so each caller can pass the filters/sort/pagination it
+ * actually uses without having to extend a central enum. Values are inlined
+ * into the query key, so prefer plain primitives (string / number / boolean)
+ * over object references.
+ */
+export type ListParams = Readonly<Record<string, unknown>>;
+
+// ─── Records ────────────────────────────────────────────────────────────────
+
+/**
+ * Keys for `/api/v1/objects/:apiName/records` and friends.
+ *
+ * Hierarchy:
+ *   ['records']                                — invalidate every record query
+ *   ['records', apiName]                       — every query for one object
+ *   ['records', apiName, 'list', params]       — a specific list view
+ *   ['records', apiName, 'detail', id]         — a specific record
+ */
+export const recordsKeys = {
+  all: () => ['records'] as const,
+  byObject: (apiName: ObjectApiName) => ['records', apiName] as const,
+  list: (apiName: ObjectApiName, params?: ListParams) =>
+    ['records', apiName, 'list', params ?? {}] as const,
+  detail: (apiName: ObjectApiName, id: RecordId) => ['records', apiName, 'detail', id] as const,
+} as const;
+
+// ─── Object definitions ─────────────────────────────────────────────────────
+
+/**
+ * Keys for `/api/v1/admin/objects` (object definitions / metadata).
+ *
+ * Hierarchy:
+ *   ['objectDefinitions']                      — invalidate everything
+ *   ['objectDefinitions', 'all']               — the list of all definitions
+ *   ['objectDefinitions', 'detail', id]        — one definition
+ */
+export const objectDefinitionsKeys = {
+  root: () => ['objectDefinitions'] as const,
+  all: () => ['objectDefinitions', 'all'] as const,
+  detail: (id: ObjectDefinitionId) => ['objectDefinitions', 'detail', id] as const,
+} as const;
+
+// ─── Field definitions ──────────────────────────────────────────────────────
+
+/**
+ * Keys for the field-definition endpoints scoped to an object.
+ *
+ * Hierarchy:
+ *   ['fieldDefinitions']                       — invalidate everything
+ *   ['fieldDefinitions', objectId]             — every field-def query for one object
+ *   ['fieldDefinitions', objectId, 'list']     — the list of fields on one object
+ */
+export const fieldDefinitionsKeys = {
+  all: () => ['fieldDefinitions'] as const,
+  byObject: (objectId: ObjectDefinitionId) => ['fieldDefinitions', objectId] as const,
+  list: (objectId: ObjectDefinitionId) => ['fieldDefinitions', objectId, 'list'] as const,
+} as const;
+
+// ─── Pipelines ──────────────────────────────────────────────────────────────
+
+/**
+ * Keys for `/api/v1/admin/pipelines` and `/api/v1/pipelines/:id/...`.
+ *
+ * Hierarchy:
+ *   ['pipelines']                              — invalidate everything
+ *   ['pipelines', 'detail', pipelineId]        — one pipeline's full payload
+ */
+export const pipelinesKeys = {
+  all: () => ['pipelines'] as const,
+  detail: (pipelineId: PipelineId) => ['pipelines', 'detail', pipelineId] as const,
+} as const;
+
+// ─── Page layouts ───────────────────────────────────────────────────────────
+
+/**
+ * Keys for the page-layout endpoints.
+ *
+ * Hierarchy:
+ *   ['pageLayouts']                            — invalidate everything
+ *   ['pageLayouts', 'object', objectId]        — every layout query for one object
+ *   ['pageLayouts', 'object', objectId, 'list']— the list of layouts for one object
+ *   ['pageLayouts', 'detail', layoutId]        — one specific layout
+ */
+export const pageLayoutsKeys = {
+  all: () => ['pageLayouts'] as const,
+  byObject: (objectId: ObjectDefinitionId) => ['pageLayouts', 'object', objectId] as const,
+  list: (objectId: ObjectDefinitionId) => ['pageLayouts', 'object', objectId, 'list'] as const,
+  detail: (layoutId: PageLayoutId) => ['pageLayouts', 'detail', layoutId] as const,
+} as const;
+
+// ─── Aggregate export ───────────────────────────────────────────────────────
+
+/**
+ * Single namespace import for callers that want to write
+ * `queryKeys.records.detail(...)` rather than juggling individual factories.
+ */
+export const queryKeys = {
+  records: recordsKeys,
+  objectDefinitions: objectDefinitionsKeys,
+  fieldDefinitions: fieldDefinitionsKeys,
+  pipelines: pipelinesKeys,
+  pageLayouts: pageLayoutsKeys,
+} as const;
+
+/**
+ * Union of every key shape produced by this module. Useful for typing
+ * helpers that accept "any query key from our factory" without resorting to
+ * `unknown[]`.
+ */
+export type AppQueryKey =
+  | ReturnType<(typeof recordsKeys)[keyof typeof recordsKeys]>
+  | ReturnType<(typeof objectDefinitionsKeys)[keyof typeof objectDefinitionsKeys]>
+  | ReturnType<(typeof fieldDefinitionsKeys)[keyof typeof fieldDefinitionsKeys]>
+  | ReturnType<(typeof pipelinesKeys)[keyof typeof pipelinesKeys]>
+  | ReturnType<(typeof pageLayoutsKeys)[keyof typeof pageLayoutsKeys]>;

--- a/docs/adr/0001-query-key-factory.md
+++ b/docs/adr/0001-query-key-factory.md
@@ -1,0 +1,140 @@
+# ADR 0001: TanStack Query key factory + shared types
+
+## Status
+
+Accepted — 2026-04-18
+
+## Context
+
+Epic [#379](https://github.com/Brianclark490/CPCRM/issues/379) migrates the
+web app from hand-rolled `useEffect` + `useState` server-state code to
+TanStack Query. Once even a handful of hooks land, two failure modes appear
+within days of any "agree on a convention later" approach:
+
+1. **Drift in query keys.** Two hooks that fetch the same resource end up
+   with subtly different keys (`['account', id]` vs `['accounts', id]` vs
+   `['records', 'account', id]`). The cache silently double-fetches and the
+   developer who has to invalidate has to grep for every variant.
+2. **Imprecise invalidation.** Without a hierarchy it's tempting to either
+   `invalidateQueries()` everything (kills perf) or pass a hand-typed array
+   that doesn't match what a sibling hook produced (silent staleness).
+
+A central, hierarchical query-key factory — the pattern popularised by
+`tkdodo` — fixes both. Every hook imports its key from one module, and
+`queryClient.invalidateQueries({ queryKey: queryKeys.records.byObject(name) })`
+hits exactly the right scope.
+
+This ADR is part of the **TQ: Foundation** milestone (issue
+[#471](https://github.com/Brianclark490/CPCRM/issues/471)) and must land
+before the first real hook in milestone M2.
+
+## Decision
+
+### 1. Single source of truth
+
+All query keys live in `apps/web/src/lib/queryKeys.ts`. Hooks **never**
+inline key arrays. Code review should reject any new `useQuery({ queryKey:
+['...'] })` whose key isn't sourced from this file.
+
+### 2. Hierarchical shape
+
+Every key is a tuple beginning with a stable string discriminator and
+narrowing left-to-right:
+
+```
+[domain, ...scope, kind, ...args]
+```
+
+For example:
+
+| Factory call                                  | Resulting key                                       |
+| --------------------------------------------- | --------------------------------------------------- |
+| `records.all()`                               | `['records']`                                       |
+| `records.byObject('account')`                 | `['records', 'account']`                            |
+| `records.list('account', { limit: 25 })`      | `['records', 'account', 'list', { limit: 25 }]`    |
+| `records.detail('account', 'rec-1')`          | `['records', 'account', 'detail', 'rec-1']`        |
+| `objectDefinitions.all()`                     | `['objectDefinitions', 'all']`                      |
+| `objectDefinitions.detail('obj-1')`           | `['objectDefinitions', 'detail', 'obj-1']`          |
+| `fieldDefinitions.list('obj-1')`              | `['fieldDefinitions', 'obj-1', 'list']`             |
+| `pipelines.detail('pipe-1')`                  | `['pipelines', 'detail', 'pipe-1']`                 |
+| `pageLayouts.list('obj-1')`                   | `['pageLayouts', 'object', 'obj-1', 'list']`        |
+| `pageLayouts.detail('layout-1')`              | `['pageLayouts', 'detail', 'layout-1']`             |
+
+The hierarchy directly mirrors what we want to be able to invalidate:
+
+- After a record mutation: `invalidateQueries({ queryKey: records.byObject(apiName) })`
+  refreshes both the list and the detail without touching unrelated objects.
+- After an admin edits an object's fields: `invalidateQueries({ queryKey:
+  fieldDefinitions.byObject(objectId) })` clears the field list for that one
+  object but leaves every other object's metadata cached.
+
+### 3. `as const` everywhere
+
+Every factory returns an `as const` tuple and is itself declared `as const`.
+This gives TanStack Query the literal-type information it needs for the
+generic inference on `useQuery`/`useMutation`, and lets the exported
+`AppQueryKey` union catch typos at compile time.
+
+### 4. List parameters are inlined into the key
+
+`records.list(apiName, params)` includes `params` as the final tuple element.
+TanStack Query hashes keys structurally, so two calls with equivalent params
+share a cache entry without any extra work from the caller. Callers should
+pass primitives only (no functions, dates, or class instances) so the hash
+is stable across renders.
+
+When a caller has no params, `records.list(apiName)` defaults to `{}` so the
+key is still well-formed and stable.
+
+### 5. Folder convention
+
+This ADR establishes `docs/adr/` as the home for **frontend / cross-cutting
+engineering** ADRs that aren't tied to backend architecture. The existing
+`docs/architecture/adr-NNN-*.md` files (API versioning, tenant isolation,
+etc.) remain where they are — they document long-lived backend decisions
+and renaming them would invalidate every inbound link.
+
+New ADRs in this folder are numbered `NNNN-kebab-case.md` starting at
+`0001`.
+
+## Consequences
+
+**Positive**
+
+- Cache hits go up because every hook fetching the same resource uses the
+  same key.
+- Invalidation becomes a one-line, scoped call instead of a grep-and-pray
+  exercise.
+- Adding a new resource family (e.g. `notifications`) is a single ~10-line
+  addition to one file, reviewable in isolation.
+- TypeScript catches misspelled keys (`recordsKeys.detial(...)`) before they
+  ship.
+
+**Negative**
+
+- One more file every PR touches when adding a new server-state hook. Worth
+  it: the cost of getting cache keys wrong vastly exceeds the cost of
+  editing one well-known file.
+- Some callers will want richer parameter types than the open-ended
+  `ListParams = Readonly<Record<string, unknown>>`. We start permissive and
+  tighten per-resource if/when the looseness causes a real bug.
+
+## Alternatives considered
+
+- **Inline string-array keys in each hook.** Rejected: this is exactly the
+  drift the epic is trying to eliminate.
+- **One enormous typed enum of every key.** Rejected: forces every new key
+  through a single hot file and produces unwieldy union types. The factory
+  pattern gives the same compile-time safety with better ergonomics.
+- **A third-party library (e.g. `@lukemorales/query-key-factory`).** Out of
+  scope for the foundation milestone — adding a dependency for ~150 lines of
+  code we'd otherwise own outright is a poor trade. Revisit if the factory
+  grows past ~500 lines.
+
+## References
+
+- Epic: [#379 Adopt TanStack Query for server state](https://github.com/Brianclark490/CPCRM/issues/379)
+- Issue: [#471 TQ: Query-key factory + shared types](https://github.com/Brianclark490/CPCRM/issues/471)
+- Implementation: `apps/web/src/lib/queryKeys.ts`
+- Tests: `apps/web/src/lib/__tests__/queryKeys.test.ts`
+- Background reading: <https://tkdodo.eu/blog/effective-react-query-keys>


### PR DESCRIPTION
Closes #471. Part of epic #379, milestone `TQ: Foundation`.

## Summary

- Adds `apps/web/src/lib/queryKeys.ts` — central, hierarchical TanStack Query key factory covering all five resource families called out in the issue: `records`, `objectDefinitions`, `fieldDefinitions`, `pipelines`, `pageLayouts`.
- Every factory returns `as const` tuples so TanStack Query gets literal-type inference, and an `AppQueryKey` union is exported for helpers that want to accept "any key from our factory".
- Adds `docs/adr/0001-query-key-factory.md` documenting the convention, the hierarchy → invalidation mapping, and why a new `docs/adr/` folder exists alongside the existing backend ADRs in `docs/architecture/`.
- Adds `apps/web/src/lib/__tests__/queryKeys.test.ts` pinning the shapes so drift is caught by CI, not code review.

## Key shapes

| Call | Key |
| --- | --- |
| `records.list('account', { limit: 25 })` | `['records', 'account', 'list', { limit: 25 }]` |
| `records.detail('account', 'rec-1')` | `['records', 'account', 'detail', 'rec-1']` |
| `objectDefinitions.all()` | `['objectDefinitions', 'all']` |
| `objectDefinitions.detail('obj-1')` | `['objectDefinitions', 'detail', 'obj-1']` |
| `fieldDefinitions.list('obj-1')` | `['fieldDefinitions', 'obj-1', 'list']` |
| `pipelines.detail('pipe-1')` | `['pipelines', 'detail', 'pipe-1']` |
| `pageLayouts.list('obj-1')` | `['pageLayouts', 'object', 'obj-1', 'list']` |
| `pageLayouts.detail('layout-1')` | `['pageLayouts', 'detail', 'layout-1']` |

The hierarchy is designed so the common invalidation moves are one-liners, e.g. after a record mutation: `invalidateQueries({ queryKey: recordsKeys.byObject(apiName) })` refreshes both list and detail for that object without touching the rest of the cache.

## Acceptance checklist (from #471)

- [x] `apps/web/src/lib/queryKeys.ts` created with all six factories from the issue
- [x] All keys exported as `const` and typed
- [x] ADR checked in under `docs/adr/`

## Test plan

- [x] `npx vitest run src/lib/__tests__/queryKeys.test.ts` — 7/7 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/lib/queryKeys.ts src/lib/__tests__/queryKeys.test.ts` — clean
- [x] `npx prettier --check` — clean
- [ ] First real consumer (#473 `usePipeline` + `useRecords`) will exercise the factory end-to-end
