### PR TITLE
test(web): renderWithQuery test helper (#472)

### DIFF
--- a/apps/web/src/__tests__/NotFoundPage.test.tsx
+++ b/apps/web/src/__tests__/NotFoundPage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { NotFoundPage } from '../pages/NotFoundPage.js';
+import { renderWithQuery } from './utils/renderWithQuery.js';
 
 const mockNavigate = vi.fn();
 
@@ -16,7 +17,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 describe('NotFoundPage', () => {
   it('renders the page not found heading and message', () => {
-    render(
+    renderWithQuery(
       <MemoryRouter>
         <NotFoundPage />
       </MemoryRouter>,
@@ -29,7 +30,7 @@ describe('NotFoundPage', () => {
   });
 
   it('navigates to /dashboard when the button is clicked', async () => {
-    render(
+    renderWithQuery(
       <MemoryRouter>
         <NotFoundPage />
       </MemoryRouter>,

--- a/apps/web/src/__tests__/utils/renderWithQuery.tsx
+++ b/apps/web/src/__tests__/utils/renderWithQuery.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement, ReactNode } from 'react';
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export interface RenderWithQueryOptions extends Omit<RenderOptions, 'wrapper'> {
+  queryClient?: QueryClient;
+}
+
+export interface RenderWithQueryResult extends RenderResult {
+  queryClient: QueryClient;
+}
+
+export function renderWithQuery(
+  ui: ReactElement,
+  { queryClient = createTestQueryClient(), ...options }: RenderWithQueryOptions = {},
+): RenderWithQueryResult {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return {
+    queryClient,
+    ...render(ui, { wrapper: Wrapper, ...options }),
+  };
+}


### PR DESCRIPTION
## Summary

Closes #472. Part of epic #379, milestone `TQ: Foundation`.

Adds a shared test helper `apps/web/src/__tests__/utils/renderWithQuery.tsx` so components migrating to TanStack Query can render inside a `QueryClientProvider` without each test re-declaring the wiring.

- `renderWithQuery(ui, options?)` wraps `@testing-library/react`'s `render` with a `QueryClientProvider`.
- A fresh `QueryClient` is created per call with `retry: false` and `gcTime: 0` (and `mutations.retry: false`) so tests don't share cache state and don't retry on error.
- Consumers can pass their own `queryClient` via options, and the returned result exposes the active client for assertions/hydration.
- Ports `NotFoundPage.test.tsx` as a smoke check that the helper works in an existing test.

## Test plan

- [x] `npm test` (web) — 47 files / 645 tests passing
- [x] `npm run typecheck` (web) — clean
- [x] `npm run lint` (web) — no new errors (pre-existing warnings only)
