### PR TITLE
feat(web): add pipeline picker to Kanban board

### DIFF
--- a/apps/web/src/__tests__/KanbanBoard.test.tsx
+++ b/apps/web/src/__tests__/KanbanBoard.test.tsx
@@ -27,6 +27,7 @@ const mockPipeline = {
   id: 'pipe-1',
   name: 'Sales Pipeline',
   objectId: 'obj-1',
+  is_default: true,
   stages: [
     {
       id: 'stage-1',
@@ -1035,6 +1036,118 @@ describe('KanbanBoard', () => {
       expect(screen.getByTestId('kanban-column-prospecting')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('kanban-column-other_stage')).not.toBeInTheDocument();
+  });
+
+  it('shows a pipeline picker and switches boards when multiple pipelines exist', async () => {
+    // Two pipelines for the same object — the picker should let the user
+    // switch boards without the page reloading. Selecting the non-default
+    // pipeline swaps the columns and the records shown to those belonging
+    // to the newly-selected pipeline.
+    const defaultPipeline = {
+      ...mockPipeline,
+      id: 'pipe-default',
+      name: 'Default Pipeline',
+      isDefault: true,
+      is_default: true,
+    };
+    const otherPipeline = {
+      id: 'pipe-other',
+      name: 'Other Pipeline',
+      objectId: 'obj-1',
+      isDefault: false,
+      is_default: false,
+      stages: [
+        {
+          id: 'stage-other-1',
+          name: 'Other Stage',
+          apiName: 'other_stage',
+          sortOrder: 0,
+          stageType: 'open',
+          colour: 'grey',
+          defaultProbability: 0,
+        },
+      ],
+    };
+    const multiPipelineRecords = {
+      data: [
+        {
+          id: 'rec-default',
+          name: 'Default Deal',
+          fieldValues: {},
+          ownerId: 'user-1',
+          pipelineId: 'pipe-default',
+          currentStageId: 'stage-1',
+          createdAt: '2026-03-01T00:00:00Z',
+        },
+        {
+          id: 'rec-other',
+          name: 'Other Deal',
+          fieldValues: {},
+          ownerId: 'user-1',
+          pipelineId: 'pipe-other',
+          currentStageId: 'stage-other-1',
+          createdAt: '2026-03-02T00:00:00Z',
+        },
+      ],
+      total: 2,
+      page: 1,
+      limit: 100,
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-default')) {
+          return Promise.resolve({ ok: true, json: async () => defaultPipeline } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines/pipe-other')) {
+          return Promise.resolve({ ok: true, json: async () => otherPipeline } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () =>
+              paginated([
+                { ...defaultPipeline, object_id: 'obj-1' },
+                { ...otherPipeline, object_id: 'obj-1' },
+              ]),
+          } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/api/v1/objects/opportunity/records')) {
+          return Promise.resolve({ ok: true, json: async () => multiPipelineRecords } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/summary')) {
+          return Promise.resolve({ ok: true, json: async () => mockSummary } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/velocity')) {
+          return Promise.resolve({ ok: true, json: async () => mockVelocity } as Response);
+        }
+        if (typeof url === 'string' && url.includes('/overdue')) {
+          return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+      }),
+    );
+
+    renderBoard();
+
+    // Default board renders first; only the default-pipeline record is visible.
+    const picker = await screen.findByTestId<HTMLSelectElement>('kanban-pipeline-picker');
+    expect(picker.value).toBe('pipe-default');
+    await waitFor(() => {
+      expect(screen.getByText('Default Deal')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Other Deal')).not.toBeInTheDocument();
+
+    // Switch to the non-default pipeline.
+    fireEvent.change(picker, { target: { value: 'pipe-other' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('kanban-column-other_stage')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('kanban-column-prospecting')).not.toBeInTheDocument();
+    expect(screen.getByText('Other Deal')).toBeInTheDocument();
+    expect(screen.queryByText('Default Deal')).not.toBeInTheDocument();
   });
 
   it('renders the summary toggle button', async () => {

--- a/apps/web/src/components/KanbanBoard.module.css
+++ b/apps/web/src/components/KanbanBoard.module.css
@@ -89,8 +89,31 @@
 .summaryHeader {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
+  gap: var(--space-3);
   margin-bottom: var(--space-2);
+}
+
+.pipelinePicker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.pipelinePicker select {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.pipelinePicker select:hover {
+  border-color: var(--color-text-muted);
 }
 
 /* ── Columns container ───────────────────────────────────── */

--- a/apps/web/src/components/KanbanBoard.tsx
+++ b/apps/web/src/components/KanbanBoard.tsx
@@ -168,6 +168,35 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     }
   });
 
+  // Selected pipeline — persisted per-object so switching objects remembers
+  // the last-viewed pipeline. `null` means "use default".
+  const pipelineStorageKey = `cpcrm-kanban-pipeline:${objectId}`;
+  const [selectedPipelineId, setSelectedPipelineIdState] = useState<
+    string | null
+  >(() => {
+    try {
+      return localStorage.getItem(pipelineStorageKey);
+    } catch {
+      return null;
+    }
+  });
+
+  const setSelectedPipelineId = useCallback(
+    (id: string | null) => {
+      setSelectedPipelineIdState(id);
+      try {
+        if (id) {
+          localStorage.setItem(pipelineStorageKey, id);
+        } else {
+          localStorage.removeItem(pipelineStorageKey);
+        }
+      } catch {
+        // localStorage unavailable
+      }
+    },
+    [pipelineStorageKey],
+  );
+
   const toggleSummary = () => {
     setSummaryCollapsed((prev) => {
       const next = !prev;
@@ -206,43 +235,60 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
     enabled: Boolean(sessionToken),
   });
 
-  const matchedPipelineId = useMemo(() => {
+  const pipelinesForObject = useMemo(() => {
     const list = pipelineListQuery.data;
-    if (!list) return undefined;
-    const forObject = list.filter(
-      (p) => (p.objectId ?? p.object_id) === objectId,
-    );
-    if (forObject.length === 0) return undefined;
-    // Prefer the default pipeline so the Kanban matches the one the server
-    // auto-assigns via `assignDefaultPipeline`. Without this, a tenant with
-    // multiple pipelines could render the non-default one, and records that
-    // arrive without a `pipeline_id` would be auto-assigned to the default
-    // at move-stage time — making every target stage cross-pipeline and
-    // producing 400 "Target stage does not belong to the same pipeline".
-    const preferred =
-      forObject.find((p) => p.isDefault ?? p.is_default) ?? forObject[0];
-    return preferred.id;
+    if (!list) return [];
+    return list.filter((p) => (p.objectId ?? p.object_id) === objectId);
   }, [pipelineListQuery.data, objectId]);
+
+  const matchedPipelineId = useMemo(() => {
+    if (pipelinesForObject.length === 0) return undefined;
+    // Honour the user's explicit choice when it still points at a valid
+    // pipeline for this object.
+    if (
+      selectedPipelineId &&
+      pipelinesForObject.some((p) => p.id === selectedPipelineId)
+    ) {
+      return selectedPipelineId;
+    }
+    // Otherwise prefer the default pipeline so the Kanban matches the one
+    // the server auto-assigns via `assignDefaultPipeline`. Without this, a
+    // tenant with multiple pipelines could render the non-default one, and
+    // records that arrive without a `pipeline_id` would be auto-assigned to
+    // the default at move-stage time — making every target stage cross-
+    // pipeline and producing 400 "Target stage does not belong to the same
+    // pipeline".
+    const preferred =
+      pipelinesForObject.find((p) => p.isDefault ?? p.is_default) ??
+      pipelinesForObject[0];
+    return preferred.id;
+  }, [pipelinesForObject, selectedPipelineId]);
 
   const pipelineDetailQuery = usePipeline(matchedPipelineId);
   const recordsQuery = useRecords(apiName, RECORDS_QUERY_PARAMS);
 
   const pipeline = pipelineDetailQuery.data ?? null;
+  const boardIsDefaultPipeline = useMemo(() => {
+    if (!matchedPipelineId) return false;
+    const match = pipelinesForObject.find((p) => p.id === matchedPipelineId);
+    return Boolean(match?.isDefault ?? match?.is_default);
+  }, [pipelinesForObject, matchedPipelineId]);
+
   const allRecords = useMemo<RecordItem[]>(() => {
     const rows = recordsQuery.data?.data ?? [];
     // The records endpoint lists every record for the object regardless of
-    // pipeline; when a tenant has more than one pipeline for the same object,
-    // rows belonging to a sibling pipeline would otherwise render here via
-    // the `fieldValues.stage` fallback and any drop would fire a cross-
-    // pipeline move-stage that the server rejects with 400 "Target stage
-    // does not belong to the same pipeline". Keep rows whose `pipelineId`
-    // matches the board's pipeline, or is unset (server will auto-assign
-    // the default pipeline on first move).
+    // pipeline. Drop rows that belong to a sibling pipeline so cards never
+    // render in a pipeline they can't actually move within — that would
+    // trigger the server's "Target stage does not belong to the same
+    // pipeline" 400.  Records without a `pipelineId` are only shown on the
+    // default pipeline, matching the server's `assignDefaultPipeline`
+    // behaviour on first move.
     if (!matchedPipelineId) return rows;
-    return rows.filter(
-      (r) => !r.pipelineId || r.pipelineId === matchedPipelineId,
-    );
-  }, [recordsQuery.data, matchedPipelineId]);
+    return rows.filter((r) => {
+      if (r.pipelineId) return r.pipelineId === matchedPipelineId;
+      return boardIsDefaultPipeline;
+    });
+  }, [recordsQuery.data, matchedPipelineId, boardIsDefaultPipeline]);
 
   const loading =
     pipelineListQuery.isLoading ||
@@ -578,8 +624,28 @@ export function KanbanBoard({ apiName, objectId }: KanbanBoardProps) {
 
   return (
     <div className={styles.board} data-testid="kanban-board">
-      {/* Summary toggle */}
+      {/* Pipeline picker + summary toggle */}
       <div className={styles.summaryHeader}>
+        {pipelinesForObject.length > 1 ? (
+          <label className={styles.pipelinePicker}>
+            Pipeline
+            <select
+              value={pipeline.id}
+              onChange={(e) => setSelectedPipelineId(e.target.value)}
+              data-testid="kanban-pipeline-picker"
+              aria-label="Select pipeline"
+            >
+              {pipelinesForObject.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                  {(p.isDefault ?? p.is_default) ? ' (default)' : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <span />
+        )}
         <button
           type="button"
           className={styles.summaryToggle}


### PR DESCRIPTION
## Summary
- Add a pipeline picker to the Kanban header so tenants with multiple pipelines per object can switch boards from the UI instead of being stuck on the default one. Selection persists per-object in localStorage.
- Tighten the record filter: records without a `pipelineId` only appear on the default pipeline, matching the server's `assignDefaultPipeline` behaviour. This keeps unassigned cards from rendering on a non-default board and triggering cross-pipeline move-stage 400s.
- New test covers the picker toggling between boards and records following the selection.

## Test plan
- [x] `vitest run` (651 tests pass)
- [x] `tsc --noEmit`
- [ ] With a tenant that has >1 pipeline for Opportunities, confirm the picker shows both and switching filters records correctly.

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm