### PR TITLE
Fix palette drop routing into new-section zones (pointer-first collision)

### DIFF
--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -2,8 +2,16 @@ import {
   DndContext,
   DragOverlay,
   closestCorners,
+  pointerWithin,
+  rectIntersection,
 } from '@dnd-kit/core';
-import type { DragStartEvent, DragEndEvent, SensorDescriptor, SensorOptions } from '@dnd-kit/core';
+import type {
+  CollisionDetection,
+  DragStartEvent,
+  DragEndEvent,
+  SensorDescriptor,
+  SensorOptions,
+} from '@dnd-kit/core';
 import { ComponentPalette } from '../../../components/ComponentPalette.js';
 import { BuilderCanvas } from '../../../components/BuilderCanvas.js';
 import { PropertiesPanel } from '../../../components/PropertiesPanel.js';
@@ -17,6 +25,19 @@ import type {
 } from '../../../components/builderTypes.js';
 import type { HeaderConfig, VisibilityRule } from '../../../components/layoutTypes.js';
 import styles from '../PageBuilderPage.module.css';
+
+// The palette's DragOverlay is wider than the new-section buttons, so
+// `closestCorners` routinely ranks an adjacent section's drop zone ahead
+// of the button the pointer is actually over. Pointer-first collision
+// ensures the droppable under the cursor wins; rectIntersection and
+// closestCorners cover keyboard drags and out-of-bounds moves.
+const collisionDetection: CollisionDetection = (args) => {
+  const pointer = pointerWithin(args);
+  if (pointer.length > 0) return pointer;
+  const rect = rectIntersection(args);
+  if (rect.length > 0) return rect;
+  return closestCorners(args);
+};
 
 interface LayoutCanvasProps {
   layout: BuilderLayout;
@@ -79,7 +100,7 @@ export function LayoutCanvas({
     <div className={styles.builderBody}>
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCorners}
+        collisionDetection={collisionDetection}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
       >


### PR DESCRIPTION
## Summary
Follow-up to #498. After merging that PR, dragging a related list onto the highlighted `+ 1-column section` / `+ 2-column section` button still snapped the drop into the section above it.

**Root cause.** #498 registered the buttons as droppables, but @dnd-kit's `closestCorners` strategy measures corner distance between the DragOverlay and each droppable. The overlay is wider than a single button, so an adjacent section's drop zone frequently ranks first — even when the button's `isOver` highlight is lit. On release, `over` resolves to the section, and the component falls into the wrong place.

**Fix.** Swap in a pointer-first collision strategy on `DndContext`:
1. `pointerWithin` — the droppable physically under the cursor wins.
2. `rectIntersection` — fallback when the pointer is between droppables.
3. `closestCorners` — final fallback for keyboard drags.

Section reorder and existing-section drops are unaffected in practice; they already relied on pointer overlap.

## Test plan
- [x] `pnpm test -- PageBuilderPage` — 651/651 pass (no new test; pointer-based collision is hard to simulate in jsdom).
- [x] Manual: drag a related list onto `+ 1-column section` / `+ 2-column section`. The new section should be created with the related list inside it, regardless of how tall the section above is.
- [ ] Manual: drag a related list onto an existing empty section — should land there.
- [ ] Manual: drag a related list onto an existing populated section — should append to it.
- [ ] Manual: reorder sections by dragging their handle — should still swap positions.

https://claude.ai/code/session_01E4nWTpDC73htxG8YjEX4uD