### PR TITLE
chore(web): drop unused exports/types from migrated record-detail hooks

### DIFF
--- a/apps/web/src/features/record-detail/hooks/useRecord.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecord.ts
@@ -22,8 +22,6 @@ interface UseRecordResult {
   pageLayout: PageLayout | null;
   loading: boolean;
   loadError: string | null;
-  api: ReturnType<typeof useApiClient>;
-  sessionToken: string | undefined;
   loadRecord: () => Promise<void>;
   setRecord: Dispatch<SetStateAction<RecordDetail>>;
 }
@@ -144,8 +142,6 @@ export function useRecord(
     pageLayout,
     loading,
     loadError,
-    api,
-    sessionToken,
     loadRecord,
     setRecord,
   };

--- a/apps/web/src/features/record-detail/hooks/useRecordEdit.ts
+++ b/apps/web/src/features/record-detail/hooks/useRecordEdit.ts
@@ -9,7 +9,6 @@ interface UseRecordEditResult {
   saveError: string | null;
   saveSuccess: boolean;
   setSaveError: (error: string | null) => void;
-  setSaveSuccess: (success: boolean) => void;
   handleEditClick: () => void;
   handleCancelClick: () => void;
   handleFieldChange: (fieldApiName: string, value: unknown) => void;
@@ -133,7 +132,6 @@ export function useRecordEdit(
     saveError,
     saveSuccess,
     setSaveError,
-    setSaveSuccess,
     handleEditClick,
     handleCancelClick,
     handleFieldChange,

--- a/apps/web/src/features/record-detail/types.ts
+++ b/apps/web/src/features/record-detail/types.ts
@@ -62,23 +62,6 @@ export interface LayoutFieldWithMetadata {
   width: string;
 }
 
-export interface LayoutDefinition {
-  id: string;
-  objectId: string;
-  name: string;
-  layoutType: string;
-  isDefault: boolean;
-  fields: LayoutFieldWithMetadata[];
-}
-
-export interface LayoutListItem {
-  id: string;
-  objectId: string;
-  name: string;
-  layoutType: string;
-  isDefault: boolean;
-}
-
 export interface LayoutSection {
   label: string;
   fields: LayoutFieldWithMetadata[];


### PR DESCRIPTION
## Summary

Sweep follow-up to the TanStack Query migrations. The `useRecord` and `useRecordEdit` hooks (and `record-detail/types.ts`) were ported piecemeal but kept returning surfaces that no consumer destructures, and duplicating types now defined in the canonical query module.

- **`useRecord`** — drop `api` and `sessionToken` from `UseRecordResult`. Both are still needed inside the hook for the query, but no caller consumes them.
- **`useRecordEdit`** — drop `setSaveSuccess` from `UseRecordEditResult`. `RecordDetailPage` only ever uses `setSaveError`; the success flag is fully managed inside the hook.
- **`record-detail/types.ts`** — delete the `LayoutDefinition` and `LayoutListItem` interfaces. The pre-migration `useRecord` was the only importer; the canonical definitions now live in `features/records/hooks/queries/useLayout.ts`.

## Scope check

Per the issue's grep checklist:
- `useState<.*loading>` / `useState<.*error>` pairs in migrated files: none found.
- `let cancelled = false` patterns in migrated files: none found (all remaining instances live in modules still on the manual-fetch path).
- Unused types/imports: addressed above.

Closes #481

## Test plan

- [x] `npm run typecheck` (web) — passes
- [x] `npm run lint` (web) — only pre-existing warnings, none in touched files
- [x] `npm test` (web) — 666 / 666 passing

https://claude.ai/code/session_01J2683UiEt9Urf82VVCHprz

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2683UiEt9Urf82VVCHprz)_