### PR TITLE
feat(page-layout): add optional zones schema (kpi/leftRail/rightRail)

### DIFF
--- a/apps/api/src/routes/__tests__/pageLayouts.test.ts
+++ b/apps/api/src/routes/__tests__/pageLayouts.test.ts
@@ -118,7 +118,32 @@ describe('GET /objects/:apiName/page-layout', () => {
 
     await handleGetEffectivePageLayout(req, res);
 
-    expect(res.json).toHaveBeenCalledWith(PUBLISHED_LAYOUT);
+    expect(res.json).toHaveBeenCalledWith({
+      ...PUBLISHED_LAYOUT,
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
+  });
+
+  it('preserves populated zones on the published layout', async () => {
+    const withZones = {
+      ...PUBLISHED_LAYOUT,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'field', config: { fieldId: 'uuid-1' } }],
+        leftRail: [],
+        rightRail: [],
+      },
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'obj-1' }] })
+      .mockResolvedValueOnce({ rows: [{ published_layout: withZones }] });
+
+    const req = mockReq('account');
+    const res = mockRes();
+
+    await handleGetEffectivePageLayout(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(withZones);
   });
 
   it('returns role-specific layout when user has a matching role', async () => {
@@ -139,7 +164,10 @@ describe('GET /objects/:apiName/page-layout', () => {
 
     await handleGetEffectivePageLayout(req, res);
 
-    expect(res.json).toHaveBeenCalledWith(roleLayout);
+    expect(res.json).toHaveBeenCalledWith({
+      ...roleLayout,
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
     // Should have queried with the user's role
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining('role = $3'),
@@ -165,7 +193,10 @@ describe('GET /objects/:apiName/page-layout', () => {
 
     await handleGetEffectivePageLayout(req, res);
 
-    expect(res.json).toHaveBeenCalledWith(PUBLISHED_LAYOUT);
+    expect(res.json).toHaveBeenCalledWith({
+      ...PUBLISHED_LAYOUT,
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
   });
 
   it('returns 204 when role-specific query returns nothing and no default exists', async () => {

--- a/apps/api/src/routes/pageLayouts.ts
+++ b/apps/api/src/routes/pageLayouts.ts
@@ -5,6 +5,8 @@ import { requireTenant } from '../middleware/tenant.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { pool } from '../db/client.js';
 import { logger } from '../lib/logger.js';
+import { normalizeLayout } from '../services/pageLayoutService.js';
+import type { PageLayoutJson } from '../services/pageLayoutService.js';
 
 export const pageLayoutsRouter = Router({ mergeParams: true });
 
@@ -84,7 +86,7 @@ export async function handleGetEffectivePageLayout(
       return;
     }
 
-    res.json(publishedLayout);
+    res.json(normalizeLayout(publishedLayout as PageLayoutJson));
   } catch (err: unknown) {
     logger.error({ err, apiName }, 'Unexpected error fetching effective page layout');
     res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -11,7 +11,9 @@ import {
   revertLayout,
   validatePageLayoutName,
   validateLayoutJson,
+  normalizeLayout,
 } from '../pageLayoutService.js';
+import type { PageLayoutJson } from '../pageLayoutService.js';
 
 const TENANT_ID = 'test-tenant-001';
 
@@ -408,7 +410,11 @@ describe('createPageLayout', () => {
     expect(result.status).toBe('draft');
     expect(result.version).toBe(1);
     expect(result.publishedLayout).toBeNull();
-    expect(result.layout).toEqual(VALID_LAYOUT_JSON);
+    // Read path normalises zones onto legacy-shaped layouts.
+    expect(result.layout).toEqual({
+      ...VALID_LAYOUT_JSON,
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
   });
 
   it('throws NOT_FOUND when object does not exist', async () => {
@@ -579,7 +585,10 @@ describe('publishPageLayout', () => {
 
     expect(result.status).toBe('published');
     expect(result.version).toBe(2);
-    expect(result.publishedLayout).toEqual(VALID_LAYOUT_JSON);
+    expect(result.publishedLayout).toEqual({
+      ...VALID_LAYOUT_JSON,
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
     expect(fakePageLayoutVersions.size).toBe(1);
   });
 
@@ -944,5 +953,153 @@ describe('revertLayout', () => {
     await expect(
       revertLayout(TENANT_ID, 'nonexistent', 'pl1', 1),
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+// ─── Tests: normalizeLayout / zones schema ──────────────────────────────────
+
+describe('normalizeLayout', () => {
+  it('fills zones with empty arrays when missing (legacy layout)', () => {
+    const normalized = normalizeLayout(VALID_LAYOUT_JSON as PageLayoutJson);
+    expect(normalized.zones).toEqual({ kpi: [], leftRail: [], rightRail: [] });
+    expect(normalized.tabs).toEqual(VALID_LAYOUT_JSON.tabs);
+    expect(normalized.header).toEqual(VALID_LAYOUT_JSON.header);
+  });
+
+  it('round-trips a populated layout unchanged', () => {
+    const newShape: PageLayoutJson = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'field', config: { fieldId: 'uuid-1' } }],
+        leftRail: [
+          { id: 'lr-1', type: 'field_section', label: 'Left', columns: 1, components: [] },
+        ],
+        rightRail: [],
+      },
+    };
+    const normalized = normalizeLayout(newShape);
+    expect(normalized.zones).toEqual(newShape.zones);
+    // Idempotent on re-normalise.
+    expect(normalizeLayout(normalized)).toEqual(normalized);
+  });
+
+  it('fills missing rail arrays when zones is partially populated', () => {
+    const partial: PageLayoutJson = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'kpi', config: {} }],
+      } as PageLayoutJson['zones'],
+    };
+    const normalized = normalizeLayout(partial);
+    expect(normalized.zones?.kpi).toHaveLength(1);
+    expect(normalized.zones?.leftRail).toEqual([]);
+    expect(normalized.zones?.rightRail).toEqual([]);
+  });
+
+  it('does not mutate the input layout', () => {
+    const snapshot = JSON.parse(JSON.stringify(VALID_LAYOUT_JSON));
+    normalizeLayout(VALID_LAYOUT_JSON as PageLayoutJson);
+    expect(VALID_LAYOUT_JSON).toEqual(snapshot);
+  });
+});
+
+describe('validateLayoutJson — zones', () => {
+  it('accepts a layout with no zones (legacy shape)', () => {
+    expect(validateLayoutJson(VALID_LAYOUT_JSON)).toBeNull();
+  });
+
+  it('accepts a layout with a fully populated zones object', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'field', config: { fieldId: 'uuid-1' } }],
+        leftRail: [
+          { id: 'lr-1', type: 'field_section', label: 'Left', columns: 1, components: [] },
+        ],
+        rightRail: [],
+      },
+    };
+    expect(validateLayoutJson(layout)).toBeNull();
+  });
+
+  it('rejects zones when it is not an object', () => {
+    const layout = { ...VALID_LAYOUT_JSON, zones: 'not-an-object' };
+    expect(validateLayoutJson(layout)).toContain('layout.zones');
+  });
+
+  it('rejects zones.kpi when it is not an array', () => {
+    const layout = { ...VALID_LAYOUT_JSON, zones: { kpi: 'oops' } };
+    expect(validateLayoutJson(layout)).toContain('layout.zones.kpi');
+  });
+
+  it('rejects zones.leftRail with an invalid section type', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        leftRail: [
+          { id: 'lr-1', type: 'invalid', label: 'Left', columns: 1, components: [] },
+        ],
+      },
+    };
+    expect(validateLayoutJson(layout)).toContain('zones.leftRail');
+  });
+
+  it('rejects a kpi component with an unknown type', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'nonexistent-type', config: {} }],
+      },
+    };
+    expect(validateLayoutJson(layout)).toContain('zones.kpi');
+  });
+});
+
+// ─── Tests: service read-path normalises zones ───────────────────────────────
+
+describe('pageLayoutService read paths normalise zones', () => {
+  beforeEach(() => {
+    fakeObjects.clear();
+    fakePageLayouts.clear();
+    fakePageLayoutVersions.clear();
+    mockQuery.mockClear();
+    fakeObjects.set('obj-1', { id: 'obj-1', tenant_id: TENANT_ID });
+  });
+
+  it('getPageLayoutById fills zones on a legacy-shaped layout', async () => {
+    fakePageLayouts.set('pl1', {
+      id: 'pl1', tenant_id: TENANT_ID, object_id: 'obj-1',
+      name: 'Default', role: null, is_default: true,
+      layout: VALID_LAYOUT_JSON, published_layout: VALID_LAYOUT_JSON,
+      version: 1, status: 'published',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      published_at: new Date().toISOString(),
+    });
+
+    const result = await getPageLayoutById(TENANT_ID, 'obj-1', 'pl1');
+    expect(result.layout.zones).toEqual({ kpi: [], leftRail: [], rightRail: [] });
+    expect(result.publishedLayout?.zones).toEqual({ kpi: [], leftRail: [], rightRail: [] });
+  });
+
+  it('listPageLayoutVersions normalises each version layout', async () => {
+    fakePageLayouts.set('pl1', {
+      id: 'pl1', tenant_id: TENANT_ID, object_id: 'obj-1',
+      name: 'Default', role: null, is_default: true,
+      layout: VALID_LAYOUT_JSON, published_layout: null,
+      version: 1, status: 'draft',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      published_at: null,
+    });
+    fakePageLayoutVersions.set('v1', {
+      id: 'v1', layout_id: 'pl1', tenant_id: TENANT_ID,
+      version: 1, layout: VALID_LAYOUT_JSON,
+      published_by: 'user-1', published_at: new Date().toISOString(),
+    });
+
+    const versions = await listPageLayoutVersions(TENANT_ID, 'obj-1', 'pl1');
+    expect(versions).toHaveLength(1);
+    expect(versions[0].layout.zones).toEqual({ kpi: [], leftRail: [], rightRail: [] });
   });
 });

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -1027,6 +1027,11 @@ describe('validateLayoutJson — zones', () => {
     expect(validateLayoutJson(layout)).toContain('layout.zones');
   });
 
