### PR TITLE
Fix drops onto existing sections after pointer-first collision change

### DIFF
--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -3,7 +3,6 @@ import {
   DragOverlay,
   closestCorners,
   pointerWithin,
-  rectIntersection,
 } from '@dnd-kit/core';
 import type {
   CollisionDetection,
@@ -26,16 +25,19 @@ import type {
 import type { HeaderConfig, VisibilityRule } from '../../../components/layoutTypes.js';
 import styles from '../PageBuilderPage.module.css';
 
-// The palette's DragOverlay is wider than the new-section buttons, so
-// `closestCorners` routinely ranks an adjacent section's drop zone ahead
-// of the button the pointer is actually over. Pointer-first collision
-// ensures the droppable under the cursor wins; rectIntersection and
-// closestCorners cover keyboard drags and out-of-bounds moves.
+// The DragOverlay is wider than the "+ N-column section" buttons, so
+// `closestCorners` often ranks an adjacent section ahead of the button
+// the pointer is actually over. Short-circuit to the new-section
+// droppable whenever the pointer is within one; fall back to
+// `closestCorners` for every other case so existing-section drops and
+// sortable reordering keep their original behaviour.
 const collisionDetection: CollisionDetection = (args) => {
-  const pointer = pointerWithin(args);
-  if (pointer.length > 0) return pointer;
-  const rect = rectIntersection(args);
-  if (rect.length > 0) return rect;
+  for (const collision of pointerWithin(args)) {
+    const container = args.droppableContainers.get(collision.id);
+    if (container?.data.current?.origin === 'new-section') {
+      return [collision];
+    }
+  }
   return closestCorners(args);
 };
 

--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -33,7 +33,7 @@ import styles from '../PageBuilderPage.module.css';
 // sortable reordering keep their original behaviour.
 const collisionDetection: CollisionDetection = (args) => {
   for (const collision of pointerWithin(args)) {
-    const container = args.droppableContainers.get(collision.id);
+    const container = args.droppableContainers.find((c) => c.id === collision.id);
     if (container?.data.current?.origin === 'new-section') {
       return [collision];
     }


### PR DESCRIPTION
## Summary
Follow-up fix to #500. The pointer-first collision change routed palette drops correctly onto `+ N-column section` buttons, but it broke drops onto existing empty and populated sections — `pointerWithin` was resolving `over` to the section sortable or a sortable field tile, and `handleDragEnd` never applied the drop.

**Fix.** Keep `closestCorners` for all sortable reorder and existing-section drops (restoring the original behaviour), and only short-circuit to a pointer-within collision when the pointer is physically inside a new-section button. This isolates the overlay-overlap fix to the one droppable that actually needed it.

## Test plan
- [x] `pnpm test -- PageBuilderPage` — 657/657 pass.
- [ ] Manual: drag a palette item onto `+ 1-column section` / `+ 2-column section` — still creates a new section containing the dropped item.
- [ ] Manual: drag onto an existing empty section — lands in that section.
- [ ] Manual: drag onto a populated section — appends to that section.
- [ ] Manual: drag a section by its handle over another section — they swap positions.

https://claude.ai/code/session_01E4nWTpDC73htxG8YjEX4uD