### PR TITLE
feat(web): useMoveStage mutation with optimistic UI + 422 rollback

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -618,6 +618,153 @@ describe('KanbanBoard', () => {
     expect(screen.getByText('Deal Value is required')).toBeInTheDocument();
   });
 
+  it('optimistically moves card to target column before server responds', async () => {
+    const fetchMock = mockFetch();
+    renderBoard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Big Deal')).toBeInTheDocument();
+    });
+
+    // Big Deal starts in Prospecting
+    const prospectingColumn = screen.getByTestId('kanban-column-prospecting');
+    const qualColumn = screen.getByTestId('kanban-column-qualification');
+    expect(prospectingColumn).toHaveTextContent('Big Deal');
+
+    // Hold the move-stage response until we flip this deferred. Every other
+    // request keeps working through the original mock so analytics panels
+    // don't flap while we inspect the optimistic state.
+    let resolveMove: (value: Response) => void = () => {};
+    const movePromise = new Promise<Response>((r) => {
+      resolveMove = r;
+    });
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (
+        typeof url === 'string' &&
+        url.includes('/move-stage') &&
+        options?.method === 'POST'
+      ) {
+        return movePromise;
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockPipeline,
+        } as Response);
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
+        } as Response);
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockRecords,
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    const card = screen.getByTestId('kanban-card-rec-1');
+    fireEvent.dragStart(card, {
+      dataTransfer: { effectAllowed: 'move', setData: vi.fn(), getData: () => 'rec-1' },
+    });
+    fireEvent.drop(qualColumn, {
+      dataTransfer: { getData: () => 'rec-1' },
+    });
+
+    // Optimistic update: card should appear in Qualification while the POST is pending
+    await waitFor(() => {
+      expect(qualColumn).toHaveTextContent('Big Deal');
+    });
+    expect(prospectingColumn).not.toHaveTextContent('Big Deal');
+
+    // Release the server response so the test finishes cleanly
+    resolveMove({
+      ok: true,
+      json: async () => ({
+        id: 'rec-1',
+        pipelineId: 'pipe-1',
+        currentStageId: 'stage-2',
+        stageEnteredAt: new Date().toISOString(),
+        fieldValues: { value: 100000, close_date: '2026-06-15', probability: 30 },
+      }),
+    } as Response);
+  });
+
+  it('rolls back optimistic move when server returns 422', async () => {
+    const fetchMock = mockFetch();
+    renderBoard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Big Deal')).toBeInTheDocument();
+    });
+
+    const prospectingColumn = screen.getByTestId('kanban-column-prospecting');
+    const qualColumn = screen.getByTestId('kanban-column-qualification');
+    expect(prospectingColumn).toHaveTextContent('Big Deal');
+
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (
+        typeof url === 'string' &&
+        url.includes('/move-stage') &&
+        options?.method === 'POST'
+      ) {
+        return Promise.resolve({
+          ok: false,
+          status: 422,
+          json: async () => ({
+            error: 'Cannot move to Qualification — missing required fields',
+            code: 'GATE_VALIDATION_FAILED',
+            failures: [
+              {
+                field: 'value',
+                label: 'Deal Value',
+                gate: 'required',
+                message: 'Deal Value is required',
+                fieldType: 'currency',
+                currentValue: null,
+                options: {},
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
+        return Promise.resolve({ ok: true, json: async () => mockPipeline } as Response);
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
+        } as Response);
+      }
+      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+        return Promise.resolve({ ok: true, json: async () => mockRecords } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    const card = screen.getByTestId('kanban-card-rec-1');
+    fireEvent.dragStart(card, {
+      dataTransfer: { effectAllowed: 'move', setData: vi.fn(), getData: () => 'rec-1' },
+    });
+    fireEvent.drop(qualColumn, {
+      dataTransfer: { getData: () => 'rec-1' },
+    });
+
+    // Gate modal opens ⇒ server responded with 422 ⇒ rollback has run
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // After rollback the card is back in Prospecting — not lingering in Qualification.
+    expect(prospectingColumn).toHaveTextContent('Big Deal');
+    expect(qualColumn).not.toHaveTextContent('Big Deal');
+  });
+
   it('places records using fieldValues.stage when present', async () => {
     const stageRecords = {
       data: [

--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -632,12 +632,14 @@ describe('KanbanBoard', () => {
     expect(prospectingColumn).toHaveTextContent('Big Deal');
 
     // Hold the move-stage response until we flip this deferred. Every other
-    // request keeps working through the original mock so analytics panels
-    // don't flap while we inspect the optimistic state.
+    // request falls back to the default mock so analytics panels (summary,
+    // velocity, overdue) still get their expected shapes and don't crash the
+    // component when `loadAnalytics()` fires in the success path.
     let resolveMove: (value: Response) => void = () => {};
     const movePromise = new Promise<Response>((r) => {
       resolveMove = r;
     });
+    const defaultImpl = fetchMock.getMockImplementation();
     fetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (
         typeof url === 'string' &&
@@ -646,25 +648,10 @@ describe('KanbanBoard', () => {
       ) {
         return movePromise;
       }
-      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => mockPipeline,
-        } as Response);
-      }
-      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
-        } as Response);
-      }
-      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => mockRecords,
-        } as Response);
-      }
-      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      return defaultImpl?.(url, options) ?? Promise.resolve({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
     });
 
     const card = screen.getByTestId('kanban-card-rec-1');
@@ -681,7 +668,9 @@ describe('KanbanBoard', () => {
     });
     expect(prospectingColumn).not.toHaveTextContent('Big Deal');
 
-    // Release the server response so the test finishes cleanly
+    // Release the server response and wait for the success path (including
+    // the `loadAnalytics()` refresh) to settle before the test exits, so we
+    // don't leak pending promises into later tests.
     resolveMove({
       ok: true,
       json: async () => ({
@@ -692,6 +681,17 @@ describe('KanbanBoard', () => {
         fieldValues: { value: 100000, close_date: '2026-06-15', probability: 30 },
       }),
     } as Response);
+
+    await waitFor(() => {
+      const moveCalls = fetchMock.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' && (call[0] as string).includes('/move-stage'),
+      );
+      expect(moveCalls.length).toBeGreaterThanOrEqual(1);
+      // Card stays in Qualification and no gate dialog appeared.
+      expect(qualColumn).toHaveTextContent('Big Deal');
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('rolls back optimistic move when server returns 422', async () => {
@@ -706,6 +706,10 @@ describe('KanbanBoard', () => {
     const qualColumn = screen.getByTestId('kanban-column-qualification');
     expect(prospectingColumn).toHaveTextContent('Big Deal');
 
+    // Only override the move-stage POST; every other request (including
+    // analytics endpoints that fire after settle) keeps using the default
+    // mock so the board renders without surprise shape mismatches.
+    const defaultImpl = fetchMock.getMockImplementation();
     fetchMock.mockImplementation((url: string, options?: RequestInit) => {
       if (
         typeof url === 'string' &&
@@ -732,19 +736,10 @@ describe('KanbanBoard', () => {
           }),
         } as Response);
       }
-      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
-        return Promise.resolve({ ok: true, json: async () => mockPipeline } as Response);
-      }
-      if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
-        } as Response);
-      }
-      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
-        return Promise.resolve({ ok: true, json: async () => mockRecords } as Response);
-      }
-      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      return defaultImpl?.(url, options) ?? Promise.resolve({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
     });
 
     const card = screen.getByTestId('kanban-card-rec-1');

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -333,9 +333,14 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
   const performMoveStage = useCallback(
     async (recordId: string, targetStageId: string): Promise<boolean> => {
       if (!sessionToken) return false;
+      const targetStage = pipeline?.stages.find((s) => s.id === targetStageId);
       try {
         await moveStage.mutateAsync(
-          { recordId, targetStageId },
+          {
+            recordId,
+            targetStageId,
+            targetStageApiName: targetStage?.apiName,
+          },
           { onSuccess: () => void loadAnalytics() },
         );
         return true;
@@ -345,7 +350,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
         return false;
       }
     },
-    [sessionToken, moveStage, loadAnalytics],
+    [sessionToken, pipeline, moveStage, loadAnalytics],
   );
 
   const handleDrop = (e: React.DragEvent, targetStageId: string) => {

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -13,6 +13,7 @@ import {
   type RecordItem,
   type RecordsResponse,
 } from '../features/records/hooks/queries/useRecords.js';
+import { useMoveStage } from '../features/pipelines/hooks/mutations/useMoveStage.js';
 import { useTenantLocale } from '../useTenantLocale.js';
 import { KanbanCard } from './KanbanCard.js';
 import type { KanbanCardRecord } from './KanbanCard.js';
@@ -27,20 +28,6 @@ import type { OverdueRecord } from './OverdueDealsPanel.js';
 import styles from './KanbanBoard.module.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-
-interface MoveStageResponse {
-  id: string;
-  pipelineId: string;
-  currentStageId: string;
-  stageEnteredAt: string;
-  fieldValues: Record<string, unknown>;
-}
-
-interface GateFailureResponse {
-  error: string;
-  code: string;
-  failures: GateFailure[];
-}
 
 interface ConfirmState {
   recordId: string;
@@ -248,10 +235,10 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
           : 'Failed to load records for the pipeline.'
         : null;
 
-  // Apply a local patch to one record in the cached records list so drag-
-  // and-drop updates reflect immediately without a full refetch.
-  const patchRecord = useCallback(
-    (recordId: string, patch: Partial<RecordItem>) => {
+  // Patch a single record in the cached list. Used by fill-and-move to
+  // reflect the PUT field update before retrying the stage move.
+  const patchRecordFields = useCallback(
+    (recordId: string, fieldValues: Record<string, unknown>) => {
       queryClient.setQueryData<RecordsResponse>(
         recordsKeys.list(apiName, RECORDS_QUERY_PARAMS),
         (prev) => {
@@ -259,7 +246,9 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
           return {
             ...prev,
             data: prev.data.map((r) =>
-              r.id === recordId ? { ...r, ...patch } : r,
+              r.id === recordId
+                ? { ...r, fieldValues: { ...r.fieldValues, ...fieldValues } }
+                : r,
             ),
           };
         },
@@ -304,6 +293,22 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     }
   }, [pipeline, loadAnalytics]);
 
+  // ── Move-stage mutation (optimistic + gate-failure rollback) ──
+  const moveStage = useMoveStage({
+    apiName,
+    listParams: RECORDS_QUERY_PARAMS,
+    pipelineId: pipeline?.id,
+    onGateFailure: (failures, vars) => {
+      const targetStage = pipeline?.stages.find((s) => s.id === vars.targetStageId);
+      setGateModal({
+        recordId: vars.recordId,
+        targetStageId: vars.targetStageId,
+        stageName: targetStage?.name ?? 'stage',
+        failures,
+      });
+    },
+  });
+
   // ── Drag and drop handlers ────────────────────────────────
 
   const handleDragStart = (recordId: string) => {
@@ -325,54 +330,23 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     setDragOverStageId(null);
   };
 
-  const performMoveStage = async (
-    recordId: string,
-    targetStageId: string,
-  ): Promise<boolean> => {
-    if (!sessionToken) return false;
-
-    try {
-      const response = await api.request(
-        `/api/v1/objects/${apiName}/records/${recordId}/move-stage`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ target_stage_id: targetStageId }),
-        },
-      );
-
-      if (response.ok) {
-        const updated = (await response.json()) as MoveStageResponse;
-        patchRecord(recordId, {
-          pipelineId: updated.pipelineId,
-          currentStageId: updated.currentStageId,
-          stageEnteredAt: updated.stageEnteredAt,
-          fieldValues: updated.fieldValues,
-        });
-        // Refresh analytics after stage change
-        void loadAnalytics();
+  const performMoveStage = useCallback(
+    async (recordId: string, targetStageId: string): Promise<boolean> => {
+      if (!sessionToken) return false;
+      try {
+        await moveStage.mutateAsync(
+          { recordId, targetStageId },
+          { onSuccess: () => void loadAnalytics() },
+        );
         return true;
-      }
-
-      if (response.status === 422) {
-        const gateError = (await response.json()) as GateFailureResponse;
-        const targetStage = pipeline?.stages.find((s) => s.id === targetStageId);
-        setGateModal({
-          recordId,
-          targetStageId,
-          stageName: targetStage?.name ?? 'stage',
-          failures: gateError.failures,
-        });
+      } catch {
+        // `onError` in the hook rolls back the cache and — for 422 — opens
+        // the gate modal.  Other failures fall through silently.
         return false;
       }
-
-      return false;
-    } catch {
-      return false;
-    }
-  };
+    },
+    [sessionToken, moveStage, loadAnalytics],
+  );
 
   const handleDrop = (e: React.DragEvent, targetStageId: string) => {
     e.preventDefault();
@@ -457,10 +431,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
       }
 
       // Update local record field values
-      const existing = allRecords.find((r) => r.id === gateModal.recordId);
-      patchRecord(gateModal.recordId, {
-        fieldValues: { ...(existing?.fieldValues ?? {}), ...fieldValues },
-      });
+      patchRecordFields(gateModal.recordId, fieldValues);
 
       // Now retry the move
       const success = await performMoveStage(

--- a/apps/web/src/features/pipelines/hooks/mutations/useMoveStage.ts
+++ b/apps/web/src/features/pipelines/hooks/mutations/useMoveStage.ts
@@ -1,0 +1,182 @@
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { ApiError, useApiClient } from '../../../../lib/apiClient.js';
+import {
+  pipelinesKeys,
+  recordsKeys,
+  type ListParams,
+  type ObjectApiName,
+  type PipelineId,
+  type RecordId,
+} from '../../../../lib/queryKeys.js';
+import type {
+  RecordItem,
+  RecordsResponse,
+} from '../../../records/hooks/queries/useRecords.js';
+import type { GateFailure } from '../../../../components/GateFailureModal.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MoveStageResponse {
+  id: string;
+  pipelineId: string;
+  currentStageId: string;
+  stageEnteredAt: string;
+  fieldValues: Record<string, unknown>;
+}
+
+export interface MoveStageVariables {
+  recordId: RecordId;
+  targetStageId: string;
+}
+
+/** Server payload returned on a 422 gate-validation failure. */
+interface GateFailureBody {
+  error?: string;
+  code?: string;
+  failures?: GateFailure[];
+}
+
+interface MoveStageContext {
+  previousRecords: RecordsResponse | undefined;
+}
+
+export interface UseMoveStageOptions {
+  apiName: ObjectApiName;
+  /**
+   * Filters/pagination used by the records list this hook mutates. Must match
+   * the params passed to the corresponding `useRecords` call so the optimistic
+   * update targets the right cache entry.
+   */
+  listParams?: ListParams;
+  /**
+   * Pipeline id whose analytics key should be invalidated on settle.  When
+   * absent, analytics invalidation is skipped — callers that haven't resolved
+   * a pipeline id yet shouldn't trigger spurious refetches.
+   */
+  pipelineId?: PipelineId;
+  /**
+   * Called when the server rejects the move with a 422 gate-validation error.
+   * Receives the parsed `failures` array so the caller can open its gate
+   * modal.  The optimistic update has already been rolled back by the time
+   * this fires.
+   */
+  onGateFailure?: (failures: GateFailure[], vars: MoveStageVariables) => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function extractGateFailures(error: unknown): GateFailure[] | null {
+  if (!(error instanceof ApiError) || error.status !== 422) return null;
+  const body = error.body as GateFailureBody | undefined;
+  if (!body || !Array.isArray(body.failures)) return null;
+  return body.failures;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Move a record to a new pipeline stage with optimistic UI and 422 rollback.
+ *
+ * Flow:
+ *   1. `onMutate` snapshots the records list and optimistically patches
+ *      `currentStageId` + `stageEnteredAt` on the affected record so the card
+ *      visibly jumps to the target column before the network round-trip.
+ *   2. `onError` restores the snapshot.  When the error is a 422 gate-
+ *      validation failure the parsed `failures` are forwarded to
+ *      `onGateFailure` so the caller can open its modal.
+ *   3. `onSuccess` merges the authoritative response (including server-
+ *      computed `fieldValues` like `probability`) back into the cache.
+ *   4. `onSettled` invalidates the pipeline analytics key so summary /
+ *      velocity / overdue panels pick up the new stage distribution.
+ */
+export function useMoveStage(
+  options: UseMoveStageOptions,
+): UseMutationResult<
+  MoveStageResponse,
+  ApiError,
+  MoveStageVariables,
+  MoveStageContext
+> {
+  const api = useApiClient();
+  const queryClient = useQueryClient();
+  const { apiName, listParams, pipelineId, onGateFailure } = options;
+  const recordsListKey = recordsKeys.list(apiName, listParams);
+
+  return useMutation<
+    MoveStageResponse,
+    ApiError,
+    MoveStageVariables,
+    MoveStageContext
+  >({
+    mutationFn: ({ recordId, targetStageId }) =>
+      api.post<MoveStageResponse>(
+        `/api/v1/objects/${apiName}/records/${recordId}/move-stage`,
+        { body: { target_stage_id: targetStageId } },
+      ),
+
+    onMutate: async ({ recordId, targetStageId }) => {
+      // Cancel in-flight refetches so they don't overwrite the optimistic patch.
+      await queryClient.cancelQueries({ queryKey: recordsListKey });
+
+      const previousRecords =
+        queryClient.getQueryData<RecordsResponse>(recordsListKey);
+      const now = new Date().toISOString();
+
+      queryClient.setQueryData<RecordsResponse>(recordsListKey, (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          data: prev.data.map((r: RecordItem) =>
+            r.id === recordId
+              ? { ...r, currentStageId: targetStageId, stageEnteredAt: now }
+              : r,
+          ),
+        };
+      });
+
+      return { previousRecords };
+    },
+
+    onError: (error, vars, context) => {
+      if (context?.previousRecords !== undefined) {
+        queryClient.setQueryData(recordsListKey, context.previousRecords);
+      }
+      const failures = extractGateFailures(error);
+      if (failures && onGateFailure) {
+        onGateFailure(failures, vars);
+      }
+    },
+
+    onSuccess: (data) => {
+      queryClient.setQueryData<RecordsResponse>(recordsListKey, (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          data: prev.data.map((r: RecordItem) =>
+            r.id === data.id
+              ? {
+                  ...r,
+                  pipelineId: data.pipelineId,
+                  currentStageId: data.currentStageId,
+                  stageEnteredAt: data.stageEnteredAt,
+                  fieldValues: data.fieldValues,
+                }
+              : r,
+          ),
+        };
+      });
+    },
+
+    onSettled: () => {
+      if (pipelineId) {
+        void queryClient.invalidateQueries({
+          queryKey: pipelinesKeys.analytics(pipelineId),
+        });
+      }
+    },
+  });
+}

--- a/apps/web/src/features/pipelines/hooks/mutations/useMoveStage.ts
+++ b/apps/web/src/features/pipelines/hooks/mutations/useMoveStage.ts
@@ -31,6 +31,13 @@ export interface MoveStageResponse {
 export interface MoveStageVariables {
   recordId: RecordId;
   targetStageId: string;
+  /**
+   * API name (or name) of the target stage.  When supplied and the record
+   * already carries a `fieldValues.stage` field, the optimistic patch rewrites
+   * it so `KanbanBoard`'s column resolver — which prefers `fieldValues.stage`
+   * over `currentStageId` — visibly moves the card before the round-trip.
+   */
+  targetStageApiName?: string;
 }
 
 /** Server payload returned on a 422 gate-validation failure. */
@@ -40,18 +47,30 @@ interface GateFailureBody {
   failures?: GateFailure[];
 }
 
+/**
+ * Snapshot of the single record being mutated. Rolling back at the record
+ * level — rather than replacing the whole list with a pre-mutate copy — keeps
+ * concurrent successful moves on *other* records intact when this one fails.
+ */
 interface MoveStageContext {
-  previousRecords: RecordsResponse | undefined;
+  previous:
+    | {
+        currentStageId: string | undefined;
+        stageEnteredAt: string | undefined;
+        fieldValues: Record<string, unknown> | undefined;
+      }
+    | null;
 }
 
 export interface UseMoveStageOptions {
   apiName: ObjectApiName;
   /**
-   * Filters/pagination used by the records list this hook mutates. Must match
-   * the params passed to the corresponding `useRecords` call so the optimistic
-   * update targets the right cache entry.
+   * Filters/pagination used by the records list this hook mutates. Required:
+   * the optimistic patch + rollback target exactly `recordsKeys.list(apiName,
+   * listParams)`, so callers must pass the same params they gave `useRecords`
+   * or the update will silently miss the cache entry.
    */
-  listParams?: ListParams;
+  listParams: ListParams;
   /**
    * Pipeline id whose analytics key should be invalidated on settle.  When
    * absent, analytics invalidation is skipped — callers that haven't resolved
@@ -76,18 +95,40 @@ function extractGateFailures(error: unknown): GateFailure[] | null {
   return body.failures;
 }
 
+/**
+ * Replace a single record in the cached list via `queryClient.setQueryData`.
+ * Leaves every other record untouched so concurrent mutations on siblings
+ * aren't clobbered.
+ */
+function patchOneRecord(
+  queryClient: ReturnType<typeof useQueryClient>,
+  key: readonly unknown[],
+  recordId: RecordId,
+  apply: (record: RecordItem) => RecordItem,
+): void {
+  queryClient.setQueryData<RecordsResponse>(key, (prev) => {
+    if (!prev) return prev;
+    return {
+      ...prev,
+      data: prev.data.map((r) => (r.id === recordId ? apply(r) : r)),
+    };
+  });
+}
+
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 /**
  * Move a record to a new pipeline stage with optimistic UI and 422 rollback.
  *
  * Flow:
- *   1. `onMutate` snapshots the records list and optimistically patches
- *      `currentStageId` + `stageEnteredAt` on the affected record so the card
- *      visibly jumps to the target column before the network round-trip.
- *   2. `onError` restores the snapshot.  When the error is a 422 gate-
- *      validation failure the parsed `failures` are forwarded to
- *      `onGateFailure` so the caller can open its modal.
+ *   1. `onMutate` snapshots the affected record's prior stage fields and
+ *      optimistically patches `currentStageId`, `stageEnteredAt`, and — when
+ *      the record has one — `fieldValues.stage`, so the card visibly jumps to
+ *      the target column before the network round-trip.
+ *   2. `onError` restores just that record's pre-mutate fields — not the
+ *      whole list — so concurrent successful moves on siblings aren't
+ *      clobbered. When the error is a 422 gate-validation failure the parsed
+ *      `failures` are forwarded to `onGateFailure`.
  *   3. `onSuccess` merges the authoritative response (including server-
  *      computed `fieldValues` like `probability`) back into the cache.
  *   4. `onSettled` invalidates the pipeline analytics key so summary /
@@ -118,32 +159,50 @@ export function useMoveStage(
         { body: { target_stage_id: targetStageId } },
       ),
 
-    onMutate: async ({ recordId, targetStageId }) => {
+    onMutate: async ({ recordId, targetStageId, targetStageApiName }) => {
       // Cancel in-flight refetches so they don't overwrite the optimistic patch.
       await queryClient.cancelQueries({ queryKey: recordsListKey });
 
-      const previousRecords =
+      const currentList =
         queryClient.getQueryData<RecordsResponse>(recordsListKey);
-      const now = new Date().toISOString();
+      const existing = currentList?.data.find((r) => r.id === recordId);
 
-      queryClient.setQueryData<RecordsResponse>(recordsListKey, (prev) => {
-        if (!prev) return prev;
+      const previous: MoveStageContext['previous'] = existing
+        ? {
+            currentStageId: existing.currentStageId,
+            stageEnteredAt: existing.stageEnteredAt,
+            fieldValues: existing.fieldValues,
+          }
+        : null;
+
+      const now = new Date().toISOString();
+      patchOneRecord(queryClient, recordsListKey, recordId, (r) => {
+        const hasStageField =
+          r.fieldValues && typeof r.fieldValues.stage === 'string';
+        const fieldValues =
+          hasStageField && targetStageApiName
+            ? { ...r.fieldValues, stage: targetStageApiName }
+            : r.fieldValues;
         return {
-          ...prev,
-          data: prev.data.map((r: RecordItem) =>
-            r.id === recordId
-              ? { ...r, currentStageId: targetStageId, stageEnteredAt: now }
-              : r,
-          ),
+          ...r,
+          currentStageId: targetStageId,
+          stageEnteredAt: now,
+          fieldValues,
         };
       });
 
-      return { previousRecords };
+      return { previous };
     },
 
     onError: (error, vars, context) => {
-      if (context?.previousRecords !== undefined) {
-        queryClient.setQueryData(recordsListKey, context.previousRecords);
+      if (context?.previous) {
+        const { previous } = context;
+        patchOneRecord(queryClient, recordsListKey, vars.recordId, (r) => ({
+          ...r,
+          currentStageId: previous.currentStageId,
+          stageEnteredAt: previous.stageEnteredAt,
+          fieldValues: previous.fieldValues ?? {},
+        }));
       }
       const failures = extractGateFailures(error);
       if (failures && onGateFailure) {
@@ -152,23 +211,13 @@ export function useMoveStage(
     },
 
     onSuccess: (data) => {
-      queryClient.setQueryData<RecordsResponse>(recordsListKey, (prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          data: prev.data.map((r: RecordItem) =>
-            r.id === data.id
-              ? {
-                  ...r,
-                  pipelineId: data.pipelineId,
-                  currentStageId: data.currentStageId,
-                  stageEnteredAt: data.stageEnteredAt,
-                  fieldValues: data.fieldValues,
-                }
-              : r,
-          ),
-        };
-      });
+      patchOneRecord(queryClient, recordsListKey, data.id, (r) => ({
+        ...r,
+        pipelineId: data.pipelineId,
+        currentStageId: data.currentStageId,
+        stageEnteredAt: data.stageEnteredAt,
+        fieldValues: data.fieldValues,
+      }));
     },
 
     onSettled: () => {

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -97,14 +97,17 @@ export const fieldDefinitionsKeys = {
  * Keys for `/api/v1/admin/pipelines` and `/api/v1/pipelines/:id/...`.
  *
  * Hierarchy:
- *   ['pipelines']                              — invalidate everything
- *   ['pipelines', 'list']                      — the list of all pipelines
- *   ['pipelines', 'detail', pipelineId]        — one pipeline's full payload
+ *   ['pipelines']                                    — invalidate everything
+ *   ['pipelines', 'list']                            — the list of all pipelines
+ *   ['pipelines', 'detail', pipelineId]              — one pipeline's full payload
+ *   ['pipelines', 'analytics', pipelineId]           — every analytics query (summary/velocity/overdue)
  */
 export const pipelinesKeys = {
   all: () => ['pipelines'] as const,
   list: () => ['pipelines', 'list'] as const,
   detail: (pipelineId: PipelineId) => ['pipelines', 'detail', pipelineId] as const,
+  analytics: (pipelineId: PipelineId) =>
+    ['pipelines', 'analytics', pipelineId] as const,
 } as const;
 
 // ─── Page layouts ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- New `useMoveStage` TanStack Query mutation (`apps/web/src/features/pipelines/hooks/mutations/useMoveStage.ts`): `onMutate` snapshots + optimistically patches the records cache, `onError` rolls back and forwards 422 `failures` to a caller-supplied `onGateFailure`, `onSuccess` merges the authoritative `MoveStageResponse` (incl. `fieldValues`) into the cache, `onSettled` invalidates the pipeline analytics key.
- `KanbanBoard.tsx` drops its inline `performMoveStage` and consumes the hook; the remaining cache-patch helper only covers the fill-and-move field PUT.
- `queryKeys.ts` gains `pipelinesKeys.analytics(pipelineId)` so future analytics queries can be invalidated cleanly.

Closes #474

## Test plan
- [x] `npm run typecheck` in `apps/web` — clean
- [x] `npm run lint` in `apps/web` — only pre-existing warnings
- [x] `npm test` in `apps/web` — 647/647 pass
- [x] New `KanbanBoard.test.tsx` cases cover optimistic drop (card renders in target column while POST is pending) and 422 rollback (card returns to origin column when gate fails)
- [ ] Manual smoke: drag a card between open stages and verify the move is instant; force a gate failure and verify the card snaps back + the gate modal opens

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm