### PR TITLE
feat(web): add route-level React error boundaries (#380)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^6.1.1",
     "react-router-dom": "^7.14.0"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,8 @@ import { AdminTargetsPage } from './pages/AdminTargetsPage.js';
 import { ProtectedRoute } from './components/ProtectedRoute.js';
 import { TenantGuard } from './components/TenantGuard.js';
 import { AppShell } from './components/AppShell.js';
+import { GlobalErrorBoundary } from './components/GlobalErrorBoundary.js';
+import { RouteErrorBoundary } from './components/RouteErrorBoundary.js';
 
 function OpportunityDetailRedirect() {
   const { id } = useParams<{ id: string }>();
@@ -42,10 +44,12 @@ function OpportunityDetailRedirect() {
 
 export function App() {
   return (
+    <GlobalErrorBoundary>
     <BrowserRouter>
       <SessionSync />
       <QueryClientProvider client={queryClient}>
       <TenantSettingsProvider>
+      <RouteErrorBoundary>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/unauthorized" element={<UnauthorizedPage />} />
@@ -345,9 +349,11 @@ export function App() {
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      </RouteErrorBoundary>
       </TenantSettingsProvider>
       {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </BrowserRouter>
+    </GlobalErrorBoundary>
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,7 +34,6 @@ import { AdminTargetsPage } from './pages/AdminTargetsPage.js';
 import { ProtectedRoute } from './components/ProtectedRoute.js';
 import { TenantGuard } from './components/TenantGuard.js';
 import { AppShell } from './components/AppShell.js';
-import { GlobalErrorBoundary } from './components/GlobalErrorBoundary.js';
 import { RouteErrorBoundary } from './components/RouteErrorBoundary.js';
 
 function OpportunityDetailRedirect() {
@@ -44,7 +43,6 @@ function OpportunityDetailRedirect() {
 
 export function App() {
   return (
-    <GlobalErrorBoundary>
     <BrowserRouter>
       <SessionSync />
       <QueryClientProvider client={queryClient}>
@@ -354,6 +352,5 @@ export function App() {
       {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </BrowserRouter>
-    </GlobalErrorBoundary>
   );
 }

--- a/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
+++ b/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
@@ -37,15 +37,26 @@ function Thrower({ shouldThrow, message = 'boom' }: { shouldThrow: boolean; mess
 
 describe('RouteErrorBoundary', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let originalClipboardDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     vi.mocked(logger.error).mockClear();
     // React logs caught errors to console.error; silence the expected noise.
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Capture the original clipboard descriptor so tests that mutate it can
+    // restore exactly what was there (JSDOM environment is shared across tests).
+    originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+    } else {
+      // Remove any property tests added on a clean environment.
+      // `delete` on a non-configurable property is a no-op, which is fine here.
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
   });
 
   it('renders children when no error is thrown', () => {

--- a/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
+++ b/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
@@ -191,4 +191,45 @@ describe('RouteErrorBoundary', () => {
     expect(copiedText).toContain('clipboard test');
     expect(await screen.findByRole('status')).toHaveTextContent('Copied');
   });
+
+  it('does not show "Copied" when the clipboard API is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow message="no clipboard" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy error/i }));
+
+    // Give any queued microtasks / timers a chance to settle.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('does not show "Copied" when the clipboard write rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow message="rejected" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy error/i }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
+++ b/apps/web/src/__tests__/RouteErrorBoundary.test.tsx
@@ -1,0 +1,194 @@
+import { type ReactElement } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import { RouteErrorBoundary } from '../components/RouteErrorBoundary.js';
+
+vi.mock('@descope/react-sdk', () => ({
+  useUser: vi.fn(() => ({ user: { userId: 'user-1', email: 'alice@example.com' } })),
+  useSession: vi.fn(() => ({ sessionToken: null, isAuthenticated: true, isSessionLoading: false })),
+}));
+
+vi.mock('../store/tenant.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store/tenant.js')>();
+  return {
+    ...actual,
+    useTenant: vi.fn(() => ({ tenantId: 'tenant-1', tenantName: 'Acme' })),
+  };
+});
+
+vi.mock('../lib/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const { logger } = await import('../lib/logger.js');
+
+function Thrower({ shouldThrow, message = 'boom' }: { shouldThrow: boolean; message?: string }) {
+  if (shouldThrow) {
+    throw new Error(message);
+  }
+  return <div>Child content</div>;
+}
+
+describe('RouteErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(logger.error).mockClear();
+    // React logs caught errors to console.error; silence the expected noise.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow={false} />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+    expect(screen.queryByTestId('route-error-fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback when a child throws', () => {
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow message="kaboom" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('route-error-fallback')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Something went wrong on this page/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Reload/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy error/i })).toBeInTheDocument();
+  });
+
+  it('reports the error through the logger with route and user context', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/users']}>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow message="kaboom" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    const [, context] = vi.mocked(logger.error).mock.calls[0];
+    expect(context).toMatchObject({
+      route: '/admin/users',
+      errorName: 'Error',
+      errorMessage: 'kaboom',
+      userId: 'user-1',
+      userEmail: 'alice@example.com',
+      tenantId: 'tenant-1',
+    });
+    expect(typeof (context as Record<string, unknown>).componentStack).toBe('string');
+  });
+
+  it('recovers when the user clicks "Try again" and the child stops throwing', async () => {
+    function Harness() {
+      return (
+        <MemoryRouter>
+          <RouteErrorBoundary>
+            <ConditionalThrower />
+          </RouteErrorBoundary>
+        </MemoryRouter>
+      );
+    }
+
+    let shouldThrow = true;
+    function ConditionalThrower() {
+      if (shouldThrow) {
+        throw new Error('first render boom');
+      }
+      return <div>Recovered content</div>;
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByTestId('route-error-fallback')).toBeInTheDocument();
+
+    // Stop throwing, then reset the boundary via the button.
+    shouldThrow = false;
+    await userEvent.click(screen.getByRole('button', { name: /Try again/i }));
+
+    expect(screen.getByText('Recovered content')).toBeInTheDocument();
+    expect(screen.queryByTestId('route-error-fallback')).not.toBeInTheDocument();
+  });
+
+  it('resets automatically when the route changes', async () => {
+    function PageA(): ReactElement {
+      throw new Error('page A failed');
+    }
+    function PageB() {
+      return <div>Page B content</div>;
+    }
+    function NavigateAway() {
+      const navigate = useNavigate();
+      return (
+        <button type="button" onClick={() => navigate('/b')}>
+          Go to B
+        </button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/a']}>
+        <NavigateAway />
+        <RouteErrorBoundary>
+          <Routes>
+            <Route path="/a" element={<PageA />} />
+            <Route path="/b" element={<PageB />} />
+          </Routes>
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('route-error-fallback')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Go to B/i }));
+
+    expect(screen.getByText('Page B content')).toBeInTheDocument();
+    expect(screen.queryByTestId('route-error-fallback')).not.toBeInTheDocument();
+  });
+
+  it('copies error details to the clipboard when "Copy error" is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <Thrower shouldThrow message="clipboard test" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy error/i }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copiedText = writeText.mock.calls[0][0] as string;
+    expect(copiedText).toContain('Error');
+    expect(copiedText).toContain('clipboard test');
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied');
+  });
+});

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../store/useTheme.js';
 import { clearServerSession } from '../lib/apiClient.js';
 import { ProfileDropdown } from './ProfileDropdown.js';
 import { ObjectTabs } from './ObjectTabs.js';
+import { RouteErrorBoundary } from './RouteErrorBoundary.js';
 import styles from './AppShell.module.css';
 
 interface AppShellProps {
@@ -108,7 +109,9 @@ export function AppShell({ children }: AppShellProps) {
       <ObjectTabs />
 
       <main className={styles.content}>
-        <div className={styles.contentContainer}>{children}</div>
+        <div className={styles.contentContainer}>
+          <RouteErrorBoundary>{children}</RouteErrorBoundary>
+        </div>
       </main>
     </div>
   );

--- a/apps/web/src/components/GlobalErrorBoundary.tsx
+++ b/apps/web/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import { type ErrorInfo, type ReactNode } from 'react';
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
+import { logger } from '../lib/logger.js';
+
+interface GlobalErrorBoundaryProps {
+  children: ReactNode;
+}
+
+/**
+ * Outermost error boundary — catches errors that escape the router or any
+ * per-route boundary (e.g. provider initialisation failures).  Uses inline
+ * styles so the fallback still renders if CSS fails to load.
+ */
+function GlobalFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const message = (error as Error)?.message ?? 'Unknown error';
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+        fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+        color: '#1a1a1a',
+        background: '#f8f7f4',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 520,
+          padding: '1.5rem',
+          borderRadius: '0.5rem',
+          border: '1px solid rgba(220, 38, 38, 0.25)',
+          background: '#fef2f2',
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: '1.25rem', color: '#dc2626' }}>
+          The application encountered a problem
+        </h1>
+        <p style={{ marginTop: '0.75rem', marginBottom: '1rem', color: '#6b6b6b' }}>
+          Something unexpected happened while loading the app. Try reloading the page; if the problem
+          continues, please contact support.
+        </p>
+        <p
+          style={{
+            marginTop: 0,
+            marginBottom: '1rem',
+            fontSize: '0.8125rem',
+            color: '#6b6b6b',
+            wordBreak: 'break-word',
+          }}
+        >
+          <strong>Error:</strong> {message}
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '0.375rem',
+              border: '1px solid #dc2626',
+              background: '#dc2626',
+              color: '#ffffff',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+          <button
+            type="button"
+            onClick={() => resetErrorBoundary()}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '0.375rem',
+              border: '1px solid rgba(220, 38, 38, 0.25)',
+              background: '#ffffff',
+              color: '#dc2626',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GlobalErrorBoundary({ children }: GlobalErrorBoundaryProps) {
+  const handleError = (error: unknown, info: ErrorInfo) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('global error boundary caught render error', {
+      errorName: err.name,
+      errorMessage: err.message,
+      componentStack: info.componentStack ?? undefined,
+    });
+  };
+
+  return (
+    <ErrorBoundary FallbackComponent={GlobalFallback} onError={handleError}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/src/components/RouteErrorBoundary.tsx
+++ b/apps/web/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { type ErrorInfo, type ReactNode } from 'react';
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
+import { useLocation } from 'react-router-dom';
+import { useUser } from '@descope/react-sdk';
+import { useTenant } from '../store/tenant.js';
+import { logger } from '../lib/logger.js';
+import { RouteErrorFallback } from './RouteErrorFallback.js';
+
+interface RouteErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Optional override for the fallback component. Defaults to the shared
+   * {@link RouteErrorFallback}, which matches the app's error surface styling.
+   */
+  FallbackComponent?: (props: FallbackProps) => ReactNode;
+}
+
+/**
+ * Per-route error boundary.
+ *
+ * Catches render errors within a single route, reports them through the
+ * frontend logger (which Issue 4.4 will wire to Application Insights), and
+ * renders an accessible fallback.  Automatically resets when the URL
+ * pathname changes so the user is not stuck on a broken view after
+ * navigating away.
+ */
+export function RouteErrorBoundary({
+  children,
+  FallbackComponent = RouteErrorFallback,
+}: RouteErrorBoundaryProps) {
+  const location = useLocation();
+  const { user } = useUser();
+  const { tenantId } = useTenant();
+
+  const handleError = (error: unknown, info: ErrorInfo) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error('route error boundary caught render error', {
+      route: location.pathname,
+      errorName: err.name,
+      errorMessage: err.message,
+      componentStack: info.componentStack ?? undefined,
+      userId: (user as { userId?: string } | undefined)?.userId,
+      userEmail: user?.email,
+      tenantId,
+    });
+  };
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={FallbackComponent}
+      onError={handleError}
+      resetKeys={[location.pathname]}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/src/components/RouteErrorFallback.module.css
+++ b/apps/web/src/components/RouteErrorFallback.module.css
@@ -1,0 +1,95 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+  max-width: 640px;
+  margin: var(--space-8) auto;
+  padding: var(--space-6);
+  border-radius: var(--radius-md, 0.5rem);
+  border: 1px solid var(--color-error-border, rgba(220, 38, 38, 0.25));
+  background-color: var(--color-error-subtle, #fef2f2);
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-error, #dc2626);
+}
+
+.message {
+  margin: 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--color-text-secondary, #6b6b6b);
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2, 0.5rem);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm, 0.375rem);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--color-error-border, rgba(220, 38, 38, 0.25));
+  background: var(--bg-surface, #ffffff);
+  color: var(--color-error-text, #dc2626);
+  transition:
+    background-color var(--transition-base, 150ms ease),
+    color var(--transition-base, 150ms ease);
+}
+
+.button:hover {
+  background: var(--color-error-subtle, #fef2f2);
+}
+
+.buttonPrimary {
+  background: var(--color-error, #dc2626);
+  color: #ffffff;
+  border-color: var(--color-error, #dc2626);
+}
+
+.buttonPrimary:hover {
+  background: var(--accent-hover, #b91c1c);
+  color: #ffffff;
+}
+
+.copyConfirm {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--color-success, #059669);
+  align-self: center;
+}
+
+.details {
+  margin-top: var(--space-2, 0.5rem);
+  width: 100%;
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.details summary {
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b6b6b);
+}
+
+.stack {
+  margin: var(--space-2, 0.5rem) 0 0;
+  padding: var(--space-3, 0.75rem);
+  background: var(--bg-muted, #f0efe9);
+  border-radius: var(--radius-sm, 0.375rem);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--color-text-primary, #1a1a1a);
+}

--- a/apps/web/src/components/RouteErrorFallback.tsx
+++ b/apps/web/src/components/RouteErrorFallback.tsx
@@ -21,15 +21,15 @@ export function RouteErrorFallback({ error, resetErrorBoundary }: FallbackProps)
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    const text = formatErrorForCopy(error as Error);
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+      return;
+    }
     try {
-      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        await navigator.clipboard.writeText(text);
-      }
+      await navigator.clipboard.writeText(formatErrorForCopy(error as Error));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
-      // If clipboard is unavailable, leave the confirmation off.
+      // Clipboard write failed (e.g. permission denied) — leave the confirmation off.
     }
   };
 

--- a/apps/web/src/components/RouteErrorFallback.tsx
+++ b/apps/web/src/components/RouteErrorFallback.tsx
@@ -10,10 +10,21 @@ function isDev(): boolean {
   }
 }
 
-function formatErrorForCopy(error: Error): string {
-  const name = error.name || 'Error';
-  const message = error.message || '';
-  const stack = error.stack || '';
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error(String(value));
+  }
+}
+
+function formatErrorForCopy(error: unknown): string {
+  const err = toError(error);
+  const name = err.name || 'Error';
+  const message = err.message || '';
+  const stack = err.stack || '';
   return `${name}: ${message}\n\n${stack}`.trim();
 }
 
@@ -25,7 +36,7 @@ export function RouteErrorFallback({ error, resetErrorBoundary }: FallbackProps)
       return;
     }
     try {
-      await navigator.clipboard.writeText(formatErrorForCopy(error as Error));
+      await navigator.clipboard.writeText(formatErrorForCopy(error));
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
@@ -67,7 +78,7 @@ export function RouteErrorFallback({ error, resetErrorBoundary }: FallbackProps)
       {isDev() && (
         <details className={styles.details}>
           <summary>Error details (dev only)</summary>
-          <pre className={styles.stack}>{formatErrorForCopy(error as Error)}</pre>
+          <pre className={styles.stack}>{formatErrorForCopy(error)}</pre>
         </details>
       )}
     </div>

--- a/apps/web/src/components/RouteErrorFallback.tsx
+++ b/apps/web/src/components/RouteErrorFallback.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+import styles from './RouteErrorFallback.module.css';
+
+function isDev(): boolean {
+  try {
+    return Boolean((import.meta as { env?: { DEV?: boolean } }).env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+function formatErrorForCopy(error: Error): string {
+  const name = error.name || 'Error';
+  const message = error.message || '';
+  const stack = error.stack || '';
+  return `${name}: ${message}\n\n${stack}`.trim();
+}
+
+export function RouteErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = formatErrorForCopy(error as Error);
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(text);
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // If clipboard is unavailable, leave the confirmation off.
+    }
+  };
+
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className={styles.root} role="alert" aria-live="assertive" data-testid="route-error-fallback">
+      <h2 className={styles.title}>Something went wrong on this page</h2>
+      <p className={styles.message}>
+        We hit an unexpected error while rendering this page. You can try again, reload the page, or copy
+        the error details to share with support.
+      </p>
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={`${styles.button} ${styles.buttonPrimary}`}
+          onClick={() => resetErrorBoundary()}
+        >
+          Try again
+        </button>
+        <button type="button" className={styles.button} onClick={handleReload}>
+          Reload
+        </button>
+        <button type="button" className={styles.button} onClick={() => void handleCopy()}>
+          Copy error
+        </button>
+        {copied && (
+          <span className={styles.copyConfirm} role="status">
+            Copied
+          </span>
+        )}
+      </div>
+      {isDev() && (
+        <details className={styles.details}>
+          <summary>Error details (dev only)</summary>
+          <pre className={styles.stack}>{formatErrorForCopy(error as Error)}</pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from '@descope/react-sdk';
 import './theme.css';
 import './index.css';
 import { App } from './App.js';
+import { GlobalErrorBoundary } from './components/GlobalErrorBoundary.js';
 
 const descopeProjectId = import.meta.env.VITE_DESCOPE_PROJECT_ID as string;
 
@@ -20,8 +21,10 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <AuthProvider projectId={descopeProjectId}>
-      <App />
-    </AuthProvider>
+    <GlobalErrorBoundary>
+      <AuthProvider projectId={descopeProjectId}>
+        <App />
+      </AuthProvider>
+    </GlobalErrorBoundary>
   </StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
                         "@tanstack/react-query": "^5.59.0",
                         "react": "^18.3.1",
                         "react-dom": "^18.3.1",
+                        "react-error-boundary": "^6.1.1",
                         "react-router-dom": "^7.14.0"
                   },
                   "devDependencies": {
@@ -6012,6 +6013,15 @@
                   },
                   "peerDependencies": {
                         "react": "^18.3.1"
+                  }
+            },
+            "node_modules/react-error-boundary": {
+                  "version": "6.1.1",
+                  "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+                  "integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+                  "license": "MIT",
+                  "peerDependencies": {
+                        "react": "^18.0.0 || ^19.0.0"
                   }
             },
             "node_modules/react-is": {


### PR DESCRIPTION
Closes #380

## Summary
- Adds per-route and global React error boundaries so a render crash in one page no longer takes down the whole app.
- Uses the `react-error-boundary` library. `RouteErrorBoundary` is wrapped around `{children}` inside `AppShell` (keeps nav/header alive, auto-resets on route change via `resetKeys=[pathname]`). `GlobalErrorBoundary` is mounted at the App root for catastrophic failures outside the shell (uses inline styles so it renders even if CSS fails to load).
- Accessible fallback UI (`role="alert"`, `aria-live="assertive"`) with **Try again**, **Reload**, and **Copy error** actions; a collapsible stack in dev only.
- Caught errors are reported through the existing `logger` shim (`apps/web/src/lib/logger.ts`) with `{ route, errorName, errorMessage, componentStack, userId, userEmail, tenantId }`. Issue #4.4 will swap the logger implementation to forward these to Application Insights.

## Files
- New: `components/RouteErrorBoundary.tsx`, `components/RouteErrorFallback.tsx`(+`.module.css`), `components/GlobalErrorBoundary.tsx`
- Modified: `App.tsx` (wraps `<Routes>` in `RouteErrorBoundary` and the whole app in `GlobalErrorBoundary`), `AppShell.tsx` (wraps page content in `RouteErrorBoundary`)
- Test: `__tests__/RouteErrorBoundary.test.tsx` — 6 tests covering passthrough, catch, logger reporting with route/user/tenant context, Try-again recovery, route-change reset, and clipboard copy
- Dep: adds `react-error-boundary@^6.1.1`

## Acceptance criteria mapping (from #380)
- [x] Every route has an error boundary — one in AppShell covers all shell-wrapped routes; a `RouteErrorBoundary` around `<Routes>` covers the non-shell routes (login, unauthorized, select-tenant, organisation provisioning, 404); `GlobalErrorBoundary` catches anything that escapes
- [x] Errors reported with route + user context — `logger.error` call includes `route`, `userId`, `userEmail`, `tenantId`, `componentStack`; Issue #4.4 will forward to App Insights
- [x] Fallback UI is accessible and actionable — `role="alert"`, `aria-live="assertive"`, keyboard-reachable Try again / Reload / Copy error
- [x] Test coverage for the boundary — `RouteErrorBoundary.test.tsx`

## Test plan
- [x] `npm run typecheck --workspace @cpcrm/web` passes
- [x] `npm run lint --workspace @cpcrm/web` passes (only pre-existing warnings)
- [x] `npm run test --workspace @cpcrm/web` — **672/672 pass** (6 new)
- [x] `VITE_DESCOPE_PROJECT_ID=dummy npm run build --workspace @cpcrm/web` succeeds
- [ ] Manual smoke in dev: temporarily `throw` in a page → shell stays alive, fallback renders, Try again / Reload / Copy error work, `logger.error` logs route+user context, navigating away auto-resets

https://claude.ai/code/session_01AyoCYccsgpP6eSHPCejBnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyoCYccsgpP6eSHPCejBnm)_