### PR TITLE
feat(page-builder): MetricCard + KPI zone whitelist (#517)

### DIFF
--- a/apps/api/src/lib/componentRegistry.ts
+++ b/apps/api/src/lib/componentRegistry.ts
@@ -16,11 +16,27 @@
 
 export type ComponentCategory = 'fields' | 'layout' | 'related' | 'widgets';
 
+export type LayoutZone = 'header' | 'kpi' | 'leftRail' | 'main' | 'rightRail';
+
+export const ALL_ZONES: readonly LayoutZone[] = [
+  'header',
+  'kpi',
+  'leftRail',
+  'main',
+  'rightRail',
+];
+
 export interface ComponentDefinition {
   type: string;
   label: string;
   icon: string;
   category: ComponentCategory;
+  /**
+   * Zones where this component type is allowed.  Enforced by the layout
+   * validator on the backend and surfaced to the builder palette so the
+   * client can hide components that don't fit the active zone.
+   */
+  allowedZones: readonly LayoutZone[];
   configSchema: Record<string, unknown>;
   defaultConfig: Record<string, unknown>;
 }
@@ -34,6 +50,7 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
     label: 'Field',
     icon: 'text-cursor',
     category: 'fields',
+    allowedZones: ['leftRail', 'main', 'rightRail'],
     configSchema: {
       fieldId: { type: 'string', required: true, description: 'UUID of the field definition' },
       span: { type: 'number', description: 'Number of grid columns to span (default 1)' },
@@ -48,6 +65,7 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
     label: 'Related List',
     icon: 'list',
     category: 'related',
+    allowedZones: ['main', 'rightRail'],
     configSchema: {
       relationshipId: { type: 'string', required: true, description: 'UUID of the relationship definition' },
       displayFields: { type: 'array', items: 'string', description: 'Field api_names to show as columns' },
@@ -63,6 +81,7 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
     label: 'Activity Timeline',
     icon: 'clock',
     category: 'widgets',
+    allowedZones: ['main', 'rightRail'],
     configSchema: {
       showFilters: { type: 'boolean', description: 'Show activity type filter controls' },
       limit: { type: 'number', description: 'Number of activities to load initially' },
@@ -74,6 +93,7 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
     label: 'Sales Targets',
     icon: 'target',
     category: 'widgets',
+    allowedZones: ['main', 'rightRail'],
     configSchema: {
       showBusinessTarget: { type: 'boolean', description: 'Show business-level target progress bar' },
       showTeamTargets: { type: 'boolean', description: 'Show team-level target progress bars' },
@@ -89,6 +109,41 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
       periodType: 'quarterly',
     },
   },
+  {
+    type: 'metric',
+    label: 'Metric Card',
+    icon: 'gauge',
+    category: 'widgets',
+    allowedZones: ['kpi'],
+    configSchema: {
+      label: { type: 'string', required: true, description: 'Display label (e.g. "pipeline.open")' },
+      source: {
+        type: 'object',
+        required: true,
+        description:
+          'Value source — `{ kind: "field", fieldApiName }` or `{ kind: "aggregate", expr }`',
+      },
+      format: {
+        type: 'string',
+        description: 'Display format: currency, number, percent, duration',
+      },
+      target: {
+        type: 'object',
+        description:
+          'Optional target for progress bar — `{ kind: "field", fieldApiName }` or `{ kind: "literal", value }`',
+      },
+      accent: {
+        type: 'string',
+        description: 'Visual accent: default, success, warning, danger',
+      },
+    },
+    defaultConfig: {
+      label: '',
+      source: { kind: 'field', fieldApiName: '' },
+      format: 'number',
+      accent: 'default',
+    },
+  },
 
   // ── Layout components ───────────────────────────────────────────────────────
   {
@@ -96,6 +151,7 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
     label: 'Blank Space',
     icon: 'square',
     category: 'layout',
+    allowedZones: ['leftRail', 'main', 'rightRail'],
     configSchema: {
       height: { type: 'number', description: 'Height in pixels' },
     },
@@ -118,4 +174,14 @@ export const VALID_COMPONENT_TYPES: ReadonlySet<string> = new Set(
  */
 export function getComponentDefinition(type: string): ComponentDefinition | undefined {
   return COMPONENT_REGISTRY.find((c) => c.type === type);
+}
+
+/**
+ * Returns true when the given component type is permitted in the given zone,
+ * false when it is not or the type is unknown.
+ */
+export function isComponentAllowedInZone(type: string, zone: LayoutZone): boolean {
+  const def = getComponentDefinition(type);
+  if (!def) return false;
+  return def.allowedZones.includes(zone);
 }

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -1012,7 +1012,17 @@ describe('validateLayoutJson — zones', () => {
     const layout = {
       ...VALID_LAYOUT_JSON,
       zones: {
-        kpi: [{ id: 'k-1', type: 'field', config: { fieldId: 'uuid-1' } }],
+        kpi: [
+          {
+            id: 'k-1',
+            type: 'metric',
+            config: {
+              label: 'pipeline.open',
+              source: { kind: 'field', fieldApiName: 'amount' },
+              format: 'currency',
+            },
+          },
+        ],
         leftRail: [
           { id: 'lr-1', type: 'field_section', label: 'Left', columns: 1, components: [] },
         ],
@@ -1020,6 +1030,51 @@ describe('validateLayoutJson — zones', () => {
       },
     };
     expect(validateLayoutJson(layout)).toBeNull();
+  });
+
+  it('rejects a non-metric component in the kpi zone', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'field', config: { fieldId: 'uuid-1' } }],
+      },
+    };
+    const err = validateLayoutJson(layout);
+    expect(err).toContain('zones.kpi');
+    expect(err).toContain('"kpi" zone');
+  });
+
+  it('rejects a metric component outside the kpi zone (e.g. inside a tab section)', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      tabs: [
+        {
+          id: 'tab-1',
+          label: 'Details',
+          sections: [
+            {
+              id: 'sec-1',
+              type: 'field_section',
+              label: 'Info',
+              columns: 2,
+              components: [
+                {
+                  id: 'm-1',
+                  type: 'metric',
+                  config: {
+                    label: 'deals.open',
+                    source: { kind: 'field', fieldApiName: 'count' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const err = validateLayoutJson(layout);
+    expect(err).toContain('metric');
+    expect(err).toContain('"main" zone');
   });
 
   it('rejects zones when it is not an object', () => {

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -4,7 +4,11 @@ import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
 import type { PageLayouts, PageLayoutVersions } from '../db/kysely.types.js';
-import { VALID_COMPONENT_TYPES } from '../lib/componentRegistry.js';
+import {
+  VALID_COMPONENT_TYPES,
+  isComponentAllowedInZone,
+  type LayoutZone,
+} from '../lib/componentRegistry.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -229,7 +233,7 @@ function validateVisibilityRule(rule: unknown): string | null {
   return null;
 }
 
-function validateComponent(comp: unknown): string | null {
+function validateComponent(comp: unknown, zone?: LayoutZone): string | null {
   if (typeof comp !== 'object' || comp === null) {
     return 'Each component must be an object';
   }
@@ -244,13 +248,17 @@ function validateComponent(comp: unknown): string | null {
     return `Component "${c.id}" must have a config object`;
   }
 
+  if (zone && !isComponentAllowedInZone(c.type, zone)) {
+    return `Component "${c.id}" of type "${c.type}" is not allowed in the "${zone}" zone`;
+  }
+
   const compVisErr = validateVisibilityRule(c.visibility);
   if (compVisErr) return `Component "${c.id}": ${compVisErr}`;
 
   return null;
 }
 
-function validateSection(section: unknown): string | null {
+function validateSection(section: unknown, zone?: LayoutZone): string | null {
   if (typeof section !== 'object' || section === null) {
     return 'Each section must be an object';
   }
@@ -273,7 +281,7 @@ function validateSection(section: unknown): string | null {
   }
 
   for (const comp of s.components) {
-    const compErr = validateComponent(comp);
+    const compErr = validateComponent(comp, zone);
     if (compErr) return compErr;
   }
 
@@ -293,7 +301,7 @@ function validateZones(zones: unknown): string | null {
       return 'layout.zones.kpi must be an array';
     }
     for (const comp of z.kpi) {
-      const compErr = validateComponent(comp);
+      const compErr = validateComponent(comp, 'kpi');
       if (compErr) return `zones.kpi: ${compErr}`;
     }
   }
@@ -304,7 +312,7 @@ function validateZones(zones: unknown): string | null {
         return `layout.zones.${rail} must be an array`;
       }
       for (const section of z[rail] as unknown[]) {
-        const secErr = validateSection(section);
+        const secErr = validateSection(section, rail);
         if (secErr) return `zones.${rail}: ${secErr}`;
       }
     }
@@ -365,7 +373,7 @@ export function validateLayoutJson(layout: unknown): string | null {
     }
 
     for (const section of t.sections) {
-      const secErr = validateSection(section);
+      const secErr = validateSection(section, 'main');
       if (secErr) return secErr;
     }
   }

--- a/apps/web/src/__tests__/MetricCard.test.tsx
+++ b/apps/web/src/__tests__/MetricCard.test.tsx
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MetricCard } from '../components/MetricCard.js';
+import type {
+  LayoutComponentDef,
+  RecordData,
+} from '../components/layoutTypes.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRecord(fieldValues: Record<string, unknown> = {}): RecordData {
+  return {
+    id: 'rec-1',
+    objectId: 'obj-1',
+    name: 'Acme Corp',
+    fieldValues,
+    ownerId: 'user-1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+    fields: [],
+    relationships: [],
+  };
+}
+
+function renderMetric(
+  config: Record<string, unknown>,
+  fieldValues: Record<string, unknown> = {},
+) {
+  const component: LayoutComponentDef = {
+    id: 'm-1',
+    type: 'metric',
+    config,
+  };
+  return render(
+    <MetricCard
+      component={component}
+      record={makeRecord(fieldValues)}
+      fields={[]}
+      objectDef={null}
+    />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('MetricCard', () => {
+  // ── Field source ────────────────────────────────────────────────────────
+
+  it('renders a plain numeric field value with the label', () => {
+    renderMetric(
+      {
+        label: 'deals.open',
+        source: { kind: 'field', fieldApiName: 'deal_count' },
+      },
+      { deal_count: 12 },
+    );
+
+    expect(screen.getByText('deals.open')).toBeInTheDocument();
+    expect(screen.getByTestId('metric-value')).toHaveTextContent('12');
+  });
+
+  it('coerces string numbers from the record', () => {
+    renderMetric(
+      {
+        label: 'count',
+        source: { kind: 'field', fieldApiName: 'amount' },
+      },
+      { amount: '42' },
+    );
+
+    expect(screen.getByTestId('metric-value')).toHaveTextContent('42');
+  });
+
+  it('renders a dash when the referenced field is missing / non-numeric', () => {
+    renderMetric(
+      {
+        label: 'foo',
+        source: { kind: 'field', fieldApiName: 'missing' },
+      },
+      {},
+    );
+
+    expect(screen.getByTestId('metric-value')).toHaveTextContent('—');
+  });
+
+  // ── Format variants ─────────────────────────────────────────────────────
+
+  it('formats currency values using the tenant locale', () => {
+    renderMetric(
+      {
+        label: 'pipeline.open',
+        source: { kind: 'field', fieldApiName: 'amount' },
+        format: 'currency',
+      },
+      { amount: 12345.67 },
+    );
+
+    const value = screen.getByTestId('metric-value').textContent ?? '';
+    // Default tenant locale: GBP / en-GB → "£12,345.67"
+    expect(value).toMatch(/£/);
+    expect(value).toMatch(/12[.,]345/);
+  });
+
+  it('formats percent values with a trailing % sign', () => {
+    renderMetric(
+      {
+        label: 'win.rate',
+        source: { kind: 'field', fieldApiName: 'rate' },
+        format: 'percent',
+      },
+      { rate: 67 },
+    );
+
+    expect(screen.getByTestId('metric-value')).toHaveTextContent('67%');
+  });
+
+  it('formats duration values in a compact unit', () => {
+    renderMetric(
+      {
+        label: 'avg.cycle',
+        source: { kind: 'field', fieldApiName: 'seconds' },
+        format: 'duration',
+      },
+      { seconds: 90 },
+    );
+
+    // 90s → 2m (rounded)
+    expect(screen.getByTestId('metric-value')).toHaveTextContent('2m');
+  });
+
+  // ── Progress bar ────────────────────────────────────────────────────────
+
+  it('does not render a progress bar when target is missing', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+      },
+      { v: 5 },
+    );
+
+    expect(screen.queryByTestId('metric-progress')).not.toBeInTheDocument();
+  });
+
+  it('renders progress at 0% when value is 0', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+        target: { kind: 'literal', value: 100 },
+      },
+      { v: 0 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-valuenow', '0');
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  it('renders progress at 50% when value is half of target', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+        target: { kind: 'literal', value: 100 },
+      },
+      { v: 50 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-valuenow', '50');
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe('50%');
+  });
+
+  it('renders progress at 100% when value equals target', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+        target: { kind: 'literal', value: 100 },
+      },
+      { v: 100 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('caps progress at 100% when value exceeds target', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+        target: { kind: 'literal', value: 100 },
+      },
+      { v: 250 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('uses a record field as the target when target.kind === "field"', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'actual' },
+        target: { kind: 'field', fieldApiName: 'quota' },
+      },
+      { actual: 40, quota: 200 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-valuenow', '20');
+  });
+
+  it('omits the progress bar when the target field cannot be resolved', () => {
+    renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'actual' },
+        target: { kind: 'field', fieldApiName: 'missing' },
+      },
+      { actual: 40 },
+    );
+
+    expect(screen.queryByTestId('metric-progress')).not.toBeInTheDocument();
+  });
+
+  // ── Aggregate source placeholder ────────────────────────────────────────
+
+  it('renders a clearly-marked placeholder for aggregate sources', () => {
+    renderMetric({
+      label: 'pipeline.total',
+      source: { kind: 'aggregate', expr: 'sum(opportunities.amount)' },
+      format: 'currency',
+    });
+
+    const card = screen.getByTestId('metric-card');
+    expect(card).toHaveAttribute('data-metric-source', 'aggregate');
+
+    const placeholder = within(card).getByTestId('metric-value-placeholder');
+    expect(placeholder).toHaveTextContent('—');
+    expect(placeholder).toHaveAttribute('title', expect.stringContaining('sum(opportunities.amount)'));
+
+    // A stub annotation is visible so users know the value is not real.
+    expect(within(card).getByText(/aggregate/i)).toBeInTheDocument();
+  });
+
+  it('does not render a progress bar for aggregate sources (no numeric value)', () => {
+    renderMetric({
+      label: 'x',
+      source: { kind: 'aggregate', expr: 'count(*)' },
+      target: { kind: 'literal', value: 100 },
+    });
+
+    expect(screen.queryByTestId('metric-progress')).not.toBeInTheDocument();
+  });
+
+  // ── Accent variants ─────────────────────────────────────────────────────
+
+  it('applies the requested accent class', () => {
+    const { container } = renderMetric(
+      {
+        label: 'x',
+        source: { kind: 'field', fieldApiName: 'v' },
+        accent: 'danger',
+      },
+      { v: 1 },
+    );
+
+    const card = container.querySelector('[data-testid="metric-card"]');
+    expect(card?.className).toMatch(/accent-danger/);
+  });
+});

--- a/apps/web/src/__tests__/iconMap.test.ts
+++ b/apps/web/src/__tests__/iconMap.test.ts
@@ -8,6 +8,7 @@ describe('resolveIcon', () => {
     expect(resolveIcon('square')).toBe('⬜');
     expect(resolveIcon('text-cursor')).toBe('✏️');
     expect(resolveIcon('list')).toBe('📋');
+    expect(resolveIcon('gauge')).toBe('📊');
   });
 
   it('maps field type identifiers to emoji characters', () => {

--- a/apps/web/src/components/LayoutComponent.tsx
+++ b/apps/web/src/components/LayoutComponent.tsx
@@ -5,6 +5,7 @@ import { LayoutFieldRenderer } from './LayoutFieldRenderer.js';
 import { RelatedListRenderer } from './RelatedListRenderer.js';
 import { PlaceholderWidget } from './PlaceholderWidget.js';
 import { SalesTargetsRenderer } from './SalesTargetsRenderer.js';
+import { MetricCard } from './MetricCard.js';
 
 // ─── Component registry (map, not switch) ─────────────────────────────────────
 
@@ -12,6 +13,7 @@ const COMPONENT_RENDERERS: Record<string, ComponentType<ComponentRendererProps>>
   field: LayoutFieldRenderer,
   related_list: RelatedListRenderer,
   sales_targets: SalesTargetsRenderer,
+  metric: MetricCard,
   activity_timeline: PlaceholderWidget,
   notes: PlaceholderWidget,
   stage_history: PlaceholderWidget,

--- a/apps/web/src/components/MetricCard.module.css
+++ b/apps/web/src/components/MetricCard.module.css
@@ -1,0 +1,106 @@
+/* ============================================================
+   MetricCard — single KPI card rendered in the `kpi` zone
+   ============================================================ */
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.875rem 0.625rem;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius-md, 8px);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.label {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #6b7280);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.value {
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #111827);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.valuePlaceholder {
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-text-muted, #9ca3af);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.valueInvalid {
+  font-size: 1.625rem;
+  font-weight: 700;
+  color: var(--color-text-muted, #9ca3af);
+  line-height: 1.1;
+}
+
+.stubNote {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.625rem;
+  color: var(--color-text-muted, #9ca3af);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.progressTrack {
+  margin-top: 0.25rem;
+  height: 3px;
+  background: var(--color-surface-subtle, #f3f4f6);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--color-accent, #6366f1);
+  border-radius: 999px;
+  transition: width 200ms ease-out;
+}
+
+/* ── Accent variants ─────────────────────────────────────── */
+
+.accent-default .progressFill {
+  background: var(--color-accent, #6366f1);
+}
+
+.accent-success .progressFill {
+  background: var(--color-success, #10b981);
+}
+
+.accent-success .value {
+  color: var(--color-success, #10b981);
+}
+
+.accent-warning .progressFill {
+  background: var(--color-warning, #f59e0b);
+}
+
+.accent-warning .value {
+  color: var(--color-warning, #d97706);
+}
+
+.accent-danger .progressFill {
+  background: var(--color-danger, #ef4444);
+}
+
+.accent-danger .value {
+  color: var(--color-danger, #dc2626);
+}

--- a/apps/web/src/components/MetricCard.tsx
+++ b/apps/web/src/components/MetricCard.tsx
@@ -1,0 +1,163 @@
+import type { ComponentRendererProps } from './layoutTypes.js';
+import { useTenantLocale } from '../useTenantLocale.js';
+import styles from './MetricCard.module.css';
+
+export type MetricFormat = 'currency' | 'number' | 'percent' | 'duration';
+export type MetricAccent = 'default' | 'success' | 'warning' | 'danger';
+
+export type MetricSource =
+  | { kind: 'field'; fieldApiName: string }
+  | { kind: 'aggregate'; expr: string };
+
+export type MetricTarget =
+  | { kind: 'field'; fieldApiName: string }
+  | { kind: 'literal'; value: number };
+
+export interface MetricCardConfig {
+  label: string;
+  source: MetricSource;
+  format?: MetricFormat;
+  target?: MetricTarget;
+  accent?: MetricAccent;
+}
+
+function isMetricSource(v: unknown): v is MetricSource {
+  if (typeof v !== 'object' || v === null) return false;
+  const s = v as Record<string, unknown>;
+  if (s.kind === 'field') return typeof s.fieldApiName === 'string';
+  if (s.kind === 'aggregate') return typeof s.expr === 'string';
+  return false;
+}
+
+function isMetricTarget(v: unknown): v is MetricTarget {
+  if (typeof v !== 'object' || v === null) return false;
+  const t = v as Record<string, unknown>;
+  if (t.kind === 'field') return typeof t.fieldApiName === 'string';
+  if (t.kind === 'literal') return typeof t.value === 'number';
+  return false;
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function formatDuration(seconds: number): string {
+  const abs = Math.abs(seconds);
+  if (abs < 60) return `${Math.round(seconds)}s`;
+  if (abs < 3_600) return `${Math.round(seconds / 60)}m`;
+  if (abs < 86_400) return `${(seconds / 3_600).toFixed(1)}h`;
+  return `${(seconds / 86_400).toFixed(1)}d`;
+}
+
+export function MetricCard({ component, record }: ComponentRendererProps) {
+  const { formatCurrency, formatNumber } = useTenantLocale();
+  const cfg = component.config as Partial<MetricCardConfig>;
+
+  const label = typeof cfg.label === 'string' ? cfg.label : '';
+  const accent: MetricAccent =
+    cfg.accent === 'success' ||
+    cfg.accent === 'warning' ||
+    cfg.accent === 'danger'
+      ? cfg.accent
+      : 'default';
+  const format: MetricFormat | undefined = cfg.format;
+
+  if (!isMetricSource(cfg.source)) {
+    return (
+      <div
+        className={`${styles.card} ${styles[`accent-${accent}`] ?? ''}`}
+        data-testid="metric-card"
+      >
+        <div className={styles.label}>{label}</div>
+        <div className={styles.valueInvalid} data-testid="metric-value">
+          —
+        </div>
+      </div>
+    );
+  }
+
+  // ── Aggregate source is a stub this round ────────────────────────────────
+  if (cfg.source.kind === 'aggregate') {
+    return (
+      <div
+        className={`${styles.card} ${styles[`accent-${accent}`] ?? ''}`}
+        data-testid="metric-card"
+        data-metric-source="aggregate"
+      >
+        <div className={styles.label}>{label}</div>
+        <div
+          className={styles.valuePlaceholder}
+          data-testid="metric-value-placeholder"
+          title={`Aggregate not yet implemented: ${cfg.source.expr}`}
+        >
+          —
+        </div>
+        <div className={styles.stubNote}>aggregate (pending)</div>
+      </div>
+    );
+  }
+
+  // ── Field source ─────────────────────────────────────────────────────────
+  const raw = record.fieldValues[cfg.source.fieldApiName];
+  const numeric = coerceNumber(raw);
+
+  let display: string;
+  if (numeric === null) {
+    display = '—';
+  } else if (format === 'currency') {
+    display = formatCurrency(numeric);
+  } else if (format === 'percent') {
+    display = `${formatNumber(Math.round(numeric * 10) / 10)}%`;
+  } else if (format === 'duration') {
+    display = formatDuration(numeric);
+  } else {
+    display = formatNumber(numeric);
+  }
+
+  // ── Target / progress bar ────────────────────────────────────────────────
+  let progressRatio: number | null = null;
+  let targetNumeric: number | null = null;
+  if (isMetricTarget(cfg.target) && numeric !== null) {
+    if (cfg.target.kind === 'literal') {
+      targetNumeric = cfg.target.value;
+    } else {
+      targetNumeric = coerceNumber(record.fieldValues[cfg.target.fieldApiName]);
+    }
+    if (targetNumeric !== null && targetNumeric > 0) {
+      progressRatio = Math.max(0, Math.min(numeric / targetNumeric, 1));
+    }
+  }
+
+  return (
+    <div
+      className={`${styles.card} ${styles[`accent-${accent}`] ?? ''}`}
+      data-testid="metric-card"
+      data-metric-source="field"
+    >
+      <div className={styles.label}>{label}</div>
+      <div className={styles.value} data-testid="metric-value">
+        {display}
+      </div>
+      {progressRatio !== null && (
+        <div
+          className={styles.progressTrack}
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(progressRatio * 100)}
+          data-testid="metric-progress"
+        >
+          <div
+            className={styles.progressFill}
+            style={{ width: `${progressRatio * 100}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/iconMap.ts
+++ b/apps/web/src/components/iconMap.ts
@@ -8,6 +8,7 @@ const ICON_MAP: Record<string, string> = {
   clock: '🕐',
   target: '🎯',
   square: '⬜',
+  gauge: '📊',
   // Field-type icons
   text: '✏️',
   textarea: '📝',


### PR DESCRIPTION
Closes #517.

## Summary

Third of the 8-part page-builder zones series. Adds the `metric`
component type — the only valid occupant of the `kpi` zone — and wires
the registry / validator to enforce that whitelist end-to-end.

- **`MetricCard` component** (`apps/web/src/components/MetricCard.tsx` + CSS module)
  - Monospace label, large numeric value, thin progress bar below.
  - Format modes: `currency` | `number` | `percent` | `duration`.
    Currency + number use the tenant locale formatters.
  - `target`: `{ kind: 'field', fieldApiName }` or
    `{ kind: 'literal', value }`. Progress = `min(value / target, 1)`,
    rendered with accent colouring and capped at 100% when over-target.
  - `source.kind === 'aggregate'`: renders a clearly-marked placeholder
    (em-dash + "aggregate (pending)" stub note, title attr echoes the
    expression). The aggregation engine lands in a separate epic.
  - Accent variants: `default` | `success` | `warning` | `danger`.

- **Component registry** (`apps/api/src/lib/componentRegistry.ts`)
  - New `allowedZones: readonly LayoutZone[]` field on each definition.
  - New `metric` entry → `allowedZones: ['kpi']`.
  - New `isComponentAllowedInZone()` helper.

- **Layout validator** (`apps/api/src/services/pageLayoutService.ts`)
  - `validateComponent(comp, zone)` now rejects components whose type
    isn't permitted in that zone.
  - Applied to `zones.kpi` (zone = `'kpi'`), `zones.leftRail` /
    `zones.rightRail`, and tab sections (zone = `'main'`).

- **Renderer dispatch**: `LayoutComponent` maps `metric` → `MetricCard`.

- **Palette icon**: `gauge` → 📊 in `iconMap`.

## Test plan

- [x] `MetricCard` renders a field source.
- [x] `MetricCard` formats currency / percent / duration.
- [x] Progress bar renders at 0 / 50 / 100 / >100%.
- [x] Aggregate source renders a placeholder.
- [x] Backend validator rejects a non-`metric` component in `kpi`.
- [x] Backend validator rejects a `metric` component outside `kpi`.
- [x] `npx vitest run` (web): 50 files / 702 tests pass.
- [x] `npx vitest run` (api): 77 files / 1530 tests pass.
- [x] `tsc --noEmit` clean on both workspaces.

https://claude.ai/code/session_018ggoJzwUTEuP9SeKhfp22P

---
_Generated by [Claude Code](https://claude.ai/code/session_018ggoJzwUTEuP9SeKhfp22P)_