### PR TITLE
fix(web): place Kanban cards by currentStageId, not fieldValues.stage

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -878,33 +878,20 @@ describe('KanbanBoard', () => {
       limit: 100,
     };
 
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockImplementation((url: string) => {
-        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
-          return Promise.resolve({ ok: true, json: async () => mockPipeline } as Response);
-        }
-        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
-          return Promise.resolve({
-            ok: true,
-            json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
-          } as Response);
-        }
-        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
-          return Promise.resolve({ ok: true, json: async () => mismatchedRecords } as Response);
-        }
-        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
-          return Promise.resolve({ ok: true, json: async () => mockSummary } as Response);
-        }
-        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
-          return Promise.resolve({ ok: true, json: async () => mockVelocity } as Response);
-        }
-        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
-          return Promise.resolve({ ok: true, json: async () => [] } as Response);
-        }
-        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
-      }),
-    );
+    // Override only the records endpoint; everything else (pipelines,
+    // summary, velocity, overdue) keeps the default mock so future endpoint
+    // changes stay in one place.
+    const fetchMock = mockFetch();
+    const defaultImpl = fetchMock.getMockImplementation();
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+        return Promise.resolve({ ok: true, json: async () => mismatchedRecords } as Response);
+      }
+      return (
+        defaultImpl?.(url, options) ??
+        Promise.resolve({ ok: false, json: async () => ({}) } as Response)
+      );
+    });
 
     renderBoard();
 

--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -854,6 +854,71 @@ describe('KanbanBoard', () => {
     expect(prospectingColumn).toHaveTextContent('Lowercase Stage');
   });
 
