### PR TITLE
TQ: Convert useFieldMutations to useMutation

### DIFF
--- a/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
+++ b/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
@@ -47,6 +47,12 @@ interface ReorderContext {
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err instanceof ApiClientError) {
+    // Surface the canonical "connection failed" copy for network-level
+    // failures — `err.message` in that case is whatever the browser threw
+    // (e.g. "Failed to fetch") and isn't user-friendly.
+    if (err.isNetwork) {
+      return 'Failed to connect to the server. Please try again.';
+    }
     return err.message || fallback;
   }
   return fallback;
@@ -59,19 +65,21 @@ export function useFieldMutations({
   const { sessionToken } = useSession();
   const api = useApiClient();
   const queryClient = useQueryClient();
-  const objectDetailKey = objectDefinitionsKeys.detail(objectId ?? '');
 
-  const invalidateFieldLists = () => {
+  // Key invalidation is driven by the mutation variables (`vars.objectId`)
+  // rather than the closed-over hook argument, so a route-param change
+  // while a mutation is in-flight can't hit the wrong cache entry.
+  const invalidateFieldLists = (targetObjectId: string) => {
     // The field list is currently served by `useFieldDefinitions`, which
     // reads from the object-detail endpoint. Invalidate both that key and
     // the dedicated `fieldDefinitions` namespace so any future hook
     // migrated onto the focused key picks up the change too.
-    void queryClient.invalidateQueries({ queryKey: objectDetailKey });
-    if (objectId) {
-      void queryClient.invalidateQueries({
-        queryKey: fieldDefinitionsKeys.byObject(objectId),
-      });
-    }
+    void queryClient.invalidateQueries({
+      queryKey: objectDefinitionsKeys.detail(targetObjectId),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: fieldDefinitionsKeys.byObject(targetObjectId),
+    });
   };
 
   // ── Field modal state ───────────────────────────────────
@@ -96,7 +104,7 @@ export function useFieldMutations({
       api.post<FieldDefinition>(`/api/v1/admin/objects/${id}/fields`, {
         body: payload,
       }),
-    onSuccess: invalidateFieldLists,
+    onSuccess: (_data, vars) => invalidateFieldLists(vars.objectId),
   });
 
   const updateFieldMutation = useMutation<
@@ -109,7 +117,7 @@ export function useFieldMutations({
         `/api/v1/admin/objects/${id}/fields/${fieldId}`,
         { body: payload },
       ),
-    onSuccess: invalidateFieldLists,
+    onSuccess: (_data, vars) => invalidateFieldLists(vars.objectId),
   });
 
   const deleteFieldMutation = useMutation<
@@ -119,7 +127,7 @@ export function useFieldMutations({
   >({
     mutationFn: ({ objectId: id, fieldId }) =>
       api.del<void>(`/api/v1/admin/objects/${id}/fields/${fieldId}`),
-    onSuccess: invalidateFieldLists,
+    onSuccess: (_data, vars) => invalidateFieldLists(vars.objectId),
   });
 
   const reorderFieldsMutation = useMutation<
@@ -133,43 +141,42 @@ export function useFieldMutations({
         `/api/v1/admin/objects/${id}/fields/reorder`,
         { body: { fieldIds } },
       ),
-    onMutate: async ({ fieldIds }) => {
+    onMutate: async ({ objectId: id, fieldIds }) => {
       // Cancel in-flight refetches so they don't overwrite the optimistic
       // patch, then reorder the cached field array to match the requested
       // id sequence before the round-trip.
-      await queryClient.cancelQueries({ queryKey: objectDetailKey });
+      const detailKey = objectDefinitionsKeys.detail(id);
+      await queryClient.cancelQueries({ queryKey: detailKey });
       const previous =
-        queryClient.getQueryData<ObjectDefinitionDetail>(objectDetailKey);
-      queryClient.setQueryData<ObjectDefinitionDetail>(
-        objectDetailKey,
-        (prev) => {
-          if (!prev) return prev;
-          const byId = new Map(prev.fields.map((f) => [f.id, f]));
-          const reordered = fieldIds
-            .map((fid) => byId.get(fid))
-            .filter((f): f is FieldDefinition => Boolean(f));
-          return { ...prev, fields: reordered };
-        },
-      );
+        queryClient.getQueryData<ObjectDefinitionDetail>(detailKey);
+      queryClient.setQueryData<ObjectDefinitionDetail>(detailKey, (prev) => {
+        if (!prev) return prev;
+        const byId = new Map(prev.fields.map((f) => [f.id, f]));
+        const reordered = fieldIds
+          .map((fid) => byId.get(fid))
+          .filter((f): f is FieldDefinition => Boolean(f));
+        return { ...prev, fields: reordered };
+      });
       return { previous };
     },
-    onError: (_err, _vars, context) => {
+    onError: (_err, vars, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(objectDetailKey, context.previous);
+        queryClient.setQueryData(
+          objectDefinitionsKeys.detail(vars.objectId),
+          context.previous,
+        );
       }
     },
-    onSuccess: (updated) => {
+    onSuccess: (updated, vars) => {
       queryClient.setQueryData<ObjectDefinitionDetail>(
-        objectDetailKey,
+        objectDefinitionsKeys.detail(vars.objectId),
         (prev) => (prev ? { ...prev, fields: updated } : prev),
       );
     },
-    onSettled: () => {
-      if (objectId) {
-        void queryClient.invalidateQueries({
-          queryKey: fieldDefinitionsKeys.byObject(objectId),
-        });
-      }
+    onSettled: (_data, _err, vars) => {
+      void queryClient.invalidateQueries({
+        queryKey: fieldDefinitionsKeys.byObject(vars.objectId),
+      });
     },
   });
 
@@ -375,8 +382,9 @@ export function useFieldMutations({
         fieldIds: newFields.map((f) => f.id),
       });
     } catch {
-      // `onError` already rolled the cache back; surfacing the error is
-      // left to the mutation's state so callers can react if needed.
+      // `onError` already rolled the optimistic patch back. Reorder failures
+      // are intentionally silent — matching the previous behaviour — so we
+      // swallow the rethrow here.
     }
   };
 

--- a/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
+++ b/apps/web/src/features/field-builder/hooks/useFieldMutations.ts
@@ -1,21 +1,55 @@
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient } from '../../../lib/apiClient.js';
-import { objectDefinitionsKeys } from '../../../lib/queryKeys.js';
+import { ApiError as ApiClientError, useApiClient } from '../../../lib/apiClient.js';
+import {
+  fieldDefinitionsKeys,
+  objectDefinitionsKeys,
+} from '../../../lib/queryKeys.js';
 import { slugify } from '../../../utils.js';
 import { buildOptionsPayload, formFromField } from '../helpers.js';
 import { EMPTY_FORM } from '../constants.js';
 import type {
   FieldDefinition,
   FieldForm,
-  ApiError,
   ObjectDefinitionDetail,
 } from '../types.js';
 
 interface UseFieldMutationsOptions {
   objectId: string | undefined;
   fields: FieldDefinition[];
+}
+
+interface CreateFieldVars {
+  objectId: string;
+  payload: Record<string, unknown>;
+}
+
+interface UpdateFieldVars {
+  objectId: string;
+  fieldId: string;
+  payload: Record<string, unknown>;
+}
+
+interface DeleteFieldVars {
+  objectId: string;
+  fieldId: string;
+}
+
+interface ReorderFieldsVars {
+  objectId: string;
+  fieldIds: string[];
+}
+
+interface ReorderContext {
+  previous: ObjectDefinitionDetail | undefined;
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiClientError) {
+    return err.message || fallback;
+  }
+  return fallback;
 }
 
 export function useFieldMutations({
@@ -27,21 +61,117 @@ export function useFieldMutations({
   const queryClient = useQueryClient();
   const objectDetailKey = objectDefinitionsKeys.detail(objectId ?? '');
 
+  const invalidateFieldLists = () => {
+    // The field list is currently served by `useFieldDefinitions`, which
+    // reads from the object-detail endpoint. Invalidate both that key and
+    // the dedicated `fieldDefinitions` namespace so any future hook
+    // migrated onto the focused key picks up the change too.
+    void queryClient.invalidateQueries({ queryKey: objectDetailKey });
+    if (objectId) {
+      void queryClient.invalidateQueries({
+        queryKey: fieldDefinitionsKeys.byObject(objectId),
+      });
+    }
+  };
+
   // ── Field modal state ───────────────────────────────────
   const [showFieldModal, setShowFieldModal] = useState(false);
   const [editingField, setEditingField] = useState<FieldDefinition | null>(null);
   const [fieldForm, setFieldForm] = useState<FieldForm>({ ...EMPTY_FORM });
   const [apiNameEdited, setApiNameEdited] = useState(false);
   const [fieldModalError, setFieldModalError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
 
   // ── Delete field state ──────────────────────────────────
   const [deleteTarget, setDeleteTarget] = useState<FieldDefinition | null>(null);
-  const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  // ── Reorder state ───────────────────────────────────────
-  const [reordering, setReordering] = useState(false);
+  // ── Mutations ───────────────────────────────────────────
+
+  const createFieldMutation = useMutation<
+    FieldDefinition,
+    ApiClientError,
+    CreateFieldVars
+  >({
+    mutationFn: ({ objectId: id, payload }) =>
+      api.post<FieldDefinition>(`/api/v1/admin/objects/${id}/fields`, {
+        body: payload,
+      }),
+    onSuccess: invalidateFieldLists,
+  });
+
+  const updateFieldMutation = useMutation<
+    FieldDefinition,
+    ApiClientError,
+    UpdateFieldVars
+  >({
+    mutationFn: ({ objectId: id, fieldId, payload }) =>
+      api.put<FieldDefinition>(
+        `/api/v1/admin/objects/${id}/fields/${fieldId}`,
+        { body: payload },
+      ),
+    onSuccess: invalidateFieldLists,
+  });
+
+  const deleteFieldMutation = useMutation<
+    void,
+    ApiClientError,
+    DeleteFieldVars
+  >({
+    mutationFn: ({ objectId: id, fieldId }) =>
+      api.del<void>(`/api/v1/admin/objects/${id}/fields/${fieldId}`),
+    onSuccess: invalidateFieldLists,
+  });
+
+  const reorderFieldsMutation = useMutation<
+    FieldDefinition[],
+    ApiClientError,
+    ReorderFieldsVars,
+    ReorderContext
+  >({
+    mutationFn: ({ objectId: id, fieldIds }) =>
+      api.patch<FieldDefinition[]>(
+        `/api/v1/admin/objects/${id}/fields/reorder`,
+        { body: { fieldIds } },
+      ),
+    onMutate: async ({ fieldIds }) => {
+      // Cancel in-flight refetches so they don't overwrite the optimistic
+      // patch, then reorder the cached field array to match the requested
+      // id sequence before the round-trip.
+      await queryClient.cancelQueries({ queryKey: objectDetailKey });
+      const previous =
+        queryClient.getQueryData<ObjectDefinitionDetail>(objectDetailKey);
+      queryClient.setQueryData<ObjectDefinitionDetail>(
+        objectDetailKey,
+        (prev) => {
+          if (!prev) return prev;
+          const byId = new Map(prev.fields.map((f) => [f.id, f]));
+          const reordered = fieldIds
+            .map((fid) => byId.get(fid))
+            .filter((f): f is FieldDefinition => Boolean(f));
+          return { ...prev, fields: reordered };
+        },
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(objectDetailKey, context.previous);
+      }
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ObjectDefinitionDetail>(
+        objectDetailKey,
+        (prev) => (prev ? { ...prev, fields: updated } : prev),
+      );
+    },
+    onSettled: () => {
+      if (objectId) {
+        void queryClient.invalidateQueries({
+          queryKey: fieldDefinitionsKeys.byObject(objectId),
+        });
+      }
+    },
+  });
 
   // ── Field modal handlers ────────────────────────────────
 
@@ -167,8 +297,6 @@ export function useFieldMutations({
       }
     }
 
-    setSaving(true);
-
     const options = buildOptionsPayload(fieldForm);
 
     const payload: Record<string, unknown> = {
@@ -188,43 +316,18 @@ export function useFieldMutations({
 
     try {
       if (editingField) {
-        const response = await api.request(
-          `/api/v1/admin/objects/${objectId}/fields/${editingField.id}`,
-          {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          },
-        );
-
-        if (response.ok) {
-          setShowFieldModal(false);
-          await queryClient.invalidateQueries({ queryKey: objectDetailKey });
-        } else {
-          const data = (await response.json()) as ApiError;
-          setFieldModalError(data.error ?? 'An unexpected error occurred');
-        }
+        await updateFieldMutation.mutateAsync({
+          objectId,
+          fieldId: editingField.id,
+          payload,
+        });
       } else {
         payload.apiName = trimmedApiName;
-
-        const response = await api.request(`/api/v1/admin/objects/${objectId}/fields`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        });
-
-        if (response.ok) {
-          setShowFieldModal(false);
-          await queryClient.invalidateQueries({ queryKey: objectDetailKey });
-        } else {
-          const data = (await response.json()) as ApiError;
-          setFieldModalError(data.error ?? 'An unexpected error occurred');
-        }
+        await createFieldMutation.mutateAsync({ objectId, payload });
       }
-    } catch {
-      setFieldModalError('Failed to connect to the server. Please try again.');
-    } finally {
-      setSaving(false);
+      setShowFieldModal(false);
+    } catch (err) {
+      setFieldModalError(errorMessage(err, 'An unexpected error occurred'));
     }
   };
 
@@ -243,26 +346,15 @@ export function useFieldMutations({
   const handleDelete = async () => {
     if (!deleteTarget || !sessionToken || !objectId) return;
 
-    setDeleting(true);
     setDeleteError(null);
-
     try {
-      const response = await api.request(
-        `/api/v1/admin/objects/${objectId}/fields/${deleteTarget.id}`,
-        { method: 'DELETE' },
-      );
-
-      if (response.ok || response.status === 204) {
-        setDeleteTarget(null);
-        await queryClient.invalidateQueries({ queryKey: objectDetailKey });
-      } else {
-        const data = (await response.json()) as ApiError;
-        setDeleteError(data.error ?? 'Failed to delete field');
-      }
-    } catch {
-      setDeleteError('Failed to connect to the server. Please try again.');
-    } finally {
-      setDeleting(false);
+      await deleteFieldMutation.mutateAsync({
+        objectId,
+        fieldId: deleteTarget.id,
+      });
+      setDeleteTarget(null);
+    } catch (err) {
+      setDeleteError(errorMessage(err, 'Failed to delete field'));
     }
   };
 
@@ -277,35 +369,14 @@ export function useFieldMutations({
     const newFields = [...fields];
     [newFields[index], newFields[swapIndex]] = [newFields[swapIndex], newFields[index]];
 
-    // Optimistically patch the cached object detail so the reorder is
-    // reflected immediately — reverting on failure below.
-    const previousDetail = queryClient.getQueryData<ObjectDefinitionDetail>(objectDetailKey);
-    queryClient.setQueryData<ObjectDefinitionDetail>(objectDetailKey, (prev) =>
-      prev ? { ...prev, fields: newFields } : prev,
-    );
-
-    setReordering(true);
     try {
-      const response = await api.request(`/api/v1/admin/objects/${objectId}/fields/reorder`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fieldIds: newFields.map((f) => f.id) }),
+      await reorderFieldsMutation.mutateAsync({
+        objectId,
+        fieldIds: newFields.map((f) => f.id),
       });
-
-      if (response.ok) {
-        const updated = (await response.json()) as FieldDefinition[];
-        queryClient.setQueryData<ObjectDefinitionDetail>(objectDetailKey, (prev) =>
-          prev ? { ...prev, fields: updated } : prev,
-        );
-      } else if (previousDetail) {
-        queryClient.setQueryData(objectDetailKey, previousDetail);
-      }
     } catch {
-      if (previousDetail) {
-        queryClient.setQueryData(objectDetailKey, previousDetail);
-      }
-    } finally {
-      setReordering(false);
+      // `onError` already rolled the cache back; surfacing the error is
+      // left to the mutation's state so callers can react if needed.
     }
   };
 
@@ -315,7 +386,7 @@ export function useFieldMutations({
     editingField,
     fieldForm,
     fieldModalError,
-    saving,
+    saving: createFieldMutation.isPending || updateFieldMutation.isPending,
     openAddFieldModal,
     openEditFieldModal,
     closeFieldModal,
@@ -327,13 +398,13 @@ export function useFieldMutations({
     handleFieldSubmit,
     // Field delete
     deleteTarget,
-    deleting,
+    deleting: deleteFieldMutation.isPending,
     deleteError,
     openDeleteConfirm,
     closeDeleteConfirm,
     handleDelete,
     // Reorder
-    reordering,
+    reordering: reorderFieldsMutation.isPending,
     handleMoveField,
   };
 }


### PR DESCRIPTION
## Summary
Replaces the hand-rolled loading flags and ad-hoc `fetch` calls in `useFieldMutations` with TanStack `useMutation`, so the field builder participates in the query lifecycle (success / error / invalidation).

## Changes
- `createFieldMutation` / `updateFieldMutation` / `deleteFieldMutation`: invalidate the object-detail key (the current source of the field list) plus `fieldDefinitionsKeys.byObject` on success, so any future focused hook on that key picks up the change without another pass.
- `reorderFieldsMutation`: cancel in-flight refetches, snapshot and optimistically reorder the cached field array, roll back on failure, then merge the authoritative server response. Invalidates `fieldDefinitionsKeys.byObject` on settle.
- `saving` / `deleting` / `reordering` flags now derive from mutation `isPending` — no more parallel `useState` tracking.
- Modal / form state remains local (`showFieldModal`, `editingField`, `fieldForm`, validation errors) per the acceptance criteria.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing unrelated warnings)
- [x] `npx vitest run` — 665 / 665 passing, including the 45 `FieldBuilderPage.test.tsx` cases that exercise create / edit / delete / reorder flows

Closes #478.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuAJ7SC9yRcCfSdW1HLC9g)_