### PR TITLE
feat(web): migrate RecordListPage to TanStack Query

### DIFF
--- a/apps/web/src/__tests__/RecordListPage.test.tsx
+++ b/apps/web/src/__tests__/RecordListPage.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { RecordListPage } from '../pages/RecordListPage.js';
+import { renderWithQuery } from './utils/renderWithQuery.js';
 
 vi.mock('@descope/react-sdk', () => ({
   useSession: vi.fn(),
 }));
 
 // Stub the Kanban board so this suite can focus on view-toggle logic
-// without pulling in react-query, pipeline hooks, and drag-and-drop.
+// without pulling in pipeline hooks and drag-and-drop.
 vi.mock('../components/KanbanBoard.js', () => ({
   KanbanBoard: () => <div data-testid="kanban-board-stub">Kanban</div>,
 }));
@@ -17,7 +18,7 @@ vi.mock('../components/KanbanBoard.js', () => ({
 const { useSession } = await import('@descope/react-sdk');
 
 function renderPage(apiName = 'account') {
-  return render(
+  return renderWithQuery(
     <MemoryRouter initialEntries={[`/objects/${apiName}`]}>
       <Routes>
         <Route path="/objects/:apiName" element={<RecordListPage />} />

--- a/apps/web/src/features/records/hooks/queries/useLayout.ts
+++ b/apps/web/src/features/records/hooks/queries/useLayout.ts
@@ -59,10 +59,7 @@ export function useLayout(
   const queryClient = useQueryClient();
 
   return useQuery<LayoutDefinition | null>({
-    queryKey: [
-      ...pageLayoutsKeys.byObject(objectId ?? ''),
-      { resolved: layoutType },
-    ],
+    queryKey: pageLayoutsKeys.resolved(objectId ?? '', layoutType),
     queryFn: async () => {
       const listPayload = await queryClient.fetchQuery<LayoutListItem[]>({
         queryKey: pageLayoutsKeys.list(objectId ?? ''),

--- a/apps/web/src/features/records/hooks/queries/useLayout.ts
+++ b/apps/web/src/features/records/hooks/queries/useLayout.ts
@@ -1,0 +1,96 @@
+import {
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useSession } from '@descope/react-sdk';
+import { unwrapList, useApiClient } from '../../../../lib/apiClient.js';
+import { pageLayoutsKeys } from '../../../../lib/queryKeys.js';
+
+export interface LayoutFieldWithMetadata {
+  fieldId: string;
+  fieldApiName: string;
+  fieldLabel: string;
+  fieldType: string;
+  sortOrder: number;
+  section: number;
+  width: string;
+}
+
+export interface LayoutDefinition {
+  id: string;
+  objectId: string;
+  name: string;
+  layoutType: string;
+  isDefault: boolean;
+  fields: LayoutFieldWithMetadata[];
+}
+
+export interface LayoutListItem {
+  id: string;
+  objectId: string;
+  name: string;
+  layoutType: string;
+  isDefault: boolean;
+}
+
+export type LayoutType = 'list' | 'form';
+
+/**
+ * Resolve the default layout of a given `layoutType` for an object, and
+ * return its full definition (sections + fields).
+ *
+ * Hitting `/api/v1/admin/objects/:objectId/layouts` first gives us the list
+ * of layouts; we pick the default (or the first of that type) and then fetch
+ * its detail. Each response is cached independently under
+ * `pageLayoutsKeys.list(objectId)` and `pageLayoutsKeys.detail(layoutId)` so
+ * invalidating one object's layouts doesn't wipe unrelated caches.
+ *
+ * Returns `null` when the object has no matching layout — callers should
+ * fall back to a default rendering (e.g. RecordListPage uses the record's
+ * own field list when no list layout is configured).
+ */
+export function useLayout(
+  objectId: string | undefined,
+  layoutType: LayoutType,
+): UseQueryResult<LayoutDefinition | null> {
+  const { sessionToken } = useSession();
+  const api = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useQuery<LayoutDefinition | null>({
+    queryKey: [
+      ...pageLayoutsKeys.byObject(objectId ?? ''),
+      { resolved: layoutType },
+    ],
+    queryFn: async () => {
+      const listPayload = await queryClient.fetchQuery<LayoutListItem[]>({
+        queryKey: pageLayoutsKeys.list(objectId ?? ''),
+        queryFn: async () => {
+          const payload = await api.get<unknown>(
+            `/api/v1/admin/objects/${objectId}/layouts`,
+          );
+          return unwrapList<LayoutListItem>(payload);
+        },
+      });
+
+      const match =
+        listPayload.find(
+          (l) => l.layoutType === layoutType && l.isDefault,
+        ) ?? listPayload.find((l) => l.layoutType === layoutType);
+
+      if (!match) return null;
+
+      const detail = await queryClient.fetchQuery<LayoutDefinition>({
+        queryKey: pageLayoutsKeys.detail(match.id),
+        queryFn: () =>
+          api.get<LayoutDefinition>(
+            `/api/v1/admin/objects/${objectId}/layouts/${match.id}`,
+          ),
+      });
+
+      return detail.fields.length > 0 ? detail : null;
+    },
+    enabled: Boolean(sessionToken && objectId),
+  });
+}

--- a/apps/web/src/features/records/hooks/queries/useObjectDefinition.ts
+++ b/apps/web/src/features/records/hooks/queries/useObjectDefinition.ts
@@ -1,0 +1,45 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSession } from '@descope/react-sdk';
+import { unwrapList, useApiClient } from '../../../../lib/apiClient.js';
+import { objectDefinitionsKeys } from '../../../../lib/queryKeys.js';
+
+export interface ObjectDefinitionSummary {
+  id: string;
+  apiName: string;
+  label?: string;
+  pluralLabel?: string;
+  isSystem?: boolean;
+  nameFieldId?: string;
+}
+
+/**
+ * Resolve the object definition for a given `apiName` from
+ * `GET /api/v1/admin/objects`.
+ *
+ * The admin list endpoint is the canonical way to translate an `apiName`
+ * (which the records routes use as a path parameter) into the opaque object
+ * id that every layout / pipeline / page-layout endpoint keys off. The raw
+ * list is cached under `objectDefinitionsKeys.all()` so every caller — this
+ * hook, the page builder, the record detail page — shares the same cache
+ * entry; the per-`apiName` match is derived via `select`.
+ */
+export function useObjectDefinition(
+  apiName: string | undefined,
+): UseQueryResult<ObjectDefinitionSummary | null> {
+  const { sessionToken } = useSession();
+  const api = useApiClient();
+
+  return useQuery<
+    ObjectDefinitionSummary[],
+    Error,
+    ObjectDefinitionSummary | null
+  >({
+    queryKey: objectDefinitionsKeys.all(),
+    queryFn: async () => {
+      const payload = await api.get<unknown>('/api/v1/admin/objects');
+      return unwrapList<ObjectDefinitionSummary>(payload);
+    },
+    select: (list) => list.find((o) => o.apiName === apiName) ?? null,
+    enabled: Boolean(sessionToken && apiName),
+  });
+}

--- a/apps/web/src/features/records/hooks/queries/useRecords.ts
+++ b/apps/web/src/features/records/hooks/queries/useRecords.ts
@@ -7,11 +7,26 @@ import { useSession } from '@descope/react-sdk';
 import { useApiClient } from '../../../../lib/apiClient.js';
 import { recordsKeys, type ListParams } from '../../../../lib/queryKeys.js';
 
+export interface RecordField {
+  apiName: string;
+  label: string;
+  fieldType: string;
+  value: unknown;
+}
+
 export interface RecordItem {
   id: string;
   name: string;
   fieldValues: Record<string, unknown>;
+  /**
+   * Label-resolved field projection the API returns alongside raw
+   * `fieldValues`.  Consumers that render a table column per field — the
+   * records list page, the layout-less fallback — rely on this array.  The
+   * Kanban board ignores it and only needs `fieldValues`.
+   */
+  fields?: RecordField[];
   ownerId: string;
+  ownerName?: string;
   pipelineId?: string;
   currentStageId?: string;
   stageEnteredAt?: string;
@@ -21,13 +36,29 @@ export interface RecordItem {
     recordName: string;
   };
   createdAt: string;
+  updatedAt?: string;
+}
+
+export interface RecordsObjectSummary {
+  id: string;
+  apiName: string;
+  label: string;
+  pluralLabel: string;
+  isSystem: boolean;
+  nameFieldId?: string;
+}
+
+export interface RecordsPagination {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
 }
 
 export interface RecordsResponse {
   data: RecordItem[];
-  total: number;
-  page: number;
-  limit: number;
+  pagination: RecordsPagination;
+  object: RecordsObjectSummary;
 }
 
 export interface UseRecordsParams {

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -116,16 +116,19 @@ export const pipelinesKeys = {
  * Keys for the page-layout endpoints.
  *
  * Hierarchy:
- *   ['pageLayouts']                            — invalidate everything
- *   ['pageLayouts', 'object', objectId]        — every layout query for one object
- *   ['pageLayouts', 'object', objectId, 'list']— the list of layouts for one object
- *   ['pageLayouts', 'detail', layoutId]        — one specific layout
- *   ['pageLayouts', 'effective', apiName]      — the effective published layout the record page consumes
+ *   ['pageLayouts']                                        — invalidate everything
+ *   ['pageLayouts', 'object', objectId]                    — every layout query for one object
+ *   ['pageLayouts', 'object', objectId, 'list']            — the list of layouts for one object
+ *   ['pageLayouts', 'object', objectId, 'resolved', type]  — the default-of-type layout for one object
+ *   ['pageLayouts', 'detail', layoutId]                    — one specific layout
+ *   ['pageLayouts', 'effective', apiName]                  — the effective published layout the record page consumes
  */
 export const pageLayoutsKeys = {
   all: () => ['pageLayouts'] as const,
   byObject: (objectId: ObjectDefinitionId) => ['pageLayouts', 'object', objectId] as const,
   list: (objectId: ObjectDefinitionId) => ['pageLayouts', 'object', objectId, 'list'] as const,
+  resolved: (objectId: ObjectDefinitionId, layoutType: string) =>
+    ['pageLayouts', 'object', objectId, 'resolved', layoutType] as const,
   detail: (layoutId: PageLayoutId) => ['pageLayouts', 'detail', layoutId] as const,
   effective: (apiName: ObjectApiName) => ['pageLayouts', 'effective', apiName] as const,
 } as const;

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -1,88 +1,20 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { useSession } from '@descope/react-sdk';
+import { useQuery } from '@tanstack/react-query';
 import { ApiError, useApiClient, unwrapList } from '../lib/apiClient.js';
+import { pipelinesKeys } from '../lib/queryKeys.js';
+import {
+  useRecords,
+  type RecordItem,
+  type RecordField,
+} from '../features/records/hooks/queries/useRecords.js';
+import { useObjectDefinition } from '../features/records/hooks/queries/useObjectDefinition.js';
+import { useLayout } from '../features/records/hooks/queries/useLayout.js';
 import { ApiErrorDisplay } from '../components/ApiErrorDisplay.js';
 import { PrimaryButton } from '../components/PrimaryButton.js';
 import { FieldRenderer } from '../components/FieldRenderer.js';
 import { KanbanBoard } from '../components/KanbanBoard.js';
 import styles from './RecordListPage.module.css';
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface ObjectDefinition {
-  id: string;
-  apiName: string;
-  label: string;
-  pluralLabel: string;
-  isSystem: boolean;
-  nameFieldId?: string;
-}
-
-interface RecordField {
-  apiName: string;
-  label: string;
-  fieldType: string;
-  value: unknown;
-}
-
-interface LinkedParentRecord {
-  objectApiName: string;
-  recordId: string;
-  recordName: string;
-}
-
-interface RecordItem {
-  id: string;
-  name: string;
-  fieldValues: Record<string, unknown>;
-  fields: RecordField[];
-  ownerId: string;
-  ownerName?: string;
-  linkedParent?: LinkedParentRecord;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface PaginationMeta {
-  total: number;
-  limit: number;
-  offset: number;
-  hasMore: boolean;
-}
-
-interface RecordsResponse {
-  data: RecordItem[];
-  pagination: PaginationMeta;
-  object: ObjectDefinition;
-}
-
-interface LayoutFieldWithMetadata {
-  fieldId: string;
-  fieldApiName: string;
-  fieldLabel: string;
-  fieldType: string;
-  sortOrder: number;
-  section: number;
-  width: string;
-}
-
-interface LayoutDefinition {
-  id: string;
-  objectId: string;
-  name: string;
-  layoutType: string;
-  isDefault: boolean;
-  fields: LayoutFieldWithMetadata[];
-}
-
-interface LayoutListItem {
-  id: string;
-  objectId: string;
-  name: string;
-  layoutType: string;
-  isDefault: boolean;
-}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -119,6 +51,29 @@ function getInitials(name: string | undefined): string {
   return (parts[0][0] ?? '?').toUpperCase();
 }
 
+/**
+ * Translate the records query error into the user-facing message the
+ * pre-TQ page rendered. A 404 from `/api/v1/objects/:apiName/records`
+ * means the object type itself doesn't exist; network failures get a
+ * connection hint; everything else is a generic "failed to load".
+ */
+function toDisplayError(error: unknown): ApiError | null {
+  if (!(error instanceof ApiError)) return null;
+  if (error.status === 404) {
+    return new ApiError({ status: 404, message: 'Object type not found.' });
+  }
+  if (error.isNetwork) {
+    return new ApiError({
+      status: 0,
+      message: 'Failed to connect to the server. Please try again.',
+    });
+  }
+  return new ApiError({
+    status: error.status,
+    message: 'Failed to load records.',
+  });
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 interface RecordListPageProps {
@@ -127,51 +82,34 @@ interface RecordListPageProps {
 
 export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   const { apiName } = useParams<{ apiName: string }>();
-  const { sessionToken } = useSession();
   const api = useApiClient();
   const navigate = useNavigate();
 
-  const [records, setRecords] = useState<RecordItem[]>([]);
-  const [objectDef, setObjectDef] = useState<ObjectDefinition | null>(null);
-  const [layoutColumns, setLayoutColumns] = useState<LayoutFieldWithMetadata[] | null>(null);
-  const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [sortBy, setSortBy] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<ApiError | null>(null);
 
   // Pipeline view toggle state
   const [viewMode, setViewMode] = useState<'list' | 'pipeline'>(initialView ?? 'list');
-  const [hasPipeline, setHasPipeline] = useState(false);
-  const [resolvedObjectId, setResolvedObjectId] = useState<string | null>(null);
   // Tracks whether the user has manually chosen a view. Once true we
   // stop auto-flipping to pipeline even if hasPipeline resolves later.
   const userToggledView = useRef(false);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset state when the object changes. Keyed on `apiName` only: a
-  // prop-only change to `initialView` (e.g. same object, switching
-  // between `/objects/:apiName` and `/objects/:apiName/pipeline`) must
-  // NOT clear pipeline state, because the loader that repopulates it
-  // is also keyed only on `apiName` and won't refetch.
+  // Reset *local* page/search/sort when the object changes. Queries are
+  // keyed on `apiName` so their data swaps automatically; we only need to
+  // clear the caller-owned state. `initialView` changes (same object,
+  // routed list → pipeline) must not reset pipeline state because the
+  // queries that populate it are keyed only on `apiName` and won't refetch.
   useEffect(() => {
-    setRecords([]);
-    setObjectDef(null);
-    setLayoutColumns(null);
-    setTotal(0);
     setPage(1);
     setSearch('');
     setDebouncedSearch('');
     setSortBy(null);
     setSortDir('asc');
-    setLoading(true);
-    setError(null);
-    setHasPipeline(false);
-    setResolvedObjectId(null);
     userToggledView.current = false;
     // Always sync viewMode to the current pinned route — otherwise a
     // user who toggled to List before navigating between two pipeline
@@ -180,17 +118,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiName]);
 
-  // Default to the pipeline view for objects that have a pipeline, unless
-  // the caller pinned an initialView or the user has manually toggled.
-  useEffect(() => {
-    if (initialView) return;
-    if (userToggledView.current) return;
-    if (hasPipeline) {
-      setViewMode('pipeline');
-    }
-  }, [hasPipeline, initialView]);
-
-  // Debounce search input
+  // Debounce search input → `debouncedSearch` feeds into the query key.
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value);
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
@@ -206,150 +134,66 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     };
   }, []);
 
-  // Fetch list layout columns and check for pipeline
+  // ── Queries ──────────────────────────────────────────────────
+
+  const objectDefQuery = useObjectDefinition(apiName);
+  const resolvedObjectId = objectDefQuery.data?.id ?? null;
+
+  const layoutQuery = useLayout(resolvedObjectId ?? undefined, 'list');
+
+  // Pipeline existence check — reuse the cached `/api/v1/admin/pipelines`
+  // list so the KanbanBoard (which fetches the same list under the same key)
+  // doesn't trigger a second request.
+  const pipelineListQuery = useQuery({
+    queryKey: pipelinesKeys.list(),
+    queryFn: async () => {
+      const payload = await api.get<unknown>('/api/v1/admin/pipelines');
+      return unwrapList<{ objectId?: string; object_id?: string }>(payload);
+    },
+    enabled: Boolean(resolvedObjectId),
+  });
+  const hasPipeline = useMemo(() => {
+    if (!resolvedObjectId || !pipelineListQuery.data) return false;
+    return pipelineListQuery.data.some(
+      (p) => (p.objectId ?? p.object_id) === resolvedObjectId,
+    );
+  }, [pipelineListQuery.data, resolvedObjectId]);
+
+  const recordsParams = useMemo(() => {
+    const params: Record<string, unknown> = {
+      limit: PAGE_SIZE,
+      offset: (page - 1) * PAGE_SIZE,
+    };
+    const trimmed = debouncedSearch.trim();
+    if (trimmed) params.search = trimmed;
+    if (sortBy) {
+      params.sort_by = sortBy;
+      params.sort_dir = sortDir;
+    }
+    return params;
+  }, [page, debouncedSearch, sortBy, sortDir]);
+
+  const recordsQuery = useRecords(apiName, recordsParams);
+
+  // Default to the pipeline view for objects that have a pipeline, unless
+  // the caller pinned an initialView or the user has manually toggled.
   useEffect(() => {
-    if (!sessionToken || !apiName) return;
+    if (initialView) return;
+    if (userToggledView.current) return;
+    if (hasPipeline) {
+      setViewMode('pipeline');
+    }
+  }, [hasPipeline, initialView]);
 
-    let cancelled = false;
+  // ── Derived view state ────────────────────────────────────────
 
-    const loadLayout = async () => {
-      try {
-        // First get the object definitions to find the object ID
-        const objResponse = await api.request('/api/v1/admin/objects');
+  const records: RecordItem[] = recordsQuery.data?.data ?? [];
+  const total = recordsQuery.data?.pagination.total ?? 0;
+  const objectDef = recordsQuery.data?.object ?? null;
+  const layoutColumns = layoutQuery.data?.fields ?? null;
 
-        if (cancelled) return;
-
-        if (!objResponse.ok) return;
-
-        const allObjects = unwrapList<{
-          id: string;
-          apiName: string;
-        }>(await objResponse.json());
-        const obj = allObjects.find((o) => o.apiName === apiName);
-        if (!obj || cancelled) return;
-
-        // Store the resolved object ID for pipeline view
-        setResolvedObjectId(obj.id);
-
-        // Check for pipeline existence (best-effort)
-        api.request('/api/v1/admin/pipelines')
-          .then((resp) => {
-            if (cancelled || !resp.ok) return null;
-            return resp.json();
-          })
-          .then((pipelines) => {
-            if (cancelled || !pipelines) return;
-            const list = unwrapList<{ objectId?: string; object_id?: string }>(pipelines);
-            const match = list.find(
-              (p) => (p.objectId ?? p.object_id) === obj.id,
-            );
-            if (!cancelled) setHasPipeline(!!match);
-          })
-          .catch(() => { /* best-effort */ });
-
-        // Fetch layouts for this object
-        const layoutsResponse = await api.request(
-          `/api/v1/admin/objects/${obj.id}/layouts`,
-        );
-
-        if (cancelled || !layoutsResponse.ok) return;
-
-        const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
-        const listLayout = layouts.find(
-          (l) => l.layoutType === 'list' && l.isDefault,
-        ) ?? layouts.find((l) => l.layoutType === 'list');
-
-        if (!listLayout || cancelled) return;
-
-        // Fetch the layout detail with fields
-        const layoutDetailResponse = await api.request(
-          `/api/v1/admin/objects/${obj.id}/layouts/${listLayout.id}`,
-        );
-
-        if (cancelled || !layoutDetailResponse.ok) return;
-
-        const layoutDetail = (await layoutDetailResponse.json()) as LayoutDefinition;
-        if (!cancelled && layoutDetail.fields.length > 0) {
-          setLayoutColumns(layoutDetail.fields);
-        }
-      } catch {
-        // Layout fetch is best-effort — fall back to record fields
-      }
-    };
-
-    void loadLayout();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionToken, api, apiName]);
-
-  // Fetch records
-  useEffect(() => {
-    if (!sessionToken || !apiName) return;
-
-    let cancelled = false;
-
-    const load = async () => {
-      setLoading(true);
-      setError(null);
-
-      const params = new URLSearchParams({
-        limit: String(PAGE_SIZE),
-        offset: String((page - 1) * PAGE_SIZE),
-      });
-      if (debouncedSearch.trim()) {
-        params.set('search', debouncedSearch.trim());
-      }
-      if (sortBy) {
-        params.set('sort_by', sortBy);
-        params.set('sort_dir', sortDir);
-      }
-
-      try {
-        const data = await api.get<RecordsResponse>(
-          `/api/v1/objects/${apiName}/records?${params.toString()}`,
-        );
-
-        if (!cancelled) {
-          setRecords(data.data);
-          setTotal(data.pagination.total);
-          setObjectDef(data.object);
-        }
-      } catch (err) {
-        if (cancelled) return;
-        if (err instanceof ApiError) {
-          if (err.status === 404) {
-            setError(
-              new ApiError({ status: 404, message: 'Object type not found.' }),
-            );
-          } else if (err.isNetwork) {
-            setError(
-              new ApiError({
-                status: 0,
-                message: 'Failed to connect to the server. Please try again.',
-              }),
-            );
-          } else {
-            setError(
-              new ApiError({
-                status: err.status,
-                message: 'Failed to load records.',
-              }),
-            );
-          }
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionToken, api, apiName, page, debouncedSearch, sortBy, sortDir]);
+  const loading = recordsQuery.isPending;
+  const error = toDisplayError(recordsQuery.error);
 
   const handleSort = (fieldApiName: string) => {
     if (sortBy === fieldApiName) {
@@ -372,8 +216,8 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
           fieldType: lf.fieldType,
           fieldId: lf.fieldId,
         }))
-      : records.length > 0
-        ? records[0].fields.map((f) => ({
+      : records.length > 0 && records[0].fields
+        ? records[0].fields.map((f: RecordField) => ({
             apiName: f.apiName,
             label: f.label,
             fieldType: f.fieldType,
@@ -553,7 +397,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
               {records.map((record) => {
                 // Build a quick lookup of field values from the record
                 const fieldMap = new Map(
-                  record.fields.map((f) => [f.apiName, f]),
+                  (record.fields ?? []).map((f) => [f.apiName, f]),
                 );
 
                 return (

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -192,7 +192,14 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   const objectDef = recordsQuery.data?.object ?? null;
   const layoutColumns = layoutQuery.data?.fields ?? null;
 
-  const loading = recordsQuery.isPending;
+  // `useRecords` uses `placeholderData: keepPreviousData` so paginating within
+  // the same object doesn't flicker — but when `apiName` changes the
+  // placeholder is for a *different* object. Treat that as loading so we
+  // don't render Account rows under `/objects/contact` while the new query
+  // resolves.
+  const isStaleObject =
+    recordsQuery.data != null && recordsQuery.data.object.apiName !== apiName;
+  const loading = recordsQuery.isPending || isStaleObject;
   const error = toDisplayError(recordsQuery.error);
 
   const handleSort = (fieldApiName: string) => {

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { useSession } from '@descope/react-sdk';
 import { ApiError, useApiClient, unwrapList } from '../lib/apiClient.js';
 import { pipelinesKeys } from '../lib/queryKeys.js';
 import {
@@ -82,6 +83,7 @@ interface RecordListPageProps {
 
 export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   const { apiName } = useParams<{ apiName: string }>();
+  const { sessionToken } = useSession();
   const api = useApiClient();
   const navigate = useNavigate();
 
@@ -105,6 +107,14 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   // routed list → pipeline) must not reset pipeline state because the
   // queries that populate it are keyed only on `apiName` and won't refetch.
   useEffect(() => {
+    // Cancel any in-flight search debounce — otherwise a pending timeout
+    // from typing on the previous object can fire after navigation and
+    // set `debouncedSearch` for the *new* object, triggering an unwanted
+    // filtered fetch.
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
     setPage(1);
     setSearch('');
     setDebouncedSearch('');
@@ -150,7 +160,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
       const payload = await api.get<unknown>('/api/v1/admin/pipelines');
       return unwrapList<{ objectId?: string; object_id?: string }>(payload);
     },
-    enabled: Boolean(resolvedObjectId),
+    enabled: Boolean(sessionToken && resolvedObjectId),
   });
   const hasPipeline = useMemo(() => {
     if (!resolvedObjectId || !pipelineListQuery.data) return false;


### PR DESCRIPTION
## Summary

Replaces the three `useEffect` fetch chains (records / object def / layout) in `RecordListPage` and their local `loading` / `error` state bags with TanStack Query hooks.

- **`useObjectDefinition(apiName)`** — new hook. Resolves an object def by `apiName` from `/api/v1/admin/objects`, caching the full list under `objectDefinitionsKeys.all()` with a `select` filter so every other consumer (page builder, field builder, record detail) shares one cache entry.
- **`useLayout(objectId, 'list')`** — new hook. Fetches the layouts list, picks the default (or first) of the requested `layoutType`, and returns the full layout detail. Each response is cached independently under `pageLayoutsKeys.list(objectId)` / `pageLayoutsKeys.detail(layoutId)`.
- **`useRecords`** types corrected to the real `{data, pagination, object}` envelope and extended with the `fields` / `ownerName` / `updatedAt` the list view renders.
- **Pipeline existence check** now reuses the cached `pipelinesKeys.list()` that `KanbanBoard` already consumes — one request instead of two.

`page`, `search`, `sortBy`, `sortDir` remain local state feeding the records query key. The search input keeps the existing 300 ms debounce so the *query key* updates, not each network call.

Closes #476

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/...` on changed files — clean
- [x] `npx vitest run` — **664 / 664 pass** (RecordListPage 16/16, ViewToggle 5/5, KanbanBoard 27/27, all other suites unchanged)
- [ ] Manual: paginating page 2 → page 1 is instant from cache within `staleTime`
- [ ] Manual: search + sort produce correct results without duplicate requests
- [ ] Manual: view-toggle + pipeline auto-default behaviour unchanged

https://claude.ai/code/session_01PemnMEe5KGTwYfHFdJQZEy