+  it('rejects zones when it is an array (typeof array === "object")', () => {
+    const layout = { ...VALID_LAYOUT_JSON, zones: [] };
+    expect(validateLayoutJson(layout)).toContain('layout.zones');
+  });
+
   it('rejects zones.kpi when it is not an array', () => {
     const layout = { ...VALID_LAYOUT_JSON, zones: { kpi: 'oops' } };
     expect(validateLayoutJson(layout)).toContain('layout.zones.kpi');

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -15,7 +15,15 @@ export interface PageLayoutJson {
     badges?: Array<{ fieldId: string; colorMap: Record<string, string> }>;
     actions?: string[];
   };
+  zones?: PageLayoutZones;
   tabs: PageLayoutTab[];
+}
+
+// KPI strip is a flat list of components; rails are vertical stacks of sections.
+export interface PageLayoutZones {
+  kpi: PageLayoutComponent[];
+  leftRail: PageLayoutSection[];
+  rightRail: PageLayoutSection[];
 }
 
 export interface PageLayoutTab {
@@ -103,6 +111,20 @@ const VALID_VISIBILITY_OPS = new Set([
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+// Fills in `zones` with empty arrays so readers always see a populated shape.
+// Old layouts (no `zones`) read as `{ kpi: [], leftRail: [], rightRail: [] }`.
+export function normalizeLayout(layout: PageLayoutJson): PageLayoutJson {
+  const z = layout.zones as Partial<PageLayoutZones> | null | undefined;
+  return {
+    ...layout,
+    zones: {
+      kpi: Array.isArray(z?.kpi) ? z!.kpi! : [],
+      leftRail: Array.isArray(z?.leftRail) ? z!.leftRail! : [],
+      rightRail: Array.isArray(z?.rightRail) ? z!.rightRail! : [],
+    },
+  };
+}
+
 function throwValidationError(message: string): never {
   const err = new Error(message) as Error & { code: string };
   err.code = 'VALIDATION_ERROR';
@@ -130,6 +152,7 @@ function throwDeleteBlockedError(message: string): never {
 // ─── Row → domain model ─────────────────────────────────────────────────────
 
 function rowToPageLayout(row: Selectable<PageLayouts>): PageLayout {
+  const rawPublished = row.published_layout as unknown as PageLayoutJson | null;
   return {
     id: row.id,
     tenantId: row.tenant_id,
@@ -137,8 +160,8 @@ function rowToPageLayout(row: Selectable<PageLayouts>): PageLayout {
     name: row.name,
     role: row.role,
     isDefault: row.is_default,
-    layout: row.layout as unknown as PageLayoutJson,
-    publishedLayout: (row.published_layout as unknown as PageLayoutJson) ?? null,
+    layout: normalizeLayout(row.layout as unknown as PageLayoutJson),
+    publishedLayout: rawPublished ? normalizeLayout(rawPublished) : null,
     version: row.version,
     status: row.status,
     createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at as unknown as string),
@@ -155,7 +178,7 @@ function rowToPageLayoutVersion(row: Selectable<PageLayoutVersions>): PageLayout
     layoutId: row.layout_id,
     tenantId: row.tenant_id,
     version: row.version,
-    layout: row.layout as unknown as PageLayoutJson,
+    layout: normalizeLayout(row.layout as unknown as PageLayoutJson),
     publishedBy: row.published_by,
     publishedAt: row.published_at instanceof Date ? row.published_at : new Date(row.published_at as unknown as string),
   };
@@ -206,6 +229,90 @@ function validateVisibilityRule(rule: unknown): string | null {
   return null;
 }
 
+function validateComponent(comp: unknown): string | null {
+  if (typeof comp !== 'object' || comp === null) {
+    return 'Each component must be an object';
+  }
+  const c = comp as Record<string, unknown>;
+  if (typeof c.id !== 'string' || c.id.trim().length === 0) {
+    return 'Each component must have an id';
+  }
+  if (typeof c.type !== 'string' || !VALID_COMPONENT_TYPES.has(c.type)) {
+    return `Component "${c.id}" has invalid type: ${String(c.type)}. Must be one of: ${[...VALID_COMPONENT_TYPES].join(', ')}`;
+  }
+  if (typeof c.config !== 'object' || c.config === null) {
+    return `Component "${c.id}" must have a config object`;
+  }
+
+  const compVisErr = validateVisibilityRule(c.visibility);
+  if (compVisErr) return `Component "${c.id}": ${compVisErr}`;
+
+  return null;
+}
+
+function validateSection(section: unknown): string | null {
+  if (typeof section !== 'object' || section === null) {
+    return 'Each section must be an object';
+  }
+  const s = section as Record<string, unknown>;
+  if (typeof s.id !== 'string' || s.id.trim().length === 0) {
+    return 'Each section must have an id';
+  }
+  if (typeof s.type !== 'string' || !VALID_SECTION_TYPES.has(s.type)) {
+    return `Section "${s.id}" has invalid type: ${String(s.type)}. Must be one of: ${[...VALID_SECTION_TYPES].join(', ')}`;
+  }
+  if (typeof s.label !== 'string' || s.label.trim().length === 0) {
+    return `Section "${s.id}" must have a label`;
+  }
+
+  const visErr = validateVisibilityRule(s.visibility);
+  if (visErr) return `Section "${s.id}": ${visErr}`;
+
+  if (!Array.isArray(s.components)) {
+    return `Section "${s.id}" must have a components array`;
+  }
+
+  for (const comp of s.components) {
+    const compErr = validateComponent(comp);
+    if (compErr) return compErr;
+  }
+
+  return null;
+}
+
+function validateZones(zones: unknown): string | null {
+  if (zones === undefined || zones === null) return null;
+  if (typeof zones !== 'object') {
+    return 'layout.zones must be an object with kpi, leftRail, rightRail arrays';
+  }
+
+  const z = zones as Record<string, unknown>;
+
+  if (z.kpi !== undefined) {
+    if (!Array.isArray(z.kpi)) {
+      return 'layout.zones.kpi must be an array';
+    }
+    for (const comp of z.kpi) {
+      const compErr = validateComponent(comp);
+      if (compErr) return `zones.kpi: ${compErr}`;
+    }
+  }
+
+  for (const rail of ['leftRail', 'rightRail'] as const) {
+    if (z[rail] !== undefined) {
+      if (!Array.isArray(z[rail])) {
+        return `layout.zones.${rail} must be an array`;
+      }
+      for (const section of z[rail] as unknown[]) {
+        const secErr = validateSection(section);
+        if (secErr) return `zones.${rail}: ${secErr}`;
+      }
+    }
+  }
+
+  return null;
+}
+
 export function validateLayoutJson(layout: unknown): string | null {
   if (typeof layout !== 'object' || layout === null) {
     return 'layout is required and must be an object';
@@ -234,6 +341,9 @@ export function validateLayoutJson(layout: unknown): string | null {
     return 'layout.header.actions must be an array of strings';
   }
 
+  const zonesErr = validateZones(l.zones);
+  if (zonesErr) return zonesErr;
+
   if (!Array.isArray(l.tabs)) {
     return 'layout.tabs is required and must be an array';
   }
@@ -255,45 +365,8 @@ export function validateLayoutJson(layout: unknown): string | null {
     }
 
     for (const section of t.sections) {
-      if (typeof section !== 'object' || section === null) {
-        return 'Each section must be an object';
-      }
-      const s = section as Record<string, unknown>;
-      if (typeof s.id !== 'string' || s.id.trim().length === 0) {
-        return 'Each section must have an id';
-      }
-      if (typeof s.type !== 'string' || !VALID_SECTION_TYPES.has(s.type)) {
-        return `Section "${s.id}" has invalid type: ${String(s.type)}. Must be one of: ${[...VALID_SECTION_TYPES].join(', ')}`;
-      }
-      if (typeof s.label !== 'string' || s.label.trim().length === 0) {
-        return `Section "${s.id}" must have a label`;
-      }
-
-      const visErr = validateVisibilityRule(s.visibility);
-      if (visErr) return `Section "${s.id}": ${visErr}`;
-
-      if (!Array.isArray(s.components)) {
-        return `Section "${s.id}" must have a components array`;
-      }
-
-      for (const comp of s.components) {
-        if (typeof comp !== 'object' || comp === null) {
-          return 'Each component must be an object';
-        }
-        const c = comp as Record<string, unknown>;
-        if (typeof c.id !== 'string' || c.id.trim().length === 0) {
-          return 'Each component must have an id';
-        }
-        if (typeof c.type !== 'string' || !VALID_COMPONENT_TYPES.has(c.type)) {
-          return `Component "${c.id}" has invalid type: ${String(c.type)}. Must be one of: ${[...VALID_COMPONENT_TYPES].join(', ')}`;
-        }
-        if (typeof c.config !== 'object' || c.config === null) {
-          return `Component "${c.id}" must have a config object`;
-        }
-
-        const compVisErr = validateVisibilityRule(c.visibility);
-        if (compVisErr) return `Component "${c.id}": ${compVisErr}`;
-      }
+      const secErr = validateSection(section);
+      if (secErr) return secErr;
     }
   }
 

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -282,7 +282,7 @@ function validateSection(section: unknown): string | null {
 
 function validateZones(zones: unknown): string | null {
   if (zones === undefined || zones === null) return null;
-  if (typeof zones !== 'object') {
+  if (typeof zones !== 'object' || Array.isArray(zones)) {
     return 'layout.zones must be an object with kpi, leftRail, rightRail arrays';
   }
 

--- a/apps/web/src/__tests__/layoutTypesNormalize.test.ts
+++ b/apps/web/src/__tests__/layoutTypesNormalize.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMPTY_ZONES,
+  normalizeLayout,
+  type LayoutZones,
+  type PageLayout,
+} from '../components/layoutTypes.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const LEGACY_LAYOUT: PageLayout = {
+  id: 'pl-1',
+  objectId: 'obj-1',
+  name: 'Default',
+  header: { primaryField: 'name', secondaryFields: ['stage'] },
+  tabs: [
+    {
+      id: 'tab-1',
+      label: 'Details',
+      sections: [
+        {
+          id: 'sec-1',
+          type: 'field_section',
+          label: 'Info',
+          columns: 2,
+          components: [
+            { id: 'comp-1', type: 'field', config: { fieldApiName: 'name' } },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const POPULATED_ZONES: LayoutZones = {
+  kpi: [{ id: 'k-1', type: 'kpi', config: { fieldApiName: 'amount' } }],
+  leftRail: [
+    {
+      id: 'lr-1',
+      type: 'field_section',
+      label: 'Left',
+      columns: 1,
+      components: [],
+    },
+  ],
+  rightRail: [],
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('normalizeLayout', () => {
+  it('fills in default zones when zones is missing (legacy layout)', () => {
+    const normalized = normalizeLayout(LEGACY_LAYOUT);
+    expect(normalized.zones).toEqual(EMPTY_ZONES);
+    // Preserves everything else unchanged
+    expect(normalized.tabs).toBe(LEGACY_LAYOUT.tabs);
+    expect(normalized.header).toBe(LEGACY_LAYOUT.header);
+  });
+
+  it('fills in default zones when zones is explicitly null', () => {
+    const input = { ...LEGACY_LAYOUT, zones: null } as unknown as PageLayout;
+    const normalized = normalizeLayout(input);
+    expect(normalized.zones).toEqual(EMPTY_ZONES);
+  });
+
+  it('round-trips a layout that already has populated zones', () => {
+    const newShape: PageLayout = { ...LEGACY_LAYOUT, zones: POPULATED_ZONES };
+    const normalized = normalizeLayout(newShape);
+    expect(normalized.zones).toEqual(POPULATED_ZONES);
+    expect(normalized.zones.kpi).toEqual(POPULATED_ZONES.kpi);
+    expect(normalized.zones.leftRail).toEqual(POPULATED_ZONES.leftRail);
+    expect(normalized.zones.rightRail).toEqual(POPULATED_ZONES.rightRail);
+    // Re-normalising a populated layout is idempotent.
+    expect(normalizeLayout(normalized)).toEqual(normalized);
+  });
+
+  it('fills missing rail arrays when zones is partially populated', () => {
+    const partial = {
+      ...LEGACY_LAYOUT,
+      zones: { kpi: POPULATED_ZONES.kpi } as Partial<LayoutZones> as LayoutZones,
+    };
+    const normalized = normalizeLayout(partial);
+    expect(normalized.zones.kpi).toEqual(POPULATED_ZONES.kpi);
+    expect(normalized.zones.leftRail).toEqual([]);
+    expect(normalized.zones.rightRail).toEqual([]);
+  });
+
+  it('does not mutate the input layout', () => {
+    const snapshot = JSON.parse(JSON.stringify(LEGACY_LAYOUT));
+    normalizeLayout(LEGACY_LAYOUT);
+    expect(LEGACY_LAYOUT).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/components/layoutTypes.ts
+++ b/apps/web/src/components/layoutTypes.ts
@@ -58,12 +58,42 @@ export interface HeaderConfig {
   secondaryFields: string[];
 }
 
+// KPI strip is a flat list of components; rails are vertical stacks of sections.
+export interface LayoutZones {
+  kpi: LayoutComponentDef[];
+  leftRail: LayoutSectionDef[];
+  rightRail: LayoutSectionDef[];
+}
+
 export interface PageLayout {
   id: string;
   objectId: string;
   name: string;
   header: HeaderConfig;
+  zones?: LayoutZones;
   tabs: LayoutTab[];
+}
+
+export const EMPTY_ZONES: LayoutZones = {
+  kpi: [],
+  leftRail: [],
+  rightRail: [],
+};
+
+// Fills in `zones` so renderer + builder always see a populated shape.
+// Old layouts (no `zones`) read as `{ kpi: [], leftRail: [], rightRail: [] }`.
+export function normalizeLayout<T extends { zones?: Partial<LayoutZones> | null }>(
+  layout: T,
+): T & { zones: LayoutZones } {
+  const z = layout.zones ?? null;
+  return {
+    ...layout,
+    zones: {
+      kpi: Array.isArray(z?.kpi) ? z!.kpi! : [],
+      leftRail: Array.isArray(z?.leftRail) ? z!.leftRail! : [],
+      rightRail: Array.isArray(z?.rightRail) ? z!.rightRail! : [],
+    },
+  };
 }
 
 export interface FieldDefinitionRef {

--- a/apps/web/src/usePageLayout.ts
+++ b/apps/web/src/usePageLayout.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useSession } from '@descope/react-sdk';
 import { useApiClient } from './lib/apiClient.js';
 import { pageLayoutsKeys } from './lib/queryKeys.js';
-import type { PageLayout } from './components/layoutTypes.js';
+import { normalizeLayout, type PageLayout } from './components/layoutTypes.js';
 
 /**
  * Fetches the effective page layout for a given object type.
@@ -37,7 +37,7 @@ export function usePageLayout(objectApiName: string | undefined) {
       if (!response.ok) {
         throw new Error(`Failed to load page layout: ${response.status}`);
       }
-      return (await response.json()) as PageLayout;
+      return normalizeLayout(await response.json() as PageLayout);
     },
   });
 


### PR DESCRIPTION
## Summary

Adds an optional `zones` object to `PageLayout` so structural areas (KPI strip, left rail, right rail) are first-class citizens alongside tabs. Tabs continue to render inside the implicit `main` zone. This PR is schema-only — no renderer/builder changes (those land in #516 / #521).

## What changed

- **Frontend types** (`apps/web/src/components/layoutTypes.ts`): added `LayoutZones` and an optional `zones` field on `PageLayout`, plus `normalizeLayout` that fills `{ kpi: [], leftRail: [], rightRail: [] }` for legacy layouts.
- **Backend service** (`apps/api/src/services/pageLayoutService.ts`): mirrored the shape as `PageLayoutZones`, exported `normalizeLayout`, and applied it on every read path (`rowToPageLayout`, `rowToPageLayoutVersion`) so the service always hands back a populated zones object.
- **Validator**: `validateLayoutJson` now accepts the optional `zones` field and validates rail sections + kpi components via the existing section/component rules. Extracted `validateSection` / `validateComponent` helpers to avoid duplication.
- **Route**: the public `GET /api/v1/objects/:apiName/page-layout` normalises the published layout before returning, matching admin-side behaviour.
- **Client**: `usePageLayout` normalises the response payload so every caller sees `zones` populated, no null-guards needed.

## Backwards compatibility

- `zones` is optional at read time; the reader treats missing as empty zones.
- No SQL migration — `page_layouts.layout` is already JSONB and old rows parse unchanged.
- Old clients that POST/PUT layouts without `zones` continue to succeed.

## Tests

- `apps/web/src/__tests__/layoutTypesNormalize.test.ts` — normalizer fills defaults, preserves populated zones, idempotent on re-normalise, immutable input.
- `apps/api/src/services/__tests__/pageLayoutService.test.ts` — added suites for `normalizeLayout`, zones-level validation (malformed shape, bad kpi component, bad rail section), and confirms `getPageLayoutById` / `listPageLayoutVersions` normalise on the way out.
- `apps/api/src/routes/__tests__/pageLayouts.test.ts` — confirms the public route normalises the 200 response and preserves populated zones when present.

## Test plan

- [x] `npm run test` — api 1527 passed / web 679 passed
- [x] `npm run typecheck` — clean across workspaces
- [x] `npm run lint` — 0 errors (pre-existing warnings only)

Closes #515

https://claude.ai/code/session_011LHQVcSsufjW36ybzd4RWf

---
_Generated by [Claude Code](https://claude.ai/code/session_011LHQVcSsufjW36ybzd4RWf)_