### PR TITLE
feat(web): default to Kanban view for objects with a pipeline

### DIFF
--- a/apps/web/src/__tests__/RecordListPage.test.tsx
+++ b/apps/web/src/__tests__/RecordListPage.test.tsx
@@ -8,6 +8,12 @@ vi.mock('@descope/react-sdk', () => ({
   useSession: vi.fn(),
 }));
 
+// Stub the Kanban board so this suite can focus on view-toggle logic
+// without pulling in react-query, pipeline hooks, and drag-and-drop.
+vi.mock('../components/KanbanBoard.js', () => ({
+  KanbanBoard: () => <div data-testid="kanban-board-stub">Kanban</div>,
+}));
+
 const { useSession } = await import('@descope/react-sdk');
 
 function renderPage(apiName = 'account') {
@@ -55,8 +61,22 @@ function makeRecordsResponse(
   };
 }
 
-function mockFetch(recordsResponse?: ReturnType<typeof makeRecordsResponse>) {
+function mockFetch(
+  recordsResponse?: ReturnType<typeof makeRecordsResponse>,
+  options: { withPipeline?: boolean } = {},
+) {
   const fetchMock = vi.fn().mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.includes('/api/v1/admin/pipelines')) {
+      // Pipelines list (only populated when a test opts in).
+      return Promise.resolve({
+        ok: true,
+        json: async () =>
+          options.withPipeline
+            ? [{ id: 'pipeline-1', objectId: 'obj-1', isDefault: true }]
+            : [],
+      } as Response);
+    }
+
     if (typeof url === 'string' && url.includes('/api/v1/admin/objects') && !url.includes('/layouts')) {
       // Admin objects list
       return Promise.resolve({
@@ -465,5 +485,52 @@ describe('RecordListPage', () => {
     const columnHeaders = screen.getAllByRole('columnheader');
     const headerTexts = columnHeaders.map((th) => th.textContent);
     expect(headerTexts).toContain('Owner');
+  });
+
+  it('defaults to the pipeline view once hasPipeline resolves', async () => {
+    mockFetch(makeRecordsResponse(), { withPipeline: true });
+    renderPage();
+
+    // Kanban board stub should render once the pipeline lookup resolves —
+    // no user toggle click required.
+    await waitFor(() => {
+      expect(screen.getByTestId('kanban-board-stub')).toBeInTheDocument();
+    });
+
+    const pipelineToggle = screen.getByRole('button', { name: /Pipeline/ });
+    expect(pipelineToggle).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('honours a manual List toggle and does not auto-flip back to pipeline', async () => {
+    const user = userEvent.setup();
+    mockFetch(makeRecordsResponse(), { withPipeline: true });
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('kanban-board-stub')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /List/ }));
+
+    // Kanban disappears and stays gone even on subsequent re-renders.
+    expect(screen.queryByTestId('kanban-board-stub')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /List/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('stays on the list view when the object has no pipeline', async () => {
+    mockFetch(makeRecordsResponse());
+    renderPage();
+
+    // Let the loader settle.
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Accounts' })).toBeInTheDocument();
+    });
+
+    // No pipeline → no toggle, no kanban.
+    expect(screen.queryByTestId('view-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('kanban-board-stub')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -153,7 +153,11 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset state when the object changes
+  // Reset state when the object changes. Keyed on `apiName` only: a
+  // prop-only change to `initialView` (e.g. same object, switching
+  // between `/objects/:apiName` and `/objects/:apiName/pipeline`) must
+  // NOT clear pipeline state, because the loader that repopulates it
+  // is also keyed only on `apiName` and won't refetch.
   useEffect(() => {
     setRecords([]);
     setObjectDef(null);
@@ -169,10 +173,12 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     setHasPipeline(false);
     setResolvedObjectId(null);
     userToggledView.current = false;
-    if (!initialView) {
-      setViewMode('list');
-    }
-  }, [apiName, initialView]);
+    // Always sync viewMode to the current pinned route — otherwise a
+    // user who toggled to List before navigating between two pipeline
+    // routes would stay stuck on list.
+    setViewMode(initialView ?? 'list');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiName]);
 
   // Default to the pipeline view for objects that have a pipeline, unless
   // the caller pinned an initialView or the user has manually toggled.

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -147,6 +147,9 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   const [viewMode, setViewMode] = useState<'list' | 'pipeline'>(initialView ?? 'list');
   const [hasPipeline, setHasPipeline] = useState(false);
   const [resolvedObjectId, setResolvedObjectId] = useState<string | null>(null);
+  // Tracks whether the user has manually chosen a view. Once true we
+  // stop auto-flipping to pipeline even if hasPipeline resolves later.
+  const userToggledView = useRef(false);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -165,7 +168,21 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     setError(null);
     setHasPipeline(false);
     setResolvedObjectId(null);
-  }, [apiName]);
+    userToggledView.current = false;
+    if (!initialView) {
+      setViewMode('list');
+    }
+  }, [apiName, initialView]);
+
+  // Default to the pipeline view for objects that have a pipeline, unless
+  // the caller pinned an initialView or the user has manually toggled.
+  useEffect(() => {
+    if (initialView) return;
+    if (userToggledView.current) return;
+    if (hasPipeline) {
+      setViewMode('pipeline');
+    }
+  }, [hasPipeline, initialView]);
 
   // Debounce search input
   const handleSearchChange = useCallback((value: string) => {
@@ -397,7 +414,10 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
               <button
                 type="button"
                 className={`${styles.viewToggleButton} ${viewMode === 'list' ? styles.viewToggleActive : ''}`}
-                onClick={() => setViewMode('list')}
+                onClick={() => {
+                  userToggledView.current = true;
+                  setViewMode('list');
+                }}
                 aria-pressed={viewMode === 'list'}
               >
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
@@ -408,7 +428,10 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
               <button
                 type="button"
                 className={`${styles.viewToggleButton} ${viewMode === 'pipeline' ? styles.viewToggleActive : ''}`}
-                onClick={() => setViewMode('pipeline')}
+                onClick={() => {
+                  userToggledView.current = true;
+                  setViewMode('pipeline');
+                }}
                 aria-pressed={viewMode === 'pipeline'}
               >
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Default `RecordListPage` to the Kanban/pipeline view whenever `hasPipeline` resolves to true and the caller hasn't pinned an `initialView`.
- Track manual toggle clicks with a `useRef` so we never override a user's explicit choice.
- `initialView='list'` routes and the explicit `/objects/:apiName/pipeline` route are unaffected — both short-circuit the auto-flip.

Motivation: for objects with a pipeline (Opportunities in particular), the list landing felt wrong — the Kanban board is the primary way people work with those records.

## Test plan
- [x] `npx vitest run` in `apps/web` — 653/653 pass
- [x] `tsc --noEmit` clean
- [ ] Manual: open `/objects/opportunity` — should land on Kanban
- [ ] Manual: toggle to List, reload — should respect explicit route (`/objects/opportunity` still auto-flips to pipeline; `/objects/opportunity/pipeline` still forced to pipeline)
- [ ] Manual: open `/objects/account` (no pipeline) — should stay on List

https://claude.ai/code/session_01RJPu9hWDMVpgK8rFfQ3tLm