### PR TITLE
TQ: migrate useRecord (record detail) to TanStack Query

### DIFF
--- a/apps/web/src/features/record-detail/hooks/useRecord.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecord.ts
@@ -25,7 +25,7 @@ interface UseRecordResult {
   api: ReturnType<typeof useApiClient>;
   sessionToken: string | undefined;
   loadRecord: () => Promise<void>;
-  setRecord: Dispatch<SetStateAction<RecordDetail | null>>;
+  setRecord: Dispatch<SetStateAction<RecordDetail>>;
 }
 
 /**
@@ -42,7 +42,7 @@ export function useRecord(
   apiName: string | undefined,
   id: string | undefined,
 ): UseRecordResult {
-  const { sessionToken } = useSession();
+  const { sessionToken, isSessionLoading } = useSession();
   const api = useApiClient();
   const queryClient = useQueryClient();
 
@@ -107,21 +107,29 @@ export function useRecord(
 
   // Mirror the pre-TQ contract: `loading` gates the whole page on the
   // primary record fetch. Object-definition / layout queries fill in
-  // progressively and never block the initial render.
-  const loading = recordEnabled && recordQuery.isPending;
+  // progressively and never block the initial render. Treat "routing
+  // params present but Descope is still resolving the session token" as
+  // loading too, otherwise the page briefly renders "Record not found."
+  // while the SDK finishes refreshing.
+  const loading =
+    (Boolean(apiName && id) && !sessionToken && isSessionLoading) ||
+    (recordEnabled && recordQuery.isPending);
 
   const loadRecord = useCallback(async () => {
     if (!apiName || !id) return;
     await queryClient.invalidateQueries({ queryKey: recordKey });
   }, [queryClient, recordKey, apiName, id]);
 
-  const setRecord = useCallback<Dispatch<SetStateAction<RecordDetail | null>>>(
+  // Narrowed to non-null — callers only patch after we already have a
+  // record (see `handleStageChanged` in RecordDetailPage), so we never
+  // want to write `null` into the detail cache slot typed as
+  // `RecordDetail`.
+  const setRecord = useCallback<Dispatch<SetStateAction<RecordDetail>>>(
     (value) => {
-      queryClient.setQueryData<RecordDetail | null>(recordKey, (current) => {
+      queryClient.setQueryData<RecordDetail>(recordKey, (current) => {
+        if (current === undefined) return current;
         if (typeof value === 'function') {
-          return (value as (prev: RecordDetail | null) => RecordDetail | null)(
-            current ?? null,
-          );
+          return (value as (prev: RecordDetail) => RecordDetail)(current);
         }
         return value;
       });

--- a/apps/web/src/features/record-detail/hooks/useRecord.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecord.ts
@@ -1,14 +1,17 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from '@descope/react-sdk';
-import { useApiClient, unwrapList } from '../../../lib/apiClient.js';
+import { ApiError, useApiClient } from '../../../lib/apiClient.js';
+import { recordsKeys } from '../../../lib/queryKeys.js';
 import { usePageLayout } from '../../../usePageLayout.js';
+import { useObjectDefinition } from '../../records/hooks/queries/useObjectDefinition.js';
+import { useLayout } from '../../records/hooks/queries/useLayout.js';
 import { groupFieldsBySection } from '../helpers.js';
 import type {
+  LayoutFieldWithMetadata,
+  LayoutSection,
   ObjectDefinition,
   RecordDetail,
-  LayoutListItem,
-  LayoutDefinition,
-  LayoutSection,
 } from '../types.js';
 import type { PageLayout } from '../../../components/layoutTypes.js';
 
@@ -22,117 +25,112 @@ interface UseRecordResult {
   api: ReturnType<typeof useApiClient>;
   sessionToken: string | undefined;
   loadRecord: () => Promise<void>;
-  setRecord: React.Dispatch<React.SetStateAction<RecordDetail | null>>;
+  setRecord: Dispatch<SetStateAction<RecordDetail | null>>;
 }
 
+/**
+ * Composes the three queries a record-detail page needs (record + object
+ * definition + form layout) into a single hook.
+ *
+ * Each query is cached under its shared key factory entry so unrelated
+ * record pages share the object-definition list, the layout list, and the
+ * layout detail rather than re-fetching them per-mount. `loadRecord`
+ * invalidates only the record detail so save/delete/related-create flows
+ * refresh the visible data without bouncing the form-layout request.
+ */
 export function useRecord(
   apiName: string | undefined,
   id: string | undefined,
 ): UseRecordResult {
   const { sessionToken } = useSession();
   const api = useApiClient();
+  const queryClient = useQueryClient();
 
-  const [record, setRecord] = useState<RecordDetail | null>(null);
-  const [objectDef, setObjectDef] = useState<ObjectDefinition | null>(null);
-  const [layoutSections, setLayoutSections] = useState<LayoutSection[] | null>(
-    null,
-  );
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const recordKey = recordsKeys.detail(apiName ?? '', id ?? '');
+  const recordEnabled = Boolean(sessionToken && apiName && id);
+
+  const recordQuery = useQuery<RecordDetail, ApiError>({
+    queryKey: recordKey,
+    queryFn: () =>
+      api.get<RecordDetail>(
+        `/api/v1/objects/${apiName}/records/${id}`,
+      ),
+    enabled: recordEnabled,
+  });
+
+  const objectDefQuery = useObjectDefinition(apiName);
+  const objectDefData = objectDefQuery.data;
+  const objectDef = useMemo<ObjectDefinition | null>(() => {
+    if (!objectDefData) return null;
+    return {
+      id: objectDefData.id,
+      apiName: objectDefData.apiName,
+      label: objectDefData.label ?? objectDefData.apiName,
+      pluralLabel: objectDefData.pluralLabel ?? objectDefData.apiName,
+      isSystem: objectDefData.isSystem ?? false,
+    };
+  }, [objectDefData]);
 
   const { layout: pageLayout } = usePageLayout(apiName);
 
-  const loadRecord = useCallback(async () => {
-    if (!sessionToken || !apiName || !id) return;
+  const formLayoutQuery = useLayout(objectDefData?.id, 'form');
+  const layoutSections = useMemo<LayoutSection[] | null>(() => {
+    const layout = formLayoutQuery.data;
+    if (!layout || layout.fields.length === 0) return null;
+    const fields: LayoutFieldWithMetadata[] = layout.fields.map((lf) => ({
+      fieldId: lf.fieldId,
+      fieldApiName: lf.fieldApiName,
+      fieldLabel: lf.fieldLabel,
+      fieldType: lf.fieldType,
+      fieldRequired: lf.fieldRequired ?? false,
+      fieldOptions: lf.fieldOptions ?? {},
+      sortOrder: lf.sortOrder,
+      section: lf.section,
+      sectionLabel: lf.sectionLabel,
+      width: lf.width,
+    }));
+    return groupFieldsBySection(fields);
+  }, [formLayoutQuery.data]);
 
-    setLoading(true);
-    setLoadError(null);
-
-    try {
-      const response = await api.request(
-        `/api/v1/objects/${apiName}/records/${id}`,
-      );
-
-      if (response.ok) {
-        const data = (await response.json()) as RecordDetail;
-        setRecord(data);
-
-        const objResponse = await api.request('/api/v1/admin/objects');
-        if (objResponse.ok) {
-          const allObjects = unwrapList<ObjectDefinition>(await objResponse.json());
-          const obj = allObjects.find((o) => o.apiName === apiName);
-          if (obj) setObjectDef(obj);
-        }
-      } else if (response.status === 404) {
-        setLoadError('Record not found.');
-      } else {
-        setLoadError('Failed to load record.');
+  const loadError = useMemo<string | null>(() => {
+    const err = recordQuery.error;
+    if (!err) return null;
+    if (err instanceof ApiError) {
+      if (err.status === 404) return 'Record not found.';
+      if (err.isNetwork) {
+        return 'Failed to connect to the server. Please try again.';
       }
-    } catch {
-      setLoadError('Failed to connect to the server. Please try again.');
-    } finally {
-      setLoading(false);
+      return 'Failed to load record.';
     }
-  }, [sessionToken, api, apiName, id]);
+    return 'Failed to connect to the server. Please try again.';
+  }, [recordQuery.error]);
 
-  useEffect(() => {
-    void loadRecord();
-  }, [loadRecord]);
+  // Mirror the pre-TQ contract: `loading` gates the whole page on the
+  // primary record fetch. Object-definition / layout queries fill in
+  // progressively and never block the initial render.
+  const loading = recordEnabled && recordQuery.isPending;
 
-  // Load form layout
-  useEffect(() => {
-    if (!sessionToken || !apiName) return;
+  const loadRecord = useCallback(async () => {
+    if (!apiName || !id) return;
+    await queryClient.invalidateQueries({ queryKey: recordKey });
+  }, [queryClient, recordKey, apiName, id]);
 
-    let cancelled = false;
-
-    const loadLayout = async () => {
-      try {
-        const objResponse = await api.request('/api/v1/admin/objects');
-        if (cancelled || !objResponse.ok) return;
-
-        const allObjects = unwrapList<{
-          id: string;
-          apiName: string;
-        }>(await objResponse.json());
-        const obj = allObjects.find((o) => o.apiName === apiName);
-        if (!obj || cancelled) return;
-
-        const layoutsResponse = await api.request(
-          `/api/v1/admin/objects/${obj.id}/layouts`,
-        );
-        if (cancelled || !layoutsResponse.ok) return;
-
-        const layouts = unwrapList<LayoutListItem>(await layoutsResponse.json());
-        const formLayout =
-          layouts.find((l) => l.layoutType === 'form' && l.isDefault) ??
-          layouts.find((l) => l.layoutType === 'form');
-
-        if (!formLayout || cancelled) return;
-
-        const layoutDetailResponse = await api.request(
-          `/api/v1/admin/objects/${obj.id}/layouts/${formLayout.id}`,
-        );
-        if (cancelled || !layoutDetailResponse.ok) return;
-
-        const layoutDetail =
-          (await layoutDetailResponse.json()) as LayoutDefinition;
-        if (!cancelled && layoutDetail.fields.length > 0) {
-          setLayoutSections(groupFieldsBySection(layoutDetail.fields));
+  const setRecord = useCallback<Dispatch<SetStateAction<RecordDetail | null>>>(
+    (value) => {
+      queryClient.setQueryData<RecordDetail | null>(recordKey, (current) => {
+        if (typeof value === 'function') {
+          return (value as (prev: RecordDetail | null) => RecordDetail | null)(
+            current ?? null,
+          );
         }
-      } catch {
-        // Layout fetch is best-effort — fall back to record fields
-      }
-    };
-
-    void loadLayout();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionToken, api, apiName]);
+        return value;
+      });
+    },
+    [queryClient, recordKey],
+  );
 
   return {
-    record,
+    record: recordQuery.data ?? null,
     objectDef,
     layoutSections,
     pageLayout,

--- a/apps/web/src/features/records/hooks/queries/useLayout.ts
+++ b/apps/web/src/features/records/hooks/queries/useLayout.ts
@@ -15,6 +15,11 @@ export interface LayoutFieldWithMetadata {
   sortOrder: number;
   section: number;
   width: string;
+  // The backend also returns these on form layouts; list-layout callers
+  // ignore them, record-detail callers depend on them.
+  fieldRequired?: boolean;
+  fieldOptions?: Record<string, unknown>;
+  sectionLabel?: string;
 }
 
 export interface LayoutDefinition {


### PR DESCRIPTION
## Summary
- Replaces `useState`/`useEffect` + `let cancelled = false` plumbing in `features/record-detail/hooks/useRecord.ts` with three cooperative TanStack Query hooks: record detail (`recordsKeys.detail`), shared `useObjectDefinition`, and shared `useLayout(objectId, 'form')`.
- `loadRecord` now invalidates only the record-detail key; `setRecord` writes through `queryClient.setQueryData` so stage patches surface immediately. Back-navigation within staleTime hits cache for record + object def + layout (acceptance criterion).
- Widens `LayoutFieldWithMetadata` in the shared `useLayout` hook with optional `fieldRequired` / `fieldOptions` / `sectionLabel` (the backend already returns them) so the record-detail path can consume the shared layout cache without casting.

## Test plan
- [x] `npm run typecheck` (apps/web) — clean
- [x] `npm run lint` (apps/web) — no new warnings
- [x] `npx vitest run` (apps/web) — 665/665 tests pass, including all 25 RecordDetailPage tests
- [ ] Manual: open a record → navigate to list → navigate back; second mount should not hit `/records/:id`, `/admin/objects`, or `/admin/objects/:id/layouts*` within the 5-minute staleTime
- [ ] Manual: edit + save a record → detail refreshes; layout request is NOT re-issued
- [ ] Manual: 404 on unknown id still renders "Record not found."

Closes #479.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPRGxw8K44pt4eizdg3C2S)_