+  it('places records by currentStageId when it disagrees with fieldValues.stage', async () => {
+    // Regression: the server treats `records.current_stage_id` as the source
+    // of truth and rejects move-stage requests whose target matches it with
+    // 400 "already in this stage". If the UI placed a card by a stale
+    // `fieldValues.stage` (left over from a previous move or a manual edit),
+    // dragging the card to its actual DB column would fire a doomed request.
+    const mismatchedRecords = {
+      data: [
+        {
+          id: 'rec-mismatch',
+          name: 'Mismatched Deal',
+          fieldValues: { value: 42000, stage: 'Prospecting' },
+          ownerId: 'user-1',
+          pipelineId: 'pipe-1',
+          currentStageId: 'stage-2',
+          stageEnteredAt: '2026-04-01T00:00:00Z',
+          createdAt: '2026-03-20T00:00:00Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 100,
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-1')) {
+          return Promise.resolve({ ok: true, json: async () => mockPipeline } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => paginated([{ ...mockPipeline, object_id: 'obj-1' }]),
+          } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+          return Promise.resolve({ ok: true, json: async () => mismatchedRecords } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/summary')) {
+          return Promise.resolve({ ok: true, json: async () => mockSummary } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/velocity')) {
+          return Promise.resolve({ ok: true, json: async () => mockVelocity } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-1/overdue')) {
+          return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+      }),
+    );
+
+    renderBoard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Mismatched Deal')).toBeInTheDocument();
+    });
+
+    const qualColumn = screen.getByTestId('kanban-column-qualification');
+    expect(qualColumn).toHaveTextContent('Mismatched Deal');
+
+    const prospectingColumn = screen.getByTestId('kanban-column-prospecting');
+    expect(prospectingColumn).not.toHaveTextContent('Mismatched Deal');
+  });
+
   it('renders the summary toggle button', async () => {
     mockFetch();
     renderBoard();

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -364,7 +364,11 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     if (!record) return;
 
     // Compute effective current stage using the same resolution logic as
-    // the column placement so that dropping onto the same column is a no-op
+    // the column placement. Priority mirrors the server's source of truth
+    // (records.current_stage_id) so dropping a card onto the column it's
+    // actually in doesn't fire a request the server rejects as 400 "already
+    // in this stage" — which happens when a stale fieldValues.stage shows
+    // the card in a different column than current_stage_id points at.
     const sortedStages = pipeline.stages.slice().sort((a, b) => a.sortOrder - b.sortOrder);
     const localStageIds = new Set(sortedStages.map((s) => s.id));
     const localStageByName = new Map<string, string>();
@@ -374,14 +378,15 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     }
 
     let effectiveCurrentStageId: string | undefined;
-    // Match fieldValues.stage first (same priority as column placement)
-    const dropFv = record.fieldValues ?? {};
-    const stageField = dropFv.stage;
-    if (typeof stageField === 'string' && stageField.trim()) {
-      effectiveCurrentStageId = localStageByName.get(stageField.trim().toLowerCase());
-    }
-    if (!effectiveCurrentStageId && record.currentStageId && localStageIds.has(record.currentStageId)) {
+    if (record.currentStageId && localStageIds.has(record.currentStageId)) {
       effectiveCurrentStageId = record.currentStageId;
+    }
+    if (!effectiveCurrentStageId) {
+      const dropFv = record.fieldValues ?? {};
+      const stageField = dropFv.stage;
+      if (typeof stageField === 'string' && stageField.trim()) {
+        effectiveCurrentStageId = localStageByName.get(stageField.trim().toLowerCase());
+      }
     }
     if (!effectiveCurrentStageId) {
       effectiveCurrentStageId = sortedStages.find((s) => s.stageType === 'open')?.id;
@@ -471,15 +476,24 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
   /**
    * Resolve which pipeline stage a record belongs to.
    *
-   * Priority:
-   *   1. fieldValues.stage matches a stage name or api_name → use that stage
-   *      (this keeps the pipeline view in sync with the stage dropdown shown
-   *       in the list view)
-   *   2. currentStageId matches a known stage in this pipeline → use it
-   *   3. Fall back to the first open stage
+   * Priority matches the server's source of truth so visual placement and
+   * move-stage requests agree:
+   *   1. `currentStageId` matches a known stage in this pipeline → use it.
+   *      The server stores this in `records.current_stage_id` and rejects
+   *      no-op moves based on it — if we placed the card by a stale
+   *      `fieldValues.stage` and the user dragged to the DB's actual
+   *      current column, the server would return 400 "already in this stage".
+   *   2. `fieldValues.stage` matches a stage name / api_name (for records
+   *      without an assigned stage id yet — e.g. freshly imported rows).
+   *   3. Fall back to the first open stage.
    */
   function resolveStageForRecord(record: RecordItem): StageDefinition | null {
-    // 1. Match fieldValues.stage against stage names / api_names
+    // 1. Explicit pipeline assignment — authoritative.
+    if (record.currentStageId && stageIds.has(record.currentStageId)) {
+      return stages.find((s) => s.id === record.currentStageId) ?? null;
+    }
+
+    // 2. Legacy fallback: match fieldValues.stage against stage names / api_names.
     const fv = record.fieldValues ?? {};
     const stageFieldValue = fv.stage;
     if (typeof stageFieldValue === 'string' && stageFieldValue.trim()) {
@@ -487,12 +501,7 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
       if (matched) return matched;
     }
 
-    // 2. Explicit pipeline assignment
-    if (record.currentStageId && stageIds.has(record.currentStageId)) {
-      return stages.find((s) => s.id === record.currentStageId) ?? null;
-    }
-
-    // 3. Fall back to the first open stage
+    // 3. Fall back to the first open stage.
     return firstOpenStage ?? null;
   }
 

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -363,35 +363,12 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     const record = allRecords.find((r) => r.id === recordId);
     if (!record) return;
 
-    // Compute effective current stage using the same resolution logic as
-    // the column placement. Priority mirrors the server's source of truth
-    // (records.current_stage_id) so dropping a card onto the column it's
-    // actually in doesn't fire a request the server rejects as 400 "already
-    // in this stage" — which happens when a stale fieldValues.stage shows
-    // the card in a different column than current_stage_id points at.
-    const sortedStages = pipeline.stages.slice().sort((a, b) => a.sortOrder - b.sortOrder);
-    const localStageIds = new Set(sortedStages.map((s) => s.id));
-    const localStageByName = new Map<string, string>();
-    for (const s of sortedStages) {
-      localStageByName.set(s.name.toLowerCase(), s.id);
-      localStageByName.set(s.apiName.toLowerCase(), s.id);
-    }
-
-    let effectiveCurrentStageId: string | undefined;
-    if (record.currentStageId && localStageIds.has(record.currentStageId)) {
-      effectiveCurrentStageId = record.currentStageId;
-    }
-    if (!effectiveCurrentStageId) {
-      const dropFv = record.fieldValues ?? {};
-      const stageField = dropFv.stage;
-      if (typeof stageField === 'string' && stageField.trim()) {
-        effectiveCurrentStageId = localStageByName.get(stageField.trim().toLowerCase());
-      }
-    }
-    if (!effectiveCurrentStageId) {
-      effectiveCurrentStageId = sortedStages.find((s) => s.stageType === 'open')?.id;
-    }
-
+    // Share column-placement logic so the drop no-op check can't drift from
+    // where the card is actually rendered. `resolveStageForRecord` mirrors the
+    // server's source of truth (records.current_stage_id), keeping us clear of
+    // the 400 "already in this stage" case a stale fieldValues.stage could
+    // otherwise trigger.
+    const effectiveCurrentStageId = resolveStageForRecord(record)?.id;
     if (effectiveCurrentStageId === targetStageId) return;
 
     const targetStage = pipeline.stages.find((s) => s.id === targetStageId);


### PR DESCRIPTION
## Summary

- Fixes the production `400 Bad Request` when dragging Kanban cards between stages.
- The server treats `records.current_stage_id` as the source of truth and rejects move-stage requests whose target matches it with `400 "already in this stage"`. The UI placed cards by `fieldValues.stage` first, so a stale stage field (left over from a previous move or a manual edit) put the card in one column visually while the DB said it was in another — dragging to the DB's actual column then fired a doomed request.
- Flips the priority in both `resolveStageForRecord` and `handleDrop`'s `effectiveCurrentStageId` so `currentStageId` wins over `fieldValues.stage`. The field-value fallback still handles legacy rows without a stage id.

## Test plan

- [x] Added a regression test covering the mismatch case (record with `currentStageId = 'stage-2'` and `fieldValues.stage = 'Prospecting'` renders in the Qualification column, not Prospecting).
- [x] `npm run typecheck` — clean.
- [x] `npx vitest run` — 648/648 passing.
- [ ] Manual smoke test: drag a card that was previously "stuck" between columns and confirm the move succeeds.

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm