### PR TITLE
feat(web): usePipeline + useRecords query hooks for Kanban

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { KanbanBoard } from '../components/KanbanBoard.js';
+import { renderWithQuery } from './utils/renderWithQuery.js';
 
 vi.mock('@descope/react-sdk', () => ({
   useSession: vi.fn(),
@@ -181,7 +182,7 @@ function mockFetch() {
 }
 
 function renderBoard() {
-  return render(
+  return renderWithQuery(
     <MemoryRouter initialEntries={['/objects/opportunity']}>
       <Routes>
         <Route

--- a/apps/web/src/__tests__/ViewToggle.test.tsx
+++ b/apps/web/src/__tests__/ViewToggle.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { RecordListPage } from '../pages/RecordListPage.js';
+import { renderWithQuery } from './utils/renderWithQuery.js';
 
 vi.mock('@descope/react-sdk', () => ({
   useSession: vi.fn(),
@@ -11,7 +12,7 @@ vi.mock('@descope/react-sdk', () => ({
 const { useSession } = await import('@descope/react-sdk');
 
 function renderPage(apiName = 'opportunity', initialView?: 'list' | 'pipeline') {
-  return render(
+  return renderWithQuery(
     <MemoryRouter initialEntries={[`/objects/${apiName}`]}>
       <Routes>
         <Route

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -1,6 +1,18 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@descope/react-sdk';
 import { ApiError, unwrapList, useApiClient } from '../lib/apiClient.js';
+import { pipelinesKeys, recordsKeys } from '../lib/queryKeys.js';
+import {
+  usePipeline,
+  type Pipeline as PipelineDefinition,
+  type PipelineStage as StageDefinition,
+} from '../features/pipelines/hooks/queries/usePipeline.js';
+import {
+  useRecords,
+  type RecordItem,
+  type RecordsResponse,
+} from '../features/records/hooks/queries/useRecords.js';
 import { useTenantLocale } from '../useTenantLocale.js';
 import { KanbanCard } from './KanbanCard.js';
 import type { KanbanCardRecord } from './KanbanCard.js';
@@ -15,43 +27,6 @@ import type { OverdueRecord } from './OverdueDealsPanel.js';
 import styles from './KanbanBoard.module.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-
-interface StageDefinition {
-  id: string;
-  name: string;
-  apiName: string;
-  sortOrder: number;
-  stageType: string;
-  colour: string;
-  defaultProbability?: number;
-  expectedDays?: number;
-}
-
-interface PipelineDefinition {
-  id: string;
-  name: string;
-  objectId: string;
-  stages: StageDefinition[];
-}
-
-interface RecordItem {
-  id: string;
-  name: string;
-  fieldValues: Record<string, unknown>;
-  ownerId: string;
-  pipelineId?: string;
-  currentStageId?: string;
-  stageEnteredAt?: string;
-  linkedParent?: { objectApiName: string; recordId: string; recordName: string };
-  createdAt: string;
-}
-
-interface RecordsResponse {
-  data: RecordItem[];
-  total: number;
-  page: number;
-  limit: number;
-}
 
 interface MoveStageResponse {
   id: string;
@@ -85,6 +60,8 @@ interface KanbanBoardProps {
   apiName: string;
   objectId: string;
 }
+
+const RECORDS_QUERY_PARAMS = { limit: 100 } as const;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -177,12 +154,8 @@ function applyFilters(
 export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
   const { sessionToken } = useSession();
   const api = useApiClient();
+  const queryClient = useQueryClient();
   const { formatCurrencyCompact } = useTenantLocale();
-
-  const [pipeline, setPipeline] = useState<PipelineDefinition | null>(null);
-  const [allRecords, setAllRecords] = useState<RecordItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   const [filters, setFilters] = useState<KanbanFilters>(EMPTY_FILTERS);
   const [draggingRecordId, setDraggingRecordId] = useState<string | null>(null);
@@ -220,99 +193,80 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     });
   };
 
-  // ── Fetch pipeline + records ─────────────────────────────
-  useEffect(() => {
-    if (!sessionToken || !objectId || !apiName) return;
+  // ── Fetch pipeline + records via TanStack Query ──────────
+  //
+  // 1. List pipelines and find the one bound to this object. The
+  //    `/api/v1/admin/pipelines` endpoint returns a paginated envelope, so
+  //    the list is unwrapped before we match on `objectId`.
+  // 2. `usePipeline(pipelineId)` fetches the stage detail once the id is
+  //    known.
+  // 3. `useRecords(apiName, { limit: 100 })` fetches the records for this
+  //    object with `keepPreviousData` so the board doesn't flicker between
+  //    cached + refetched results.
+  const pipelineListQuery = useQuery({
+    queryKey: pipelinesKeys.list(),
+    queryFn: async () => {
+      const payload = await api.get<unknown>('/api/v1/admin/pipelines');
+      return unwrapList<
+        PipelineDefinition & { objectId?: string; object_id?: string }
+      >(payload);
+    },
+    enabled: Boolean(sessionToken),
+  });
 
-    let cancelled = false;
+  const matchedPipelineId = useMemo(() => {
+    const list = pipelineListQuery.data;
+    if (!list) return undefined;
+    return list.find((p) => (p.objectId ?? p.object_id) === objectId)?.id;
+  }, [pipelineListQuery.data, objectId]);
 
-    const loadAll = async () => {
-      try {
-        // 1. Find pipeline for this object. The admin/pipelines endpoint
-        // returns a paginated `{ data, pagination }` envelope, so unwrap
-        // via unwrapList (which also tolerates a bare array for future-
-        // proofing against endpoint shape changes).
-        let pipelines: Array<
-          PipelineDefinition & { objectId?: string; object_id?: string }
-        >;
-        try {
-          const payload = await api.get<unknown>('/api/v1/admin/pipelines');
-          pipelines = unwrapList<
-            PipelineDefinition & { objectId?: string; object_id?: string }
-          >(payload);
-        } catch {
-          if (!cancelled) {
-            setError('Failed to load pipeline configuration.');
-            setLoading(false);
-          }
-          return;
-        }
+  const pipelineDetailQuery = usePipeline(matchedPipelineId);
+  const recordsQuery = useRecords(apiName, RECORDS_QUERY_PARAMS);
 
-        if (cancelled) return;
+  const pipeline = pipelineDetailQuery.data ?? null;
+  const allRecords = useMemo<RecordItem[]>(
+    () => recordsQuery.data?.data ?? [],
+    [recordsQuery.data],
+  );
 
-        const match = pipelines.find(
-          (p) => (p.objectId ?? p.object_id) === objectId,
-        );
+  const loading =
+    pipelineListQuery.isLoading ||
+    (matchedPipelineId !== undefined &&
+      (pipelineDetailQuery.isLoading || recordsQuery.isLoading));
 
-        if (!match) {
-          setPipeline(null);
-          setLoading(false);
-          return;
-        }
+  // Surface records/detail errors only once we know there *is* a pipeline
+  // for this object. Otherwise the "no pipeline configured" path would be
+  // shadowed by a spurious records-fetch failure.
+  const error: string | null = pipelineListQuery.isError
+    ? 'Failed to load pipeline configuration.'
+    : matchedPipelineId && pipelineDetailQuery.isError
+      ? 'Failed to load pipeline stages.'
+      : matchedPipelineId && recordsQuery.isError
+        ? recordsQuery.error instanceof ApiError &&
+          recordsQuery.error.isNetwork
+          ? 'Failed to connect to the server.'
+          : 'Failed to load records for the pipeline.'
+        : null;
 
-        // 2. Fetch pipeline detail AND records in parallel
-        const [detailResult, recordsResult] = await Promise.allSettled([
-          api.get<PipelineDefinition>(`/api/v1/admin/pipelines/${match.id}`),
-          api.get<RecordsResponse>(
-            `/api/v1/objects/${apiName}/records?limit=100`,
-          ),
-        ]);
-
-        if (cancelled) return;
-
-        if (detailResult.status === 'rejected') {
-          setError('Failed to load pipeline stages.');
-          setLoading(false);
-          return;
-        }
-
-        const detail = detailResult.value;
-
-        let records: RecordItem[] = [];
-        if (recordsResult.status === 'fulfilled') {
-          records = Array.isArray(recordsResult.value.data)
-            ? recordsResult.value.data
-            : [];
-        }
-
-        // Set both pipeline and records in the same render batch
-        setPipeline(detail);
-        setAllRecords(records);
-
-        if (recordsResult.status === 'rejected') {
-          setError('Failed to load records for the pipeline.');
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(
-            err instanceof ApiError && err.isNetwork
-              ? 'Failed to connect to the server.'
-              : 'Failed to load pipeline configuration.',
-          );
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void loadAll();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionToken, api, objectId, apiName]);
+  // Apply a local patch to one record in the cached records list so drag-
+  // and-drop updates reflect immediately without a full refetch.
+  const patchRecord = useCallback(
+    (recordId: string, patch: Partial<RecordItem>) => {
+      queryClient.setQueryData<RecordsResponse>(
+        recordsKeys.list(apiName, RECORDS_QUERY_PARAMS),
+        (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            data: prev.data.map((r) =>
+              r.id === recordId ? { ...r, ...patch } : r,
+            ),
+          };
+        },
+      );
+    },
+    [queryClient, apiName],
+  );
 
   // ── Fetch pipeline analytics ──────────────────────────────
   const loadAnalytics = useCallback(async () => {
@@ -391,20 +345,12 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
 
       if (response.ok) {
         const updated = (await response.json()) as MoveStageResponse;
-        // Update local state
-        setAllRecords((prev) =>
-          prev.map((r) =>
-            r.id === recordId
-              ? {
-                  ...r,
-                  pipelineId: updated.pipelineId,
-                  currentStageId: updated.currentStageId,
-                  stageEnteredAt: updated.stageEnteredAt,
-                  fieldValues: updated.fieldValues,
-                }
-              : r,
-          ),
-        );
+        patchRecord(recordId, {
+          pipelineId: updated.pipelineId,
+          currentStageId: updated.currentStageId,
+          stageEnteredAt: updated.stageEnteredAt,
+          fieldValues: updated.fieldValues,
+        });
         // Refresh analytics after stage change
         void loadAnalytics();
         return true;
@@ -511,13 +457,10 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
       }
 
       // Update local record field values
-      setAllRecords((prev) =>
-        prev.map((r) =>
-          r.id === gateModal.recordId
-            ? { ...r, fieldValues: { ...r.fieldValues, ...fieldValues } }
-            : r,
-        ),
-      );
+      const existing = allRecords.find((r) => r.id === gateModal.recordId);
+      patchRecord(gateModal.recordId, {
+        fieldValues: { ...(existing?.fieldValues ?? {}), ...fieldValues },
+      });
 
       // Now retry the move
       const success = await performMoveStage(

--- a/apps/web/src/features/pipelines/hooks/queries/usePipeline.ts
+++ b/apps/web/src/features/pipelines/hooks/queries/usePipeline.ts
@@ -1,0 +1,43 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSession } from '@descope/react-sdk';
+import { useApiClient } from '../../../../lib/apiClient.js';
+import { pipelinesKeys } from '../../../../lib/queryKeys.js';
+
+export interface PipelineStage {
+  id: string;
+  name: string;
+  apiName: string;
+  sortOrder: number;
+  stageType: string;
+  colour: string;
+  defaultProbability?: number;
+  expectedDays?: number;
+}
+
+export interface Pipeline {
+  id: string;
+  name: string;
+  objectId: string;
+  stages: PipelineStage[];
+}
+
+/**
+ * Fetches a single pipeline definition by id from
+ * `GET /api/v1/admin/pipelines/{id}`.
+ *
+ * The query is disabled until both a session and a pipeline id are available,
+ * so callers can pass `undefined` while resolving the id without triggering
+ * a request.
+ */
+export function usePipeline(
+  pipelineId: string | undefined,
+): UseQueryResult<Pipeline> {
+  const { sessionToken } = useSession();
+  const api = useApiClient();
+
+  return useQuery({
+    queryKey: pipelinesKeys.detail(pipelineId ?? ''),
+    queryFn: () => api.get<Pipeline>(`/api/v1/admin/pipelines/${pipelineId}`),
+    enabled: Boolean(sessionToken && pipelineId),
+  });
+}

--- a/apps/web/src/features/records/hooks/queries/useRecords.ts
+++ b/apps/web/src/features/records/hooks/queries/useRecords.ts
@@ -1,0 +1,73 @@
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useSession } from '@descope/react-sdk';
+import { useApiClient } from '../../../../lib/apiClient.js';
+import { recordsKeys, type ListParams } from '../../../../lib/queryKeys.js';
+
+export interface RecordItem {
+  id: string;
+  name: string;
+  fieldValues: Record<string, unknown>;
+  ownerId: string;
+  pipelineId?: string;
+  currentStageId?: string;
+  stageEnteredAt?: string;
+  linkedParent?: {
+    objectApiName: string;
+    recordId: string;
+    recordName: string;
+  };
+  createdAt: string;
+}
+
+export interface RecordsResponse {
+  data: RecordItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface UseRecordsParams {
+  limit?: number;
+  offset?: number;
+  [key: string]: unknown;
+}
+
+function buildQueryString(params: UseRecordsParams): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    search.set(key, String(value));
+  }
+  const str = search.toString();
+  return str ? `?${str}` : '';
+}
+
+/**
+ * Fetches the paginated list of records for an object from
+ * `GET /api/v1/objects/{apiName}/records`.
+ *
+ * Uses `placeholderData: keepPreviousData` so that paginating / filtering the
+ * list keeps showing the previous page of data while the new page loads —
+ * avoiding flicker when the user flips through views.
+ */
+export function useRecords(
+  apiName: string | undefined,
+  params: UseRecordsParams = {},
+): UseQueryResult<RecordsResponse> {
+  const { sessionToken } = useSession();
+  const api = useApiClient();
+
+  return useQuery({
+    queryKey: recordsKeys.list(apiName ?? '', params as ListParams),
+    queryFn: () =>
+      api.get<RecordsResponse>(
+        `/api/v1/objects/${apiName}/records${buildQueryString(params)}`,
+      ),
+    enabled: Boolean(sessionToken && apiName),
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -98,10 +98,12 @@ export const fieldDefinitionsKeys = {
  *
  * Hierarchy:
  *   ['pipelines']                              — invalidate everything
+ *   ['pipelines', 'list']                      — the list of all pipelines
  *   ['pipelines', 'detail', pipelineId]        — one pipeline's full payload
  */
 export const pipelinesKeys = {
   all: () => ['pipelines'] as const,
+  list: () => ['pipelines', 'list'] as const,
   detail: (pipelineId: PipelineId) => ['pipelines', 'detail', pipelineId] as const,
 } as const;
 


### PR DESCRIPTION
## Summary

Introduces the first TanStack Query read hooks and migrates the Kanban board off its hand-rolled `useEffect` fetcher (closes #473).

- `apps/web/src/features/pipelines/hooks/queries/usePipeline.ts` — `GET /api/v1/admin/pipelines/{id}`, keyed by `pipelinesKeys.detail(id)` and disabled until a session + id are available.
- `apps/web/src/features/records/hooks/queries/useRecords.ts` — `GET /api/v1/objects/{apiName}/records`, keyed by `recordsKeys.list(apiName, params)` with `placeholderData: keepPreviousData` (the v5 form of `keepPreviousData: true`).
- `KanbanBoard` now resolves the pipeline id via an inline `useQuery` on `pipelinesKeys.list()`, then composes `usePipeline` + `useRecords` for the rest. The `pipeline`, `allRecords`, `loading`, and `error` local `useState` are gone — loading/error are derived from the queries, and the records list is read from the cache.
- Drag-and-drop stage changes now patch the cached records list via `queryClient.setQueryData` instead of a parallel `setAllRecords`, so the Kanban and any other consumer of that cache stay in sync.

A `pipelinesKeys.list()` factory was added to the query-key module to give the pipeline-list query a proper hierarchical key.

## Test plan
- [x] `npx tsc --noEmit` (apps/web)
- [x] `npx vitest run` — 645/645 passing, including the full `KanbanBoard.test.tsx` suite (19 cases covering columns, drag/drop, gate failure, stage resolution, summary toggle, no-pipeline/error states)
- [x] `npx eslint` on every touched file
- [ ] Manual: load `/objects/opportunity` in pipeline view, drag a card between stages, and confirm no duplicate `/records` or `/pipelines` requests in DevTools Network tab on repeat navigation

https://claude.ai/code/session_011NN7E51eoy5wiYQoS7AExG