### PR TITLE
Fix related-list drop zones and placed-tile label on page builder

### DIFF
--- a/apps/web/src/__tests__/PageBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/PageBuilderPage.test.tsx
@@ -197,6 +197,11 @@ const samplePageLayoutDetail = {
                 type: 'field',
                 config: { fieldApiName: 'name', span: 1, readOnly: false },
               },
+              {
+                id: 'comp-rl-1',
+                type: 'related_list',
+                config: { relationshipId: 'rel-2', displayFields: [], limit: 5, allowCreate: true },
+              },
             ],
           },
         ],
@@ -410,6 +415,19 @@ describe('PageBuilderPage', () => {
     const inboundFallback = screen.getByTestId('palette-item-palette-rel-rel-3');
     expect(inboundFallback).toHaveTextContent('Leads');
     expect(inboundFallback).not.toHaveTextContent('Account');
+  });
+
+  it('renders placed related_list tiles with the relationship label, not the generic type', async () => {
+    mockAllFetches();
+    renderPage();
+
+    // comp-rl-1 in samplePageLayoutDetail targets rel-2 (Primary Contacts).
+    const tile = await screen.findByTestId('canvas-component-comp-rl-1');
+    expect(tile).toHaveTextContent('Primary Contacts');
+    // "Related List" (with space) is the registry fallback label; it should
+    // not appear when a relationshipId resolves. The type badge renders
+    // "related_list" (snake_case), so this substring check is safe.
+    expect(tile).not.toHaveTextContent('Related List');
   });
 
   it('shows related fields from lookup relationships in the component palette', async () => {

--- a/apps/web/src/components/BuilderCanvas.module.css
+++ b/apps/web/src/components/BuilderCanvas.module.css
@@ -120,7 +120,8 @@
     background var(--transition-base);
 }
 
-.addSectionBtn:hover {
+.addSectionBtn:hover,
+.addSectionBtnOver {
   color: var(--accent-text);
   border-color: var(--accent);
   background: var(--accent-soft);

--- a/apps/web/src/components/BuilderCanvas.tsx
+++ b/apps/web/src/components/BuilderCanvas.tsx
@@ -5,6 +5,7 @@ import type {
   BuilderLayout,
   BuilderSection,
   FieldRef,
+  RelationshipRef,
   ComponentDefinition,
 } from './builderTypes.js';
 import { HeaderZoneEditor } from './HeaderZoneEditor.js';
@@ -37,9 +38,40 @@ function DroppableTab({ tabId, isActive, children }: DroppableTabProps) {
   );
 }
 
+interface AddSectionDropZoneProps {
+  tabId: string;
+  columns: number;
+  label: string;
+  testId: string;
+  onClick: () => void;
+}
+
+function AddSectionDropZone({ tabId, columns, label, testId, onClick }: AddSectionDropZoneProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `add-section-${tabId}-${columns}`,
+    data: { origin: 'new-section', tabId, columns },
+  });
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      className={`${styles.addSectionBtn} ${isOver ? styles.addSectionBtnOver : ''}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      data-testid={testId}
+    >
+      {label}
+    </button>
+  );
+}
+
 interface BuilderCanvasProps {
   layout: BuilderLayout;
   fields: FieldRef[];
+  relationships: RelationshipRef[];
   registry: ComponentDefinition[];
   selectedId: string | null;
   onSelect: (id: string | null) => void;
@@ -60,6 +92,7 @@ interface BuilderCanvasProps {
 export function BuilderCanvas({
   layout,
   fields,
+  relationships,
   registry,
   selectedId,
   onSelect,
@@ -190,6 +223,7 @@ export function BuilderCanvas({
                 key={section.id}
                 section={section}
                 fields={fields}
+                relationships={relationships}
                 registry={registry}
                 selectedId={selectedId}
                 onSelectComponent={onSelectComponent}
@@ -202,28 +236,20 @@ export function BuilderCanvas({
           </SortableContext>
 
           <div className={styles.addSectionRow}>
-            <button
-              type="button"
-              className={styles.addSectionBtn}
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddSection(activeTab.id, 1);
-              }}
-              data-testid="add-section-1col"
-            >
-              + 1-column section
-            </button>
-            <button
-              type="button"
-              className={styles.addSectionBtn}
-              onClick={(e) => {
-                e.stopPropagation();
-                onAddSection(activeTab.id, 2);
-              }}
-              data-testid="add-section-2col"
-            >
-              + 2-column section
-            </button>
+            <AddSectionDropZone
+              tabId={activeTab.id}
+              columns={1}
+              label="+ 1-column section"
+              testId="add-section-1col"
+              onClick={() => onAddSection(activeTab.id, 1)}
+            />
+            <AddSectionDropZone
+              tabId={activeTab.id}
+              columns={2}
+              label="+ 2-column section"
+              testId="add-section-2col"
+              onClick={() => onAddSection(activeTab.id, 2)}
+            />
           </div>
         </div>
       )}

--- a/apps/web/src/components/DraggableComponent.tsx
+++ b/apps/web/src/components/DraggableComponent.tsx
@@ -1,6 +1,11 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { BuilderComponent, FieldRef, ComponentDefinition } from './builderTypes.js';
+import type {
+  BuilderComponent,
+  FieldRef,
+  RelationshipRef,
+  ComponentDefinition,
+} from './builderTypes.js';
 import { resolveIcon } from './iconMap.js';
 import styles from './DraggableComponent.module.css';
 
@@ -10,6 +15,7 @@ interface DraggableComponentProps {
   component: BuilderComponent;
   sectionId: string;
   fields: FieldRef[];
+  relationships: RelationshipRef[];
   registry: ComponentDefinition[];
   isSelected: boolean;
   onSelect: () => void;
@@ -21,11 +27,20 @@ interface DraggableComponentProps {
 function getComponentLabel(
   component: BuilderComponent,
   fields: FieldRef[],
+  relationships: RelationshipRef[],
   registry: ComponentDefinition[],
 ): string {
   if (component.type === 'field') {
     const field = fields.find((f) => f.apiName === component.config.fieldApiName);
     return field ? field.label : String(component.config.fieldApiName ?? 'Unknown field');
+  }
+
+  if (component.type === 'related_list') {
+    const relId = component.config.relationshipId;
+    if (relId) {
+      const rel = relationships.find((r) => r.id === relId);
+      if (rel) return rel.displayLabel;
+    }
   }
 
   const def = registry.find((r) => r.type === component.type);
@@ -54,6 +69,7 @@ export function DraggableComponent({
   component,
   sectionId,
   fields,
+  relationships,
   registry,
   isSelected,
   onSelect,
@@ -81,7 +97,7 @@ export function DraggableComponent({
     opacity: isDragging ? 0.4 : 1,
   };
 
-  const label = getComponentLabel(component, fields, registry);
+  const label = getComponentLabel(component, fields, relationships, registry);
   const icon = getComponentIcon(component, fields, registry);
 
   return (

--- a/apps/web/src/components/DroppableSection.tsx
+++ b/apps/web/src/components/DroppableSection.tsx
@@ -5,7 +5,13 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { BuilderSection, BuilderComponent, FieldRef, ComponentDefinition } from './builderTypes.js';
+import type {
+  BuilderSection,
+  BuilderComponent,
+  FieldRef,
+  RelationshipRef,
+  ComponentDefinition,
+} from './builderTypes.js';
 import { DraggableComponent } from './DraggableComponent.js';
 import styles from './DroppableSection.module.css';
 
@@ -14,6 +20,7 @@ import styles from './DroppableSection.module.css';
 interface DroppableSectionProps {
   section: BuilderSection;
   fields: FieldRef[];
+  relationships: RelationshipRef[];
   registry: ComponentDefinition[];
   selectedId: string | null;
   onSelectComponent: (componentId: string) => void;
@@ -28,6 +35,7 @@ interface DroppableSectionProps {
 export function DroppableSection({
   section,
   fields,
+  relationships,
   registry,
   selectedId,
   onSelectComponent,
@@ -113,6 +121,7 @@ export function DroppableSection({
               component={comp}
               sectionId={section.id}
               fields={fields}
+              relationships={relationships}
               registry={registry}
               isSelected={selectedId === comp.id}
               onSelect={() => onSelectComponent(comp.id)}

--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -94,6 +94,7 @@ export function LayoutCanvas({
         <BuilderCanvas
           layout={layout}
           fields={fields}
+          relationships={relationships}
           registry={registry}
           selectedId={selectedId}
           onSelect={onSelect}

--- a/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
@@ -36,18 +36,37 @@ export function usePageLayoutDnd({ layout, updateLayout }: UsePageLayoutDndOptio
       const paletteData = activeData as unknown as PaletteDragData;
       const overData = over.data.current;
 
+      const newComp: BuilderComponent = {
+        id: uid(),
+        type: paletteData.componentType,
+        config: { ...paletteData.defaultConfig },
+      };
+
+      // Palette → new-section drop: create a section and place the component in it.
+      if (overData && overData.origin === 'new-section') {
+        const targetTabId = overData.tabId as string;
+        const columns = (overData.columns as number) ?? 1;
+        updateLayout((draft) => {
+          const tab = draft.tabs.find((t: BuilderTab) => t.id === targetTabId);
+          if (!tab) return draft;
+          tab.sections.push({
+            id: uid(),
+            type: 'field_section',
+            label: `Section ${tab.sections.length + 1}`,
+            columns,
+            components: [newComp],
+          });
+          return draft;
+        });
+        return;
+      }
+
       let targetSectionId: string | null = null;
       if (overData && 'sectionId' in overData) {
         targetSectionId = overData.sectionId as string;
       }
 
       if (!targetSectionId) return;
-
-      const newComp: BuilderComponent = {
-        id: uid(),
-        type: paletteData.componentType,
-        config: { ...paletteData.defaultConfig },
-      };
 
       updateLayout((draft) => {
         const loc = findSection(draft, targetSectionId!);


### PR DESCRIPTION
## Summary
Fixes two follow-up bugs in the Page Builder that surfaced after the related-lists-palette label fix in #493.

- **Dropping a related list into a new section.** The `+ 1-column section` / `+ 2-column section` buttons were plain buttons with no `useDroppable` registration, so @dnd-kit routed drops to the nearest existing section (usually the last one rendered). Now each button registers as a droppable with `{ origin: 'new-section', tabId, columns }` and `usePageLayoutDnd` handles that origin by creating the section and placing the component inside it in a single layout mutation.
- **Canvas tile label for placed related lists.** `getComponentLabel` only special-cased `type === 'field'`; everything else fell through to the registry label, so every placed related list rendered as the generic string "Related List". Plumbed `relationships` through `BuilderCanvas → DroppableSection → DraggableComponent` and resolve the tile's label via `component.config.relationshipId`.

## Stacked on #493
This PR is based on `claude/fix-related-lists-names-jA69j` so its diff stays focused on the drop-zone + tile-label changes. Merging #493 first will auto-rebase this PR's base onto `main`.

## Test plan
- [x] `pnpm test -- PageBuilderPage` — 651/651 pass, including a new assertion that a placed `related_list` component renders the relationship's `displayLabel` on the canvas (not "Related List").
- [ ] Manual: on the Account page builder, drag a related list from the palette onto `+ 1-column section` / `+ 2-column section` and confirm a new section is created with the related list inside, labeled with the relationship name.
- [ ] Manual: drag a related list onto an existing section and confirm it still lands there.
- [ ] Manual: confirm field drops into new-section zones still work (no regression).

https://claude.ai/code/session_01E4nWTpDC73htxG8YjEX4uD