### PR TITLE
feat(page-layout): zoned record detail shell (header · KPI · 3-col body)

### DIFF
--- a/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
+++ b/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
@@ -636,6 +636,34 @@ describe('PageLayoutRenderer', () => {
     expect(screen.queryByTestId('layout-right-rail')).not.toBeInTheDocument();
   });
 
+  it('forces rail sections to render in a single column regardless of declared columns', () => {
+    const layout = makeLayout({
+      zones: {
+        kpi: [],
+        leftRail: [
+          {
+            id: 'left-multi',
+            label: 'Left Rail Multi-Col',
+            columns: 3,
+            components: [
+              { id: 'lr1', type: 'field', config: { fieldApiName: 'email' } },
+            ],
+          },
+        ],
+        rightRail: [],
+      },
+    });
+
+    const { container } = renderLayout(layout);
+    const leftRail = screen.getByTestId('layout-left-rail');
+    expect(leftRail).toBeInTheDocument();
+
+    const cols1Nodes = container.querySelectorAll('[class*="cols1"]');
+    expect(cols1Nodes.length).toBeGreaterThanOrEqual(1);
+    const cols3Nodes = container.querySelectorAll('[class*="cols3"]');
+    expect(cols3Nodes.length).toBe(0);
+  });
+
   it('renders left and right rails with their sections', () => {
     const layout = makeLayout({
       zones: {

--- a/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
+++ b/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
@@ -542,6 +542,78 @@ describe('PageLayoutRenderer', () => {
 
   // ── Section with initially collapsed state ──────────────────────────────
 
+  // ── Zoned shell (KPI strip + rails) ─────────────────────────────────────
+
+  it('collapses to a simple shell when zones are absent (legacy layout)', () => {
+    renderLayout();
+    expect(screen.queryByTestId('kpi-strip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('layout-left-rail')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('layout-right-rail')).not.toBeInTheDocument();
+    expect(screen.getByTestId('layout-main')).toBeInTheDocument();
+  });
+
+  it('collapses empty zones cleanly', () => {
+    const layout = makeLayout({
+      zones: { kpi: [], leftRail: [], rightRail: [] },
+    });
+    renderLayout(layout);
+    expect(screen.queryByTestId('kpi-strip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('layout-left-rail')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('layout-right-rail')).not.toBeInTheDocument();
+  });
+
+  it('renders KPI strip with zone components', () => {
+    const layout = makeLayout({
+      zones: {
+        kpi: [
+          { id: 'k1', type: 'activity_timeline', config: {} },
+          { id: 'k2', type: 'notes', config: {} },
+        ],
+        leftRail: [],
+        rightRail: [],
+      },
+    });
+    renderLayout(layout);
+    expect(screen.getByTestId('kpi-strip')).toBeInTheDocument();
+    expect(screen.getByText('Activity Timeline')).toBeInTheDocument();
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+  });
+
+  it('renders left and right rails with their sections', () => {
+    const layout = makeLayout({
+      zones: {
+        kpi: [],
+        leftRail: [
+          {
+            id: 'left-sec',
+            label: 'Left Rail Section',
+            columns: 1,
+            components: [
+              { id: 'lr1', type: 'field', config: { fieldApiName: 'email' } },
+            ],
+          },
+        ],
+        rightRail: [
+          {
+            id: 'right-sec',
+            label: 'Right Rail Section',
+            columns: 1,
+            components: [
+              { id: 'rr1', type: 'field', config: { fieldApiName: 'phone' } },
+            ],
+          },
+        ],
+      },
+    });
+
+    renderLayout(layout);
+
+    expect(screen.getByTestId('layout-left-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('layout-right-rail')).toBeInTheDocument();
+    expect(screen.getByText('Left Rail Section')).toBeInTheDocument();
+    expect(screen.getByText('Right Rail Section')).toBeInTheDocument();
+  });
+
   it('renders section collapsed when collapsed is true', () => {
     const layout = makeLayout({
       tabs: [

--- a/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
+++ b/apps/web/src/__tests__/PageLayoutRenderer.test.tsx
@@ -579,6 +579,63 @@ describe('PageLayoutRenderer', () => {
     expect(screen.getByText('Notes')).toBeInTheDocument();
   });
 
+  it('hides KPI strip when every KPI component fails visibility', () => {
+    const layout = makeLayout({
+      zones: {
+        kpi: [
+          {
+            id: 'k-hidden',
+            type: 'activity_timeline',
+            config: {},
+            visibility: {
+              operator: 'AND',
+              conditions: [{ field: 'status', op: 'equals', value: 'Closed' }],
+            },
+          },
+        ],
+        leftRail: [],
+        rightRail: [],
+      },
+    });
+    renderLayout(layout);
+    expect(screen.queryByTestId('kpi-strip')).not.toBeInTheDocument();
+  });
+
+  it('hides rails when every rail section fails visibility', () => {
+    const layout = makeLayout({
+      zones: {
+        kpi: [],
+        leftRail: [
+          {
+            id: 'left-hidden',
+            label: 'Hidden Left',
+            columns: 1,
+            visibility: {
+              operator: 'AND',
+              conditions: [{ field: 'status', op: 'equals', value: 'Closed' }],
+            },
+            components: [],
+          },
+        ],
+        rightRail: [
+          {
+            id: 'right-hidden',
+            label: 'Hidden Right',
+            columns: 1,
+            visibility: {
+              operator: 'AND',
+              conditions: [{ field: 'status', op: 'equals', value: 'Closed' }],
+            },
+            components: [],
+          },
+        ],
+      },
+    });
+    renderLayout(layout);
+    expect(screen.queryByTestId('layout-left-rail')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('layout-right-rail')).not.toBeInTheDocument();
+  });
+
   it('renders left and right rails with their sections', () => {
     const layout = makeLayout({
       zones: {

--- a/apps/web/src/components/KpiStrip.module.css
+++ b/apps/web/src/components/KpiStrip.module.css
@@ -1,0 +1,17 @@
+/* ============================================================
+   KpiStrip — Horizontal row of KPI cards below the header
+   ============================================================ */
+
+.kpiStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.kpiItem {
+  flex: 1 1 180px;
+  min-width: 0;
+}

--- a/apps/web/src/components/KpiStrip.module.css
+++ b/apps/web/src/components/KpiStrip.module.css
@@ -4,14 +4,17 @@
 
 .kpiStrip {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   background: var(--color-surface, #fff);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 
 .kpiItem {
-  flex: 1 1 180px;
+  flex: 0 0 180px;
   min-width: 0;
 }

--- a/apps/web/src/components/KpiStrip.tsx
+++ b/apps/web/src/components/KpiStrip.tsx
@@ -1,0 +1,44 @@
+import type {
+  LayoutComponentDef,
+  RecordData,
+  FieldDefinitionRef,
+  ObjectDefinitionRef,
+} from './layoutTypes.js';
+import { LayoutComponent } from './LayoutComponent.js';
+import styles from './KpiStrip.module.css';
+
+interface KpiStripProps {
+  components: LayoutComponentDef[];
+  record: RecordData;
+  fields: FieldDefinitionRef[];
+  objectDef: ObjectDefinitionRef | null;
+  onRecordCreated?: () => void;
+}
+
+export function KpiStrip({
+  components,
+  record,
+  fields,
+  objectDef,
+  onRecordCreated,
+}: KpiStripProps) {
+  if (components.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.kpiStrip} data-testid="kpi-strip">
+      {components.map((comp) => (
+        <div key={comp.id} className={styles.kpiItem}>
+          <LayoutComponent
+            component={comp}
+            record={record}
+            fields={fields}
+            objectDef={objectDef}
+            onRecordCreated={onRecordCreated}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/KpiStrip.tsx
+++ b/apps/web/src/components/KpiStrip.tsx
@@ -5,6 +5,7 @@ import type {
   ObjectDefinitionRef,
 } from './layoutTypes.js';
 import { LayoutComponent } from './LayoutComponent.js';
+import { evaluateVisibility } from './evaluateVisibility.js';
 import styles from './KpiStrip.module.css';
 
 interface KpiStripProps {
@@ -22,13 +23,17 @@ export function KpiStrip({
   objectDef,
   onRecordCreated,
 }: KpiStripProps) {
-  if (components.length === 0) {
+  const visible = components.filter((c) =>
+    evaluateVisibility(c.visibility, record.fieldValues),
+  );
+
+  if (visible.length === 0) {
     return null;
   }
 
   return (
     <div className={styles.kpiStrip} data-testid="kpi-strip">
-      {components.map((comp) => (
+      {visible.map((comp) => (
         <div key={comp.id} className={styles.kpiItem}>
           <LayoutComponent
             component={comp}

--- a/apps/web/src/components/PageLayoutRenderer.module.css
+++ b/apps/web/src/components/PageLayoutRenderer.module.css
@@ -1,12 +1,83 @@
 /* ============================================================
-   PageLayoutRenderer — Main layout orchestrator
+   PageLayoutRenderer — Zoned record detail shell
    ============================================================ */
 
 .layoutRenderer {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.stickyTop {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--color-surface, #fff);
+}
+
+/* ── Body grid ────────────────────────────────────────────────
+   Base: main only. Rails are opted in via modifier classes so
+   layouts with empty zones collapse to a single full-width column
+   and match the pre-zones output. */
+.body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+  align-items: start;
+}
+
+.body.withLeftRail {
+  grid-template-columns: minmax(240px, 1fr) minmax(0, 3fr);
+}
+
+.body.withRightRail {
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
+}
+
+.body.withLeftRail.withRightRail {
+  grid-template-columns:
+    minmax(240px, 1fr)
+    minmax(0, 3fr)
+    minmax(280px, 1fr);
+}
+
+.rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .tabContent {
   display: flex;
   flex-direction: column;
+}
+
+/* ── Responsive: collapse rails under main on narrow screens ── */
+@media (max-width: 960px) {
+  .body,
+  .body.withLeftRail,
+  .body.withRightRail,
+  .body.withLeftRail.withRightRail {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .leftRail {
+    order: 2;
+  }
+
+  .main {
+    order: 1;
+  }
+
+  .rightRail {
+    order: 3;
+  }
 }

--- a/apps/web/src/components/PageLayoutRenderer.tsx
+++ b/apps/web/src/components/PageLayoutRenderer.tsx
@@ -4,10 +4,13 @@ import type {
   RecordData,
   FieldDefinitionRef,
   ObjectDefinitionRef,
+  LayoutSectionDef,
 } from './layoutTypes.js';
+import { EMPTY_ZONES } from './layoutTypes.js';
 import { RecordHeader } from './RecordHeader.js';
 import { PageLayoutTabBar } from './PageLayoutTabBar.js';
 import { LayoutSection } from './LayoutSection.js';
+import { KpiStrip } from './KpiStrip.js';
 import styles from './PageLayoutRenderer.module.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -25,8 +28,8 @@ interface PageLayoutRendererProps {
 
 /**
  * Renders a full record detail page from a PageLayout definition.
- * Always shows the RecordHeader at the top, followed by tab navigation,
- * and the active tab's sections.
+ * Shell: [header] · [KPI strip] · [left rail | main (tabs + sections) | right rail].
+ * Empty zones collapse; layouts without zones render like the pre-zones shell.
  */
 export function PageLayoutRenderer({
   layout,
@@ -41,37 +44,92 @@ export function PageLayoutRenderer({
   );
 
   const activeTab = layout.tabs.find((t) => t.id === activeTabId) ?? layout.tabs[0];
+  const zones = layout.zones ?? EMPTY_ZONES;
+  const hasLeftRail = zones.leftRail.length > 0;
+  const hasRightRail = zones.rightRail.length > 0;
+
+  const bodyClass = [
+    styles.body,
+    hasLeftRail ? styles.withLeftRail : '',
+    hasRightRail ? styles.withRightRail : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const renderRail = (sections: LayoutSectionDef[]) =>
+    sections.map((section) => (
+      <LayoutSection
+        key={section.id}
+        section={{ ...section, columns: 1 }}
+        record={record}
+        fields={fields}
+        objectDef={objectDef}
+        onRecordCreated={onRecordCreated}
+      />
+    ));
 
   return (
     <div className={styles.layoutRenderer} data-testid="page-layout-renderer">
-      <RecordHeader
-        layout={layout}
-        record={record}
-        objectDef={objectDef}
-        fields={fields}
-        actions={actions}
-      />
+      <div className={styles.stickyTop}>
+        <RecordHeader
+          layout={layout}
+          record={record}
+          objectDef={objectDef}
+          fields={fields}
+          actions={actions}
+        />
 
-      <PageLayoutTabBar
-        tabs={layout.tabs}
-        activeTabId={activeTabId}
-        onTabChange={setActiveTabId}
-      />
+        <KpiStrip
+          components={zones.kpi}
+          record={record}
+          fields={fields}
+          objectDef={objectDef}
+          onRecordCreated={onRecordCreated}
+        />
+      </div>
 
-      {activeTab && (
-        <div className={styles.tabContent} data-testid={`tab-content-${activeTab.id}`}>
-          {activeTab.sections.map((section) => (
-            <LayoutSection
-              key={section.id}
-              section={section}
-              record={record}
-              fields={fields}
-              objectDef={objectDef}
-              onRecordCreated={onRecordCreated}
-            />
-          ))}
+      <div className={bodyClass} data-testid="layout-body">
+        {hasLeftRail && (
+          <aside
+            className={`${styles.rail} ${styles.leftRail}`}
+            data-testid="layout-left-rail"
+          >
+            {renderRail(zones.leftRail)}
+          </aside>
+        )}
+
+        <div className={styles.main} data-testid="layout-main">
+          <PageLayoutTabBar
+            tabs={layout.tabs}
+            activeTabId={activeTabId}
+            onTabChange={setActiveTabId}
+          />
+
+          {activeTab && (
+            <div className={styles.tabContent} data-testid={`tab-content-${activeTab.id}`}>
+              {activeTab.sections.map((section) => (
+                <LayoutSection
+                  key={section.id}
+                  section={section}
+                  record={record}
+                  fields={fields}
+                  objectDef={objectDef}
+                  onRecordCreated={onRecordCreated}
+                />
+              ))}
+            </div>
+          )}
         </div>
-      )}
+
+        {hasRightRail && (
+          <aside
+            className={`${styles.rail} ${styles.rightRail}`}
+            data-testid="layout-right-rail"
+          >
+            {renderRail(zones.rightRail)}
+          </aside>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/PageLayoutRenderer.tsx
+++ b/apps/web/src/components/PageLayoutRenderer.tsx
@@ -11,6 +11,7 @@ import { RecordHeader } from './RecordHeader.js';
 import { PageLayoutTabBar } from './PageLayoutTabBar.js';
 import { LayoutSection } from './LayoutSection.js';
 import { KpiStrip } from './KpiStrip.js';
+import { evaluateVisibility } from './evaluateVisibility.js';
 import styles from './PageLayoutRenderer.module.css';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -45,8 +46,14 @@ export function PageLayoutRenderer({
 
   const activeTab = layout.tabs.find((t) => t.id === activeTabId) ?? layout.tabs[0];
   const zones = layout.zones ?? EMPTY_ZONES;
-  const hasLeftRail = zones.leftRail.length > 0;
-  const hasRightRail = zones.rightRail.length > 0;
+  const visibleLeftRail = zones.leftRail.filter((s) =>
+    evaluateVisibility(s.visibility, record.fieldValues),
+  );
+  const visibleRightRail = zones.rightRail.filter((s) =>
+    evaluateVisibility(s.visibility, record.fieldValues),
+  );
+  const hasLeftRail = visibleLeftRail.length > 0;
+  const hasRightRail = visibleRightRail.length > 0;
 
   const bodyClass = [
     styles.body,
@@ -94,7 +101,7 @@ export function PageLayoutRenderer({
             className={`${styles.rail} ${styles.leftRail}`}
             data-testid="layout-left-rail"
           >
-            {renderRail(zones.leftRail)}
+            {renderRail(visibleLeftRail)}
           </aside>
         )}
 
@@ -126,7 +133,7 @@ export function PageLayoutRenderer({
             className={`${styles.rail} ${styles.rightRail}`}
             data-testid="layout-right-rail"
           >
-            {renderRail(zones.rightRail)}
+            {renderRail(visibleRightRail)}
           </aside>
         )}
       </div>


### PR DESCRIPTION
## Summary

Closes #516. Rebuilds `PageLayoutRenderer` as a zoned record detail shell:

```
[ header band ]
[ KPI strip   ]
[ left rail | main (tabs + sections) | right rail ]
```

- Sticky top container wraps `RecordHeader` + new `KpiStrip`.
- Body is a CSS grid: `minmax(240px, 1fr) | minmax(0, 3fr) | minmax(280px, 1fr)`. Rails are opt-in via `withLeftRail` / `withRightRail` modifier classes, so layouts with empty zones collapse to a single full-width column and render identically to the pre-zones shell.
- New `KpiStrip` wrapper (`apps/web/src/components/KpiStrip.tsx`) dispatches each `zones.kpi` component through the existing `LayoutComponent` registry. The actual KPI card palette lands in #517.
- Rails render each `zones.leftRail` / `zones.rightRail` section through the existing `LayoutSection`, forced to `columns: 1`.
- Responsive: rails collapse below main under 960px.

## Test plan

- [x] `npm run test` — 683/683 pass (49 files).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — only pre-existing warnings in unrelated files.
- [x] New tests verify: legacy layouts (no zones) show no KPI strip or rails; empty zones collapse; KPI strip renders zone components; left + right rails render their sections.
- [x] Existing `PageLayoutRenderer` behavior (header, tabs, sections, visibility, related list, placeholders, collapsed state) unchanged.

Depends on #515 (zones schema) which is already merged. Styling to match the dark/mint mock is scoped to #519.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRenyRqVXbaQSv6P2VYw4D)_