### PR TITLE
fix(api): adopt target stage's pipeline when record has no pipeline

### DIFF
--- a/apps/api/src/services/__tests__/stageMovementService.kysely-sql.test.ts
+++ b/apps/api/src/services/__tests__/stageMovementService.kysely-sql.test.ts
@@ -92,7 +92,30 @@ const { capturedQueries, mockQuery, mockConnect, resetCapture } = vi.hoisted(
         return { rows: [] };
       }
 
-      // stage lookup by id + tenant_id (target stage)
+      // target stage joined with pipeline_definitions to project
+      // pipeline_object_id (for cross-object validation).
+      if (
+        s.includes('FROM STAGE_DEFINITIONS') &&
+        s.includes('JOIN PIPELINE_DEFINITIONS') &&
+        s.includes('PIPELINE_OBJECT_ID')
+      ) {
+        const id = params![0] as string;
+        const row = fakeStages.get(id);
+        if (row) {
+          const pipeline = fakePipelines.get(row.pipeline_id as string);
+          return {
+            rows: [
+              {
+                ...row,
+                pipeline_object_id: pipeline?.object_id ?? null,
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      }
+
+      // stage lookup by id + tenant_id (target stage, legacy)
       if (s.startsWith('SELECT * FROM STAGE_DEFINITIONS WHERE ID')) {
         const id = params![0] as string;
         const row = fakeStages.get(id);

--- a/apps/api/src/services/__tests__/stageMovementService.test.ts
+++ b/apps/api/src/services/__tests__/stageMovementService.test.ts
@@ -500,7 +500,7 @@ describe('moveRecordStage', () => {
     ).rejects.toThrow('Record is already in this stage');
   });
 
-  it('auto-assigns default pipeline and moves record when record has no pipeline', async () => {
+  it('adopts target stage pipeline and moves record when record has no pipeline', async () => {
     seedPipelineAndStages();
 
     fakeRecords.set('rec-no-pipeline', {
@@ -522,13 +522,45 @@ describe('moveRecordStage', () => {
     expect(result.pipelineId).toBe('pipeline-1');
   });
 
-  it('throws VALIDATION_ERROR when record has no pipeline and no default pipeline exists', async () => {
-    // Only seed stages, not the pipeline — so assignDefaultPipeline returns false
+  it('adopts the target stage pipeline even when a sibling pipeline is also default', async () => {
+    // Regression: when multiple pipelines for an object are marked
+    // is_default=true the legacy `assignDefaultPipeline` lookup could
+    // pick a different pipeline than the one the user chose a stage
+    // from, producing a cross-pipeline 400. Picking the target stage's
+    // pipeline directly avoids the ambiguity.
+    seedPipelineAndStages();
+
+    // Second default pipeline for the same object, with its own stages.
+    fakePipelines.set('pipeline-2', {
+      id: 'pipeline-2',
+      object_id: 'obj-opportunity-id',
+      name: 'Sales Pipeline 2',
+      is_default: true,
+    });
+    fakeStages.set('stage-p2-prospect', {
+      id: 'stage-p2-prospect',
+      pipeline_id: 'pipeline-2',
+      name: 'Prospecting',
+      api_name: 'prospecting',
+      sort_order: 0,
+      stage_type: 'open',
+      default_probability: 10,
+    });
+    fakeStages.set('stage-p2-qualification', {
+      id: 'stage-p2-qualification',
+      pipeline_id: 'pipeline-2',
+      name: 'Qualification',
+      api_name: 'qualification',
+      sort_order: 1,
+      stage_type: 'open',
+      default_probability: 25,
+    });
+
     fakeRecords.set('rec-no-pipeline', {
       id: 'rec-no-pipeline',
       object_id: 'obj-opportunity-id',
       name: 'No Pipeline',
-      field_values: {},
+      field_values: { value: 50000 },
       owner_id: 'user-123',
       pipeline_id: null,
       current_stage_id: null,
@@ -537,9 +569,17 @@ describe('moveRecordStage', () => {
       updated_at: new Date().toISOString(),
     });
 
-    await expect(
-      moveRecordStage(TENANT_ID, 'opportunity', 'rec-no-pipeline', 'stage-qualification', 'user-123'),
-    ).rejects.toThrow('Record is not assigned to a pipeline');
+    // User picks a stage from pipeline-2 — the record should adopt pipeline-2.
+    const result = await moveRecordStage(
+      TENANT_ID,
+      'opportunity',
+      'rec-no-pipeline',
+      'stage-p2-qualification',
+      'user-123',
+    );
+
+    expect(result.currentStageId).toBe('stage-p2-qualification');
+    expect(result.pipelineId).toBe('pipeline-2');
   });
 
   it('applies default_probability on stage entry', async () => {

--- a/apps/api/src/services/__tests__/stageMovementService.test.ts
+++ b/apps/api/src/services/__tests__/stageMovementService.test.ts
@@ -83,7 +83,30 @@ const {
       return { rows: [] };
     }
 
-    // Stage lookup by id + tenant_id (target stage)
+    // Target stage lookup joined with parent pipeline to project
+    // pipeline_definitions.object_id (for cross-object validation).
+    if (
+      s.includes('FROM STAGE_DEFINITIONS') &&
+      s.includes('JOIN PIPELINE_DEFINITIONS') &&
+      s.includes('PIPELINE_OBJECT_ID')
+    ) {
+      const stageId = params![0] as string;
+      const stage = fakeStages.get(stageId);
+      if (stage) {
+        const pipeline = fakePipelines.get(stage.pipeline_id as string);
+        return {
+          rows: [
+            {
+              ...stage,
+              pipeline_object_id: pipeline?.object_id ?? null,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    }
+
+    // Stage lookup by id + tenant_id (target stage, legacy path)
     if (s.startsWith('SELECT * FROM STAGE_DEFINITIONS WHERE ID')) {
       const stageId = params![0] as string;
       const stage = fakeStages.get(stageId);
@@ -476,6 +499,15 @@ describe('moveRecordStage', () => {
     seedPipelineAndStages();
     seedRecord();
 
+    // Second pipeline for the SAME object — exercises the cross-pipeline
+    // rejection path (not the cross-object one).
+    fakePipelines.set('pipeline-2', {
+      id: 'pipeline-2',
+      object_id: 'obj-opportunity-id',
+      name: 'Other Pipeline',
+      is_default: false,
+    });
+
     // Add a stage in a different pipeline
     fakeStages.set('stage-other', {
       id: 'stage-other',
@@ -580,6 +612,63 @@ describe('moveRecordStage', () => {
 
     expect(result.currentStageId).toBe('stage-p2-qualification');
     expect(result.pipelineId).toBe('pipeline-2');
+  });
+
+  it('rejects move when target stage belongs to a different object type', async () => {
+    // Regression: adopting the target stage's pipeline must still reject
+    // cross-object moves — a record for object A cannot be moved to a
+    // stage whose parent pipeline belongs to object B.
+    seedPipelineAndStages();
+
+    // Foreign pipeline for a different object.
+    fakePipelines.set('pipeline-other', {
+      id: 'pipeline-other',
+      object_id: 'obj-contact-id',
+      name: 'Contact Pipeline',
+      is_default: true,
+    });
+    fakeStages.set('stage-foreign', {
+      id: 'stage-foreign',
+      pipeline_id: 'pipeline-other',
+      name: 'Foreign',
+      api_name: 'foreign',
+      sort_order: 0,
+      stage_type: 'open',
+      default_probability: 0,
+    });
+
+    fakeRecords.set('rec-no-pipeline', {
+      id: 'rec-no-pipeline',
+      object_id: 'obj-opportunity-id',
+      name: 'No Pipeline',
+      field_values: {},
+      owner_id: 'user-123',
+      pipeline_id: null,
+      current_stage_id: null,
+      stage_entered_at: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    try {
+      await moveRecordStage(
+        TENANT_ID,
+        'opportunity',
+        'rec-no-pipeline',
+        'stage-foreign',
+        'user-123',
+      );
+      expect.fail('Should have thrown');
+    } catch (err: unknown) {
+      const error = err as Error & {
+        code: string;
+        details?: Record<string, unknown>;
+      };
+      expect(error.code).toBe('VALIDATION_ERROR');
+      expect(error.message).toMatch(/different object type/i);
+      expect(error.details?.recordObjectId).toBe('obj-opportunity-id');
+      expect(error.details?.targetStagePipelineObjectId).toBe('obj-contact-id');
+    }
   });
 
   it('applies default_probability on stage entry', async () => {

--- a/apps/api/src/services/stageMovementService.ts
+++ b/apps/api/src/services/stageMovementService.ts
@@ -253,14 +253,31 @@ export async function moveRecordStage(
     //    Picking the stage implicitly picks the pipeline; this honours user
     //    intent and side-steps "default pipeline" lookups that can diverge
     //    from the frontend when multiple pipelines are marked is_default.
+    //
+    //    We also project the parent pipeline's object_id so we can reject
+    //    cross-object moves before adopting the target stage's pipeline.
     const targetStageRow = await trx
-      .selectFrom('stage_definitions')
-      .selectAll()
-      .where('id', '=', targetStageId)
-      .where('tenant_id', '=', tenantId)
+      .selectFrom('stage_definitions as sd')
+      .innerJoin('pipeline_definitions as pd', 'pd.id', 'sd.pipeline_id')
+      .selectAll('sd')
+      .select('pd.object_id as pipeline_object_id')
+      .where('sd.id', '=', targetStageId)
+      .where('sd.tenant_id', '=', tenantId)
       .executeTakeFirst();
     if (!targetStageRow) {
       throwNotFoundError('Target stage not found');
+    }
+    const targetStagePipelineObjectId = targetStageRow.pipeline_object_id as string;
+    if (targetStagePipelineObjectId !== objectId) {
+      throw AppError.validation(
+        'Target stage belongs to a different object type',
+        {
+          recordId,
+          recordObjectId: objectId,
+          targetStageId,
+          targetStagePipelineObjectId,
+        },
+      );
     }
     const targetStage = rowToStage(
       targetStageRow as unknown as Record<string, unknown>,

--- a/apps/api/src/services/stageMovementService.ts
+++ b/apps/api/src/services/stageMovementService.ts
@@ -248,46 +248,97 @@ export async function moveRecordStage(
       ? new Date(stageEnteredAtRaw as unknown as string)
       : null;
 
-    // 3. Auto-assign default pipeline if the record has no pipeline yet
+    // 3. Fetch the target stage first so we can use its pipeline_id to
+    //    resolve ambiguity when the record has no pipeline assigned yet.
+    //    Picking the stage implicitly picks the pipeline; this honours user
+    //    intent and side-steps "default pipeline" lookups that can diverge
+    //    from the frontend when multiple pipelines are marked is_default.
+    const targetStageRow = await trx
+      .selectFrom('stage_definitions')
+      .selectAll()
+      .where('id', '=', targetStageId)
+      .where('tenant_id', '=', tenantId)
+      .executeTakeFirst();
+    if (!targetStageRow) {
+      throwNotFoundError('Target stage not found');
+    }
+    const targetStage = rowToStage(
+      targetStageRow as unknown as Record<string, unknown>,
+    );
+
+    // 4. Resolve the record's pipeline. If the record is not yet assigned,
+    //    adopt the target stage's pipeline and seed a current stage so gate
+    //    validation below runs in the correct pipeline context.
     let resolvedPipelineId = pipelineId;
     let resolvedCurrentStageId = currentStageId;
     let resolvedStageEnteredAt = stageEnteredAt;
 
-    if (!resolvedPipelineId || !resolvedCurrentStageId) {
-      const assigned = await assignDefaultPipeline(
-        trx,
-        recordId,
-        objectId,
-        ownerId,
-        tenantId,
-      );
-      if (!assigned) {
-        throwValidationError('Record is not assigned to a pipeline');
+    if (!resolvedPipelineId) {
+      resolvedPipelineId = targetStage.pipelineId;
+
+      if (!resolvedCurrentStageId) {
+        // Seed current stage = first open stage in the adopted pipeline
+        // (fall back to first stage by sort_order when no open stage).
+        const initialStageRow = await trx
+          .selectFrom('stage_definitions')
+          .select(['id', 'stage_type'])
+          .where('pipeline_id', '=', resolvedPipelineId)
+          .where('tenant_id', '=', tenantId)
+          .orderBy('sort_order', 'asc')
+          .execute();
+        const seedStage =
+          initialStageRow.find((s) => s.stage_type === 'open') ??
+          initialStageRow[0];
+        if (!seedStage) {
+          throwValidationError('Pipeline has no stages');
+        }
+        resolvedCurrentStageId = seedStage.id as string;
+        resolvedStageEnteredAt = new Date();
       }
 
-      // Re-read the record to pick up the newly assigned pipeline columns
-      const refreshRow = await trx
-        .selectFrom('records')
-        .select(['pipeline_id', 'current_stage_id', 'stage_entered_at'])
+      // Persist the pipeline assignment now so stage_history and the
+      // record row reflect the adopted pipeline once the transaction
+      // commits.
+      await trx
+        .updateTable('records')
+        .set({
+          pipeline_id: resolvedPipelineId,
+          current_stage_id: resolvedCurrentStageId,
+          stage_entered_at: resolvedStageEnteredAt,
+        })
         .where('id', '=', recordId)
         .where('tenant_id', '=', tenantId)
-        .executeTakeFirst();
-      if (!refreshRow) {
-        throwValidationError('Record is not assigned to a pipeline');
+        .execute();
+    } else if (!resolvedCurrentStageId) {
+      // Pipeline present but no current stage — seed from first open stage
+      // in the existing pipeline.
+      const initialStageRow = await trx
+        .selectFrom('stage_definitions')
+        .select(['id', 'stage_type'])
+        .where('pipeline_id', '=', resolvedPipelineId)
+        .where('tenant_id', '=', tenantId)
+        .orderBy('sort_order', 'asc')
+        .execute();
+      const seedStage =
+        initialStageRow.find((s) => s.stage_type === 'open') ??
+        initialStageRow[0];
+      if (!seedStage) {
+        throwValidationError('Pipeline has no stages');
       }
-
-      resolvedPipelineId = (refreshRow.pipeline_id as string | null) ?? null;
-      resolvedCurrentStageId = (refreshRow.current_stage_id as string | null) ?? null;
-      resolvedStageEnteredAt = refreshRow.stage_entered_at
-        ? new Date(refreshRow.stage_entered_at as unknown as string)
-        : null;
-
-      if (!resolvedPipelineId || !resolvedCurrentStageId) {
-        throwValidationError('Record is not assigned to a pipeline');
-      }
+      resolvedCurrentStageId = seedStage.id as string;
+      resolvedStageEnteredAt = new Date();
+      await trx
+        .updateTable('records')
+        .set({
+          current_stage_id: resolvedCurrentStageId,
+          stage_entered_at: resolvedStageEnteredAt,
+        })
+        .where('id', '=', recordId)
+        .where('tenant_id', '=', tenantId)
+        .execute();
     }
 
-    // 4. Fetch the current stage
+    // 5. Fetch the current stage
     const currentStageRow = await trx
       .selectFrom('stage_definitions')
       .selectAll()
@@ -302,20 +353,7 @@ export async function moveRecordStage(
       currentStageRow as unknown as Record<string, unknown>,
     );
 
-    // 5. Fetch the target stage and validate it belongs to the same pipeline
-    const targetStageRow = await trx
-      .selectFrom('stage_definitions')
-      .selectAll()
-      .where('id', '=', targetStageId)
-      .where('tenant_id', '=', tenantId)
-      .executeTakeFirst();
-    if (!targetStageRow) {
-      throwNotFoundError('Target stage not found');
-    }
-    const targetStage = rowToStage(
-      targetStageRow as unknown as Record<string, unknown>,
-    );
-
+    // 6. Target stage must belong to the record's resolved pipeline.
     if (targetStage.pipelineId !== resolvedPipelineId) {
       throw AppError.validation(
         'Target stage does not belong to the same pipeline',
@@ -332,7 +370,7 @@ export async function moveRecordStage(
       throwValidationError('Record is already in this stage');
     }
 
-    // 6. Determine if gate validation is required
+    // 7. Determine if gate validation is required
     const isForwardMove = targetStage.sortOrder > currentStage.sortOrder;
     const isWonOrLost = targetStage.stageType === 'won' || targetStage.stageType === 'lost';
     const requireGateValidation = isForwardMove || isWonOrLost;


### PR DESCRIPTION
## Summary

- Fix the root cause of "Target stage does not belong to the same pipeline" 400s for this tenant: when a record has no pipeline assigned yet, `moveRecordStage` now adopts the **target stage's pipeline** instead of running an ambiguous `is_default=true` lookup.
- Regression test asserting that behaviour when two pipelines for the same object are both marked default.

## Context

From PR #495's diagnostic output, the failing record had:

- `recordPipelineId: 33b844fe-0139-4131-8d81-1b10284add20`
- `targetStagePipelineId: 541d02fe-cc93-4261-ab1c-52ff6f0e8f14`

These are two different pipelines both marked `is_default=true` on the `opportunity` object. The frontend's `StageFieldRenderer` loaded the dropdown from pipeline `541d02fe` (its pick of the default) while the server's `assignDefaultPipeline` picked `33b844fe` — producing a guaranteed cross-pipeline 400 on every move.

Since selecting a stage implicitly selects its pipeline, deriving the pipeline from the target stage sidesteps the disagreement entirely. The pre-existing "cross-pipeline move" validation still fires when a record **is** already assigned to a different pipeline than the target stage.

`assignDefaultPipeline` is left in place for its other caller (record creation in `recordService.ts`) — only `moveRecordStage` switches strategy.

## Test plan

- [ ] CI passes (`pnpm --filter @cpcrm/api test`)
- [ ] Deploy to Azure; drop a card on Sales Pipeline (default) Kanban
- [ ] Change stage from the record detail dropdown — move succeeds
- [ ] Confirm a record already assigned to pipeline A still rejects a stage from pipeline B

## Follow-up (not in this PR)

Worth adding a partial unique index on `pipeline_definitions (tenant_id, object_id) WHERE is_default` so two defaults for the same object can't coexist. Flag this to the user.

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm