### PR TITLE
fix(web): prefer default pipeline when object has multiple

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -962,6 +962,81 @@ describe('KanbanBoard', () => {
     expect(screen.queryByText('In Other Pipeline')).not.toBeInTheDocument();
   });
 
+  it('prefers the default pipeline when multiple exist for the object', async () => {
+    // When a tenant has more than one pipeline for the same object, the
+    // server's `assignDefaultPipeline` routes records without a
+    // `pipeline_id` to the pipeline flagged `is_default`. The Kanban must
+    // render that same pipeline, otherwise target stages would live in the
+    // non-default pipeline and the server would reject moves with 400
+    // "Target stage does not belong to the same pipeline".
+    const defaultPipeline = {
+      ...mockPipeline,
+      id: 'pipe-default',
+      name: 'Default Pipeline',
+      isDefault: true,
+    };
+    const nonDefaultPipeline = {
+      id: 'pipe-other',
+      name: 'Other Pipeline',
+      objectId: 'obj-1',
+      isDefault: false,
+      stages: [
+        {
+          id: 'stage-other-1',
+          name: 'Other Stage',
+          apiName: 'other_stage',
+          sortOrder: 0,
+          stageType: 'open',
+          colour: 'grey',
+          defaultProbability: 0,
+        },
+      ],
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-default')) {
+          return Promise.resolve({ ok: true, json: async () => defaultPipeline } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () =>
+              paginated([
+                // Non-default comes first so the test fails if the Kanban
+                // naively picks the first match rather than the default.
+                { ...nonDefaultPipeline, object_id: 'obj-1' },
+                { ...defaultPipeline, object_id: 'obj-1' },
+              ]),
+          } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+          return Promise.resolve({ ok: true, json: async () => mockRecords } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-default/summary')) {
+          return Promise.resolve({ ok: true, json: async () => mockSummary } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-default/velocity')) {
+          return Promise.resolve({ ok: true, json: async () => mockVelocity } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/pipelines/pipe-default/overdue')) {
+          return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+      }),
+    );
+
+    renderBoard();
+
+    // Default pipeline's Prospecting column should render, not the other
+    // pipeline's single "Other Stage" column.
+    await waitFor(() => {
+      expect(screen.getByTestId('kanban-column-prospecting')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('kanban-column-other_stage')).not.toBeInTheDocument();
+  });
+
   it('renders the summary toggle button', async () => {
     mockFetch();
     renderBoard();

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -195,7 +195,12 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     queryFn: async () => {
       const payload = await api.get<unknown>('/api/v1/admin/pipelines');
       return unwrapList<
-        PipelineDefinition & { objectId?: string; object_id?: string }
+        PipelineDefinition & {
+          objectId?: string;
+          object_id?: string;
+          isDefault?: boolean;
+          is_default?: boolean;
+        }
       >(payload);
     },
     enabled: Boolean(sessionToken),
@@ -204,7 +209,19 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
   const matchedPipelineId = useMemo(() => {
     const list = pipelineListQuery.data;
     if (!list) return undefined;
-    return list.find((p) => (p.objectId ?? p.object_id) === objectId)?.id;
+    const forObject = list.filter(
+      (p) => (p.objectId ?? p.object_id) === objectId,
+    );
+    if (forObject.length === 0) return undefined;
+    // Prefer the default pipeline so the Kanban matches the one the server
+    // auto-assigns via `assignDefaultPipeline`. Without this, a tenant with
+    // multiple pipelines could render the non-default one, and records that
+    // arrive without a `pipeline_id` would be auto-assigned to the default
+    // at move-stage time — making every target stage cross-pipeline and
+    // producing 400 "Target stage does not belong to the same pipeline".
+    const preferred =
+      forObject.find((p) => p.isDefault ?? p.is_default) ?? forObject[0];
+    return preferred.id;
   }, [pipelineListQuery.data, objectId]);
 
   const pipelineDetailQuery = usePipeline(matchedPipelineId);

--- a/apps/web/src/components/StageFieldRenderer.tsx
+++ b/apps/web/src/components/StageFieldRenderer.tsx
@@ -155,15 +155,24 @@ export function StageFieldRenderer({
       // loading a sibling pipeline for the same object.
       if (pipelineId) return pipelineId;
 
-      // Fall back to the first pipeline matching this object (create forms).
+      // Fall back to the default pipeline for this object, matching the
+      // server's auto-assignment behaviour.  Falls back to the first match
+      // when no pipeline is marked default.
       const response = await api.request('/api/v1/admin/pipelines');
       if (!response.ok) return null;
       const pipelines = unwrapList<
-        PipelineDefinition & { objectId?: string; object_id?: string }
+        PipelineDefinition & {
+          objectId?: string;
+          object_id?: string;
+          isDefault?: boolean;
+          is_default?: boolean;
+        }
       >(await response.json());
-      const match = pipelines.find(
+      const forObject = pipelines.filter(
         (p) => (p.objectId ?? p.object_id) === objectId,
       );
+      const match =
+        forObject.find((p) => p.isDefault ?? p.is_default) ?? forObject[0];
       return match?.id ?? null;
     };
 


### PR DESCRIPTION
## Summary
- Kanban board and StageFieldRenderer both resolved an object's pipeline by picking the first match, while the server auto-assigns records to the pipeline flagged `is_default`. When a tenant has multiple pipelines for the same object, this divergence caused move-stage to fail with `Target stage does not belong to the same pipeline` on both the board drag-drop and the detail-page Stage dropdown.
- Align the client fallback with the server: prefer `is_default: true`, fall back to the first match only when no pipeline is flagged.
- New Kanban test covers the multi-pipeline case.

## Test plan
- [x] `vitest run` (650 tests pass)
- [x] `tsc --noEmit`
- [ ] Verify drag-drop on a tenant with multiple pipelines for one object
- [ ] Verify detail-page Stage dropdown on the same tenant

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm