### PR TITLE
fix(web): hide Kanban records that belong to a different pipeline

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -906,6 +906,62 @@ describe('KanbanBoard', () => {
     expect(prospectingColumn).not.toHaveTextContent('Mismatched Deal');
   });
 
+  it('hides records that belong to a different pipeline', async () => {
+    // Regression: the records endpoint returns every record for the object
+    // regardless of pipeline. If a row's `pipelineId` points at a sibling
+    // pipeline, rendering it via `fieldValues.stage` fallback lets the user
+    // drag it — and the resulting move-stage fires cross-pipeline and the
+    // server rejects with 400 "Target stage does not belong to the same
+    // pipeline". Such rows should be hidden entirely.
+    const mixedPipelineRecords = {
+      data: [
+        {
+          id: 'rec-this-pipeline',
+          name: 'In This Pipeline',
+          fieldValues: { value: 10000 },
+          ownerId: 'user-1',
+          pipelineId: 'pipe-1',
+          currentStageId: 'stage-1',
+          stageEnteredAt: '2026-04-01T00:00:00Z',
+          createdAt: '2026-03-01T00:00:00Z',
+        },
+        {
+          id: 'rec-other-pipeline',
+          name: 'In Other Pipeline',
+          fieldValues: { value: 20000, stage: 'Qualification' },
+          ownerId: 'user-2',
+          pipelineId: 'pipe-2',
+          currentStageId: 'stage-x',
+          stageEnteredAt: '2026-04-01T00:00:00Z',
+          createdAt: '2026-03-01T00:00:00Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      limit: 100,
+    };
+
+    const fetchMock = mockFetch();
+    const defaultImpl = fetchMock.getMockImplementation();
+    fetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+        return Promise.resolve({ ok: true, json: async () => mixedPipelineRecords } as Response);
+      }
+      return (
+        defaultImpl?.(url, options) ??
+        Promise.resolve({ ok: false, json: async () => ({}) } as Response)
+      );
+    });
+
+    renderBoard();
+
+    await waitFor(() => {
+      expect(screen.getByText('In This Pipeline')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('In Other Pipeline')).not.toBeInTheDocument();
+  });
+
   it('renders the summary toggle button', async () => {
     mockFetch();
     renderBoard();

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -211,10 +211,21 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
   const recordsQuery = useRecords(apiName, RECORDS_QUERY_PARAMS);
 
   const pipeline = pipelineDetailQuery.data ?? null;
-  const allRecords = useMemo<RecordItem[]>(
-    () => recordsQuery.data?.data ?? [],
-    [recordsQuery.data],
-  );
+  const allRecords = useMemo<RecordItem[]>(() => {
+    const rows = recordsQuery.data?.data ?? [];
+    // The records endpoint lists every record for the object regardless of
+    // pipeline; when a tenant has more than one pipeline for the same object,
+    // rows belonging to a sibling pipeline would otherwise render here via
+    // the `fieldValues.stage` fallback and any drop would fire a cross-
+    // pipeline move-stage that the server rejects with 400 "Target stage
+    // does not belong to the same pipeline". Keep rows whose `pipelineId`
+    // matches the board's pipeline, or is unset (server will auto-assign
+    // the default pipeline on first move).
+    if (!matchedPipelineId) return rows;
+    return rows.filter(
+      (r) => !r.pipelineId || r.pipelineId === matchedPipelineId,
+    );
+  }, [recordsQuery.data, matchedPipelineId]);
 
   const loading =
     pipelineListQuery.isLoading ||


### PR DESCRIPTION
## Summary

- Fixes the production `400 "Target stage does not belong to the same pipeline"` on Kanban drag-drop.
- The records endpoint lists every record for an object regardless of pipeline. When a tenant has more than one pipeline for the same object, rows belonging to a sibling pipeline were rendered on the current Kanban via the `fieldValues.stage` fallback. Dragging such a card fired a move-stage POST whose target stage lived in a different pipeline than the record's `pipeline_id` — the server correctly rejects this with 400.
- Filters `allRecords` by `pipelineId` so only records belonging to the board's pipeline — or records with no pipeline yet (the server auto-assigns the default on first move) — are rendered.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npx vitest run` — 649/649 passing.
- [x] New regression test: `hides records that belong to a different pipeline`.
- [ ] Manual smoke test in production after deploy: the ghost `MCA to CSP` card should no longer appear in the opportunity Kanban if it lives in a different pipeline; other records should drag without the 400.

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm