### PR TITLE
fix(api): preserve AppError details in move-stage 400

### DIFF
--- a/apps/api/src/routes/__tests__/records.test.ts
+++ b/apps/api/src/routes/__tests__/records.test.ts
@@ -1063,6 +1063,41 @@ describe('POST /objects/:apiName/records/:id/move-stage', () => {
     });
   });
 
+  it('includes AppError details in 400 body for cross-pipeline target stage', async () => {
+    const err = Object.assign(
+      new Error('Target stage does not belong to the same pipeline'),
+      {
+        code: 'VALIDATION_ERROR',
+        details: {
+          recordId: VALID_UUID,
+          recordPipelineId: 'pipeline-a',
+          targetStageId: VALID_UUID_2,
+          targetStagePipelineId: 'pipeline-b',
+        },
+      },
+    );
+    mockMoveRecordStage.mockRejectedValue(err);
+
+    const req = mockReq(
+      { target_stage_id: VALID_UUID_2 },
+      { userId: 'user-123', tenantId: 'tenant-abc' },
+      { apiName: 'opportunity', id: VALID_UUID },
+    );
+    const res = mockRes();
+
+    await handleMoveStage(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Target stage does not belong to the same pipeline',
+      code: 'VALIDATION_ERROR',
+      recordId: VALID_UUID,
+      recordPipelineId: 'pipeline-a',
+      targetStageId: VALID_UUID_2,
+      targetStagePipelineId: 'pipeline-b',
+    });
+  });
+
   it('returns 500 on unexpected error', async () => {
     mockMoveRecordStage.mockRejectedValue(new Error('Database error'));
 

--- a/apps/api/src/routes/records.ts
+++ b/apps/api/src/routes/records.ts
@@ -473,7 +473,13 @@ export async function handleMoveStage(
 
     if (code === 'VALIDATION_ERROR') {
       const fieldErrors = (err as Error & { fieldErrors?: Record<string, string> }).fieldErrors;
-      res.status(400).json({ error: (err as Error).message, code: 'VALIDATION_ERROR', ...(fieldErrors && { fieldErrors }) });
+      const details = (err as Error & { details?: Record<string, unknown> }).details;
+      res.status(400).json({
+        error: (err as Error).message,
+        code: 'VALIDATION_ERROR',
+        ...(fieldErrors && { fieldErrors }),
+        ...(details && details),
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary

- The move-stage route catches `VALIDATION_ERROR` and rebuilds a legacy JSON body, which silently dropped the `AppError.details` payload added in #494.
- Spread `details` into the 400 response so clients receive `recordId`, `recordPipelineId`, `targetStageId`, and `targetStagePipelineId` for the "Target stage does not belong to the same pipeline" error.
- Unblocks diagnosis of the remaining multi-pipeline default-board 400 without needing DB access.

## Context

On the Sales Pipeline (default) board the move-stage POST returns 400 with message "Target stage does not belong to the same pipeline". With the response detail fields now reaching the browser, the two UUIDs in the response body will reveal whether the record got auto-assigned to the wrong pipeline, whether the target stage is bound to a sibling pipeline, or something else.

## Test plan

- [ ] CI passes (`pnpm --filter @cpcrm/api test`)
- [ ] Deploy to Azure; reproduce drop on Sales Pipeline (default)
- [ ] DevTools → Network → failed `move-stage` → Response shows `recordPipelineId` and `targetStagePipelineId`

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm