### PR TITLE
feat(page-layout): rail palette — identity, contacts, activity (#518)

### DIFF
--- a/apps/api/src/lib/__tests__/componentRegistry.test.ts
+++ b/apps/api/src/lib/__tests__/componentRegistry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COMPONENT_REGISTRY,
+  VALID_COMPONENT_TYPES,
+  getComponentDefinition,
+  isComponentAllowedInZone,
+} from '../componentRegistry.js';
+
+describe('componentRegistry', () => {
+  describe('VALID_COMPONENT_TYPES', () => {
+    it('contains one entry per registered component', () => {
+      expect(VALID_COMPONENT_TYPES.size).toBe(COMPONENT_REGISTRY.length);
+    });
+
+    it('includes the rail palette types (issue #518)', () => {
+      expect(VALID_COMPONENT_TYPES.has('identity')).toBe(true);
+      expect(VALID_COMPONENT_TYPES.has('contacts')).toBe(true);
+      expect(VALID_COMPONENT_TYPES.has('activity')).toBe(true);
+    });
+  });
+
+  describe('getComponentDefinition', () => {
+    it('returns the definition for a registered type', () => {
+      const def = getComponentDefinition('identity');
+      expect(def?.type).toBe('identity');
+      expect(def?.allowedZones).toEqual(['leftRail', 'rightRail', 'main']);
+    });
+
+    it('returns undefined for an unregistered type', () => {
+      expect(getComponentDefinition('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('isComponentAllowedInZone', () => {
+    it('allows rail components in rail zones', () => {
+      for (const type of ['identity', 'contacts', 'activity']) {
+        expect(isComponentAllowedInZone(type, 'leftRail')).toBe(true);
+        expect(isComponentAllowedInZone(type, 'rightRail')).toBe(true);
+        expect(isComponentAllowedInZone(type, 'main')).toBe(true);
+      }
+    });
+
+    it('rejects rail components in the kpi zone', () => {
+      for (const type of ['identity', 'contacts', 'activity']) {
+        expect(isComponentAllowedInZone(type, 'kpi')).toBe(false);
+      }
+    });
+
+    it('allows components with no allowedZones in every zone (back-compat)', () => {
+      // `field` has no allowedZones → permitted anywhere.
+      for (const zone of ['kpi', 'leftRail', 'rightRail', 'main'] as const) {
+        expect(isComponentAllowedInZone('field', zone)).toBe(true);
+      }
+    });
+
+    it('returns false for unknown component types', () => {
+      expect(isComponentAllowedInZone('nonexistent', 'kpi')).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/lib/componentRegistry.ts
+++ b/apps/api/src/lib/componentRegistry.ts
@@ -8,6 +8,9 @@
  * - **type**          – unique key used in layout JSON (`component.type`)
  * - **label / icon**  – display metadata for the builder palette
  * - **category**      – grouping in the palette sidebar
+ * - **allowedZones**  – optional whitelist of zones where the component may be
+ *                       placed.  Omitted = allowed everywhere (backwards compat).
+ *                       Zones: 'kpi', 'leftRail', 'rightRail', 'main'.
  * - **configSchema**  – JSON-Schema-like description of the `config` object
  * - **defaultConfig** – sensible defaults applied when a component is first added
  */
@@ -16,11 +19,17 @@
 
 export type ComponentCategory = 'fields' | 'layout' | 'related' | 'widgets';
 
+/** Zones referenced by `allowedZones`. 'main' = inside a tab's section. */
+export type ComponentZone = 'kpi' | 'leftRail' | 'rightRail' | 'main';
+
+export const ALL_ZONES: readonly ComponentZone[] = ['kpi', 'leftRail', 'rightRail', 'main'];
+
 export interface ComponentDefinition {
   type: string;
   label: string;
   icon: string;
   category: ComponentCategory;
+  allowedZones?: readonly ComponentZone[];
   configSchema: Record<string, unknown>;
   defaultConfig: Record<string, unknown>;
 }
@@ -55,6 +64,57 @@ export const COMPONENT_REGISTRY: readonly ComponentDefinition[] = [
       allowCreate: { type: 'boolean', description: 'Show inline "New" button' },
     },
     defaultConfig: { relationshipId: '', displayFields: [], limit: 5, allowCreate: true },
+  },
+
+  // ── Rail palette (issue #518) ───────────────────────────────────────────────
+  // Bread-and-butter components for the leftRail / rightRail zones.  Also
+  // allowed in the main zone (inside tab sections).
+  {
+    type: 'identity',
+    label: 'Identity',
+    icon: 'id-card',
+    category: 'widgets',
+    allowedZones: ['leftRail', 'rightRail', 'main'],
+    configSchema: {
+      fields: {
+        type: 'array',
+        items: 'string',
+        description: 'Field api_names to show as label/value rows',
+      },
+    },
+    defaultConfig: { fields: [] },
+  },
+  {
+    type: 'contacts',
+    label: 'Contacts',
+    icon: 'users',
+    category: 'widgets',
+    allowedZones: ['leftRail', 'rightRail', 'main'],
+    configSchema: {
+      relationshipId: {
+        type: 'string',
+        required: true,
+        description: 'UUID of the relationship to the contact object',
+      },
+      limit: { type: 'number', description: 'Max contacts to display' },
+    },
+    defaultConfig: { relationshipId: '', limit: 5 },
+  },
+  {
+    type: 'activity',
+    label: 'Activity Feed',
+    icon: 'activity',
+    category: 'widgets',
+    allowedZones: ['leftRail', 'rightRail', 'main'],
+    configSchema: {
+      limit: { type: 'number', description: 'Max activity items to display' },
+      types: {
+        type: 'array',
+        items: 'string',
+        description: 'Activity types to include (e.g. replied, call, edit, note, meeting)',
+      },
+    },
+    defaultConfig: { limit: 20, types: [] },
   },
 
   // ── Widget components ───────────────────────────────────────────────────────
@@ -118,4 +178,17 @@ export const VALID_COMPONENT_TYPES: ReadonlySet<string> = new Set(
  */
 export function getComponentDefinition(type: string): ComponentDefinition | undefined {
   return COMPONENT_REGISTRY.find((c) => c.type === type);
+}
+
+/**
+ * Returns true if a component type is allowed in the given zone.
+ * Components that do not declare `allowedZones` are permitted in any zone.
+ * Unknown component types return false — caller should separately check
+ * `VALID_COMPONENT_TYPES` for a clearer error message.
+ */
+export function isComponentAllowedInZone(type: string, zone: ComponentZone): boolean {
+  const def = getComponentDefinition(type);
+  if (!def) return false;
+  if (!def.allowedZones) return true;
+  return def.allowedZones.includes(zone);
 }

--- a/apps/api/src/services/__tests__/pageLayoutService.test.ts
+++ b/apps/api/src/services/__tests__/pageLayoutService.test.ts
@@ -1058,6 +1058,96 @@ describe('validateLayoutJson — zones', () => {
     };
     expect(validateLayoutJson(layout)).toContain('zones.kpi');
   });
+
+  // ── Zone whitelist (issue #518) ──────────────────────────────────────────
+  // Components with `allowedZones` can only appear in zones they whitelist.
+  // Rail palette components (identity, contacts, activity) are restricted to
+  // leftRail / rightRail / main — so a KPI placement must be rejected.
+
+  it('accepts an identity component in leftRail', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        leftRail: [
+          {
+            id: 'lr-1',
+            type: 'field_section',
+            label: 'Identity',
+            columns: 1,
+            components: [
+              { id: 'c-1', type: 'identity', config: { fields: ['name'] } },
+            ],
+          },
+        ],
+      },
+    };
+    expect(validateLayoutJson(layout)).toBeNull();
+  });
+
+  it('accepts a contacts component in rightRail', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        rightRail: [
+          {
+            id: 'rr-1',
+            type: 'related_list',
+            label: 'Contacts',
+            columns: 1,
+            components: [
+              { id: 'c-1', type: 'contacts', config: { relationshipId: 'rel-1' } },
+            ],
+          },
+        ],
+      },
+    };
+    expect(validateLayoutJson(layout)).toBeNull();
+  });
+
+  it('accepts an activity component in a main-zone section', () => {
+    const layout = {
+      header: { primaryField: 'name' },
+      tabs: [{
+        id: 'tab-1', label: 'Tab', sections: [{
+          id: 'sec-1', type: 'widget_section', label: 'Activity', columns: 1,
+          components: [{ id: 'c-1', type: 'activity', config: { limit: 5 } }],
+        }],
+      }],
+    };
+    expect(validateLayoutJson(layout)).toBeNull();
+  });
+
+  it('rejects a rail-only component (identity) placed in the kpi zone', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'identity', config: { fields: [] } }],
+      },
+    };
+    const err = validateLayoutJson(layout);
+    expect(err).toContain('zones.kpi');
+    expect(err).toContain('not allowed in zone "kpi"');
+  });
+
+  it('rejects a rail-only component (contacts) placed in the kpi zone', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'contacts', config: { relationshipId: 'rel-1' } }],
+      },
+    };
+    expect(validateLayoutJson(layout)).toContain('not allowed in zone "kpi"');
+  });
+
+  it('rejects a rail-only component (activity) placed in the kpi zone', () => {
+    const layout = {
+      ...VALID_LAYOUT_JSON,
+      zones: {
+        kpi: [{ id: 'k-1', type: 'activity', config: {} }],
+      },
+    };
+    expect(validateLayoutJson(layout)).toContain('not allowed in zone "kpi"');
+  });
 });
 
 // ─── Tests: service read-path normalises zones ───────────────────────────────

--- a/apps/api/src/services/pageLayoutService.ts
+++ b/apps/api/src/services/pageLayoutService.ts
@@ -4,7 +4,11 @@ import type { Selectable, Updateable } from 'kysely';
 import { logger } from '../lib/logger.js';
 import { db } from '../db/kysely.js';
 import type { PageLayouts, PageLayoutVersions } from '../db/kysely.types.js';
-import { VALID_COMPONENT_TYPES } from '../lib/componentRegistry.js';
+import {
+  VALID_COMPONENT_TYPES,
+  isComponentAllowedInZone,
+  type ComponentZone,
+} from '../lib/componentRegistry.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -229,7 +233,7 @@ function validateVisibilityRule(rule: unknown): string | null {
   return null;
 }
 
-function validateComponent(comp: unknown): string | null {
+function validateComponent(comp: unknown, zone: ComponentZone): string | null {
   if (typeof comp !== 'object' || comp === null) {
     return 'Each component must be an object';
   }
@@ -239,6 +243,9 @@ function validateComponent(comp: unknown): string | null {
   }
   if (typeof c.type !== 'string' || !VALID_COMPONENT_TYPES.has(c.type)) {
     return `Component "${c.id}" has invalid type: ${String(c.type)}. Must be one of: ${[...VALID_COMPONENT_TYPES].join(', ')}`;
+  }
+  if (!isComponentAllowedInZone(c.type, zone)) {
+    return `Component "${c.id}" of type "${c.type}" is not allowed in zone "${zone}"`;
   }
   if (typeof c.config !== 'object' || c.config === null) {
     return `Component "${c.id}" must have a config object`;
@@ -250,7 +257,7 @@ function validateComponent(comp: unknown): string | null {
   return null;
 }
 
-function validateSection(section: unknown): string | null {
+function validateSection(section: unknown, zone: ComponentZone): string | null {
   if (typeof section !== 'object' || section === null) {
     return 'Each section must be an object';
   }
@@ -273,7 +280,7 @@ function validateSection(section: unknown): string | null {
   }
 
   for (const comp of s.components) {
-    const compErr = validateComponent(comp);
+    const compErr = validateComponent(comp, zone);
     if (compErr) return compErr;
   }
 
@@ -293,7 +300,7 @@ function validateZones(zones: unknown): string | null {
       return 'layout.zones.kpi must be an array';
     }
     for (const comp of z.kpi) {
-      const compErr = validateComponent(comp);
+      const compErr = validateComponent(comp, 'kpi');
       if (compErr) return `zones.kpi: ${compErr}`;
     }
   }
@@ -304,7 +311,7 @@ function validateZones(zones: unknown): string | null {
         return `layout.zones.${rail} must be an array`;
       }
       for (const section of z[rail] as unknown[]) {
-        const secErr = validateSection(section);
+        const secErr = validateSection(section, rail);
         if (secErr) return `zones.${rail}: ${secErr}`;
       }
     }
@@ -365,7 +372,7 @@ export function validateLayoutJson(layout: unknown): string | null {
     }
 
     for (const section of t.sections) {
-      const secErr = validateSection(section);
+      const secErr = validateSection(section, 'main');
       if (secErr) return secErr;
     }
   }

--- a/apps/web/src/__tests__/ActivityFeed.test.tsx
+++ b/apps/web/src/__tests__/ActivityFeed.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActivityFeed } from '../components/ActivityFeed.js';
+import type {
+  LayoutComponentDef,
+  RecordData,
+  ObjectDefinitionRef,
+} from '../components/layoutTypes.js';
+
+const objectDef: ObjectDefinitionRef = {
+  id: 'obj-1',
+  apiName: 'account',
+  label: 'Account',
+  pluralLabel: 'Accounts',
+  isSystem: true,
+};
+
+function makeRecord(): RecordData {
+  return {
+    id: 'rec-1',
+    objectId: 'obj-1',
+    name: 'Acme',
+    fieldValues: {},
+    ownerId: 'u-1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+    fields: [],
+    relationships: [],
+  };
+}
+
+function makeComponent(config: Record<string, unknown>): LayoutComponentDef {
+  return { id: 'c-1', type: 'activity', config };
+}
+
+describe('ActivityFeed', () => {
+  it('renders without crashing with empty config', () => {
+    const record = makeRecord();
+    render(
+      <ActivityFeed
+        component={makeComponent({})}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByTestId('activity-feed')).toBeInTheDocument();
+  });
+
+  it('renders the ActivityPanel empty-state when there are no activity items', () => {
+    const record = makeRecord();
+    render(
+      <ActivityFeed
+        component={makeComponent({ limit: 10 })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByText('No recent activity')).toBeInTheDocument();
+  });
+
+  it('accepts a types filter in config without crashing', () => {
+    const record = makeRecord();
+    render(
+      <ActivityFeed
+        component={makeComponent({ types: ['call', 'note'] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByTestId('activity-feed')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/ContactsPanel.test.tsx
+++ b/apps/web/src/__tests__/ContactsPanel.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ContactsPanel } from '../components/ContactsPanel.js';
+import type {
+  LayoutComponentDef,
+  RecordData,
+  ObjectDefinitionRef,
+  RelationshipRef,
+} from '../components/layoutTypes.js';
+
+const objectDef: ObjectDefinitionRef = {
+  id: 'obj-1',
+  apiName: 'account',
+  label: 'Account',
+  pluralLabel: 'Accounts',
+  isSystem: true,
+};
+
+function makeRelationship(overrides: Partial<RelationshipRef> = {}): RelationshipRef {
+  return {
+    relationshipId: 'rel-contacts',
+    label: 'Contacts',
+    relationshipType: 'lookup',
+    direction: 'source',
+    relatedObjectApiName: 'contact',
+    records: [
+      {
+        id: 'c-1',
+        name: 'Jane Doe',
+        fieldValues: { role: 'CEO', isPrimary: true },
+      },
+      {
+        id: 'c-2',
+        name: 'John Smith',
+        fieldValues: { role: 'CTO', isPrimary: false },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeRecord(relationships: RelationshipRef[] = []): RecordData {
+  return {
+    id: 'rec-1',
+    objectId: 'obj-1',
+    name: 'Acme',
+    fieldValues: {},
+    ownerId: 'u-1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+    fields: [],
+    relationships,
+  };
+}
+
+function makeComponent(config: Record<string, unknown>): LayoutComponentDef {
+  return { id: 'c-1', type: 'contacts', config };
+}
+
+function renderPanel(
+  config: Record<string, unknown>,
+  relationships: RelationshipRef[],
+) {
+  const record = makeRecord(relationships);
+  return render(
+    <MemoryRouter>
+      <ContactsPanel
+        component={makeComponent(config)}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('ContactsPanel', () => {
+  it('renders a row per related contact with initials, name, and role', () => {
+    renderPanel({ relationshipId: 'rel-contacts' }, [makeRelationship()]);
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('John Smith')).toBeInTheDocument();
+    expect(screen.getByText('CEO')).toBeInTheDocument();
+    expect(screen.getByText('CTO')).toBeInTheDocument();
+    // Initials derived from first letter of each word.
+    expect(screen.getByText('JD')).toBeInTheDocument();
+    expect(screen.getByText('JS')).toBeInTheDocument();
+  });
+
+  it('shows a PRIMARY badge only on the primary contact', () => {
+    renderPanel({ relationshipId: 'rel-contacts' }, [makeRelationship()]);
+
+    const badges = screen.getAllByTestId('contacts-panel-primary-badge');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent('PRIMARY');
+  });
+
+  it('links each contact to its detail page', () => {
+    renderPanel({ relationshipId: 'rel-contacts' }, [makeRelationship()]);
+
+    const link = screen.getByRole('link', { name: 'Jane Doe' });
+    expect(link).toHaveAttribute('href', '/objects/contact/c-1');
+  });
+
+  it('respects the limit config', () => {
+    renderPanel({ relationshipId: 'rel-contacts', limit: 1 }, [makeRelationship()]);
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.queryByText('John Smith')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty-state when the relationship has no records', () => {
+    renderPanel(
+      { relationshipId: 'rel-contacts' },
+      [makeRelationship({ records: [] })],
+    );
+
+    expect(screen.getByTestId('contacts-panel-empty-rel-contacts')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the relationshipId is missing or unknown', () => {
+    const { container: missing } = renderPanel({}, [makeRelationship()]);
+    expect(missing).toBeEmptyDOMElement();
+
+    const { container: unknown } = renderPanel(
+      { relationshipId: 'does-not-exist' },
+      [makeRelationship()],
+    );
+    expect(unknown).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/__tests__/IdentityPanel.test.tsx
+++ b/apps/web/src/__tests__/IdentityPanel.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IdentityPanel } from '../components/IdentityPanel.js';
+import type {
+  LayoutComponentDef,
+  RecordData,
+  ObjectDefinitionRef,
+} from '../components/layoutTypes.js';
+
+const objectDef: ObjectDefinitionRef = {
+  id: 'obj-1',
+  apiName: 'account',
+  label: 'Account',
+  pluralLabel: 'Accounts',
+  isSystem: true,
+};
+
+function makeRecord(overrides: Partial<RecordData> = {}): RecordData {
+  return {
+    id: 'rec-1',
+    objectId: 'obj-1',
+    name: 'Acme',
+    fieldValues: {
+      name: 'Acme Corp',
+      status: 'Active',
+      industry: 'Tech',
+      empty_field: '',
+    },
+    ownerId: 'u-1',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+    fields: [
+      { apiName: 'name', label: 'Account Name', fieldType: 'text' },
+      { apiName: 'status', label: 'Status', fieldType: 'text' },
+      { apiName: 'industry', label: 'Industry', fieldType: 'text' },
+      { apiName: 'empty_field', label: 'Empty', fieldType: 'text' },
+    ],
+    relationships: [],
+    ...overrides,
+  };
+}
+
+function makeComponent(config: Record<string, unknown>): LayoutComponentDef {
+  return { id: 'c-1', type: 'identity', config };
+}
+
+describe('IdentityPanel', () => {
+  it('renders configured field labels and values', () => {
+    const record = makeRecord();
+    render(
+      <IdentityPanel
+        component={makeComponent({ fields: ['name', 'status', 'industry'] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByText('Account Name')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Industry')).toBeInTheDocument();
+    expect(screen.getByText('Tech')).toBeInTheDocument();
+  });
+
+  it('preserves the configured order of fields', () => {
+    const record = makeRecord();
+    render(
+      <IdentityPanel
+        component={makeComponent({ fields: ['industry', 'name', 'status'] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    const labels = screen.getAllByRole('term').map((el) => el.textContent);
+    expect(labels).toEqual(['Industry', 'Account Name', 'Status']);
+  });
+
+  it('shows an em-dash for empty field values', () => {
+    const record = makeRecord();
+    render(
+      <IdentityPanel
+        component={makeComponent({ fields: ['empty_field'] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('skips field names not present in the field definitions', () => {
+    const record = makeRecord();
+    render(
+      <IdentityPanel
+        component={makeComponent({ fields: ['name', 'does_not_exist'] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByText('Account Name')).toBeInTheDocument();
+    expect(screen.queryByText('does_not_exist')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty-state when no fields are configured', () => {
+    const record = makeRecord();
+    render(
+      <IdentityPanel
+        component={makeComponent({ fields: [] })}
+        record={record}
+        fields={record.fields}
+        objectDef={objectDef}
+      />,
+    );
+
+    expect(screen.getByTestId('identity-panel-empty')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ActivityFeed.tsx
+++ b/apps/web/src/components/ActivityFeed.tsx
@@ -1,0 +1,34 @@
+import type { ComponentRendererProps } from './layoutTypes.js';
+import { ActivityPanel, type ActivityItem } from './ActivityPanel.js';
+
+/**
+ * Chronological feed of record events (replied / call / edit / note / meeting).
+ * Thin adapter around ActivityPanel — intended for side rails or the main zone.
+ * Config:
+ *   - limit?: number         – max items to show
+ *   - types?: string[]       – filter to these ActivityItem types
+ *
+ * Real wiring lives with the activity service (#384); for now ActivityFeed
+ * surfaces the same empty-state ActivityPanel renders when there are no items.
+ */
+export function ActivityFeed({ component }: ComponentRendererProps) {
+  const limitCfg = component.config.limit;
+  const limit = typeof limitCfg === 'number' && limitCfg > 0 ? limitCfg : undefined;
+
+  const typesCfg = component.config.types;
+  const types = Array.isArray(typesCfg)
+    ? (typesCfg.filter((t) => typeof t === 'string') as string[])
+    : null;
+
+  const allItems: ActivityItem[] = [];
+  const filtered = types && types.length > 0
+    ? allItems.filter((item) => types.includes(item.type))
+    : allItems;
+  const shown = limit !== undefined ? filtered.slice(0, limit) : filtered;
+
+  return (
+    <div data-testid="activity-feed">
+      <ActivityPanel items={shown} />
+    </div>
+  );
+}

--- a/apps/web/src/components/ContactsPanel.module.css
+++ b/apps/web/src/components/ContactsPanel.module.css
@@ -1,0 +1,88 @@
+/* ============================================================
+   ContactsPanel — compact contact card list for side rails
+   ============================================================ */
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  font-weight: 500;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.name:hover {
+  text-decoration: underline;
+}
+
+.role {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.empty {
+  padding: var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/apps/web/src/components/ContactsPanel.tsx
+++ b/apps/web/src/components/ContactsPanel.tsx
@@ -1,0 +1,92 @@
+import { Link } from 'react-router-dom';
+import type { ComponentRendererProps, RelatedRecordRef } from './layoutTypes.js';
+import styles from './ContactsPanel.module.css';
+
+const ROLE_FIELD_CANDIDATES = ['role', 'title', 'contactRole', 'jobTitle'] as const;
+const PRIMARY_FIELD_CANDIDATES = ['isPrimary', 'primary', 'is_primary'] as const;
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean).slice(0, 2);
+  if (parts.length === 0) return '?';
+  return parts.map((p) => p.charAt(0).toUpperCase()).join('');
+}
+
+function pickString(record: RelatedRecordRef, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const v = record.fieldValues[key];
+    if (typeof v === 'string' && v.trim().length > 0) return v;
+  }
+  return null;
+}
+
+function pickBoolean(record: RelatedRecordRef, keys: readonly string[]): boolean {
+  for (const key of keys) {
+    const v = record.fieldValues[key];
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'string') return v.toLowerCase() === 'true';
+  }
+  return false;
+}
+
+/**
+ * Lists related contact records via an existing relationship.
+ * Each row: avatar initials · name · optional role · optional "PRIMARY" badge.
+ * Intended for side rails; uses the same relationship fetch logic as RelatedListRenderer.
+ */
+export function ContactsPanel({ component, record }: ComponentRendererProps) {
+  const relationshipId =
+    typeof component.config.relationshipId === 'string'
+      ? component.config.relationshipId
+      : null;
+  const limitCfg = component.config.limit;
+  const limit = typeof limitCfg === 'number' && limitCfg > 0 ? limitCfg : undefined;
+
+  if (!relationshipId) return null;
+
+  const relationship = record.relationships.find(
+    (r) => r.relationshipId === relationshipId,
+  );
+  if (!relationship) return null;
+
+  const allRecords = relationship.records;
+  const shown = limit !== undefined ? allRecords.slice(0, limit) : allRecords;
+
+  if (shown.length === 0) {
+    return (
+      <div className={styles.empty} data-testid={`contacts-panel-empty-${relationshipId}`}>
+        No {relationship.label.toLowerCase()}
+      </div>
+    );
+  }
+
+  return (
+    <ul className={styles.list} data-testid={`contacts-panel-${relationshipId}`}>
+      {shown.map((contact) => {
+        const role = pickString(contact, ROLE_FIELD_CANDIDATES);
+        const isPrimary = pickBoolean(contact, PRIMARY_FIELD_CANDIDATES);
+
+        return (
+          <li key={contact.id} className={styles.item}>
+            <span className={styles.avatar} aria-hidden="true">
+              {initials(contact.name)}
+            </span>
+            <div className={styles.content}>
+              <Link
+                to={`/objects/${relationship.relatedObjectApiName}/${contact.id}`}
+                className={styles.name}
+              >
+                {contact.name}
+              </Link>
+              {role && <span className={styles.role}>{role}</span>}
+            </div>
+            {isPrimary && (
+              <span className={styles.badge} data-testid="contacts-panel-primary-badge">
+                PRIMARY
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/components/IdentityPanel.module.css
+++ b/apps/web/src/components/IdentityPanel.module.css
@@ -1,0 +1,51 @@
+/* ============================================================
+   IdentityPanel — compact field list for side rails
+   ============================================================ */
+
+.list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.label {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.value {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  text-align: right;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-4) var(--space-4);
+  font-size: var(--font-size-sm);
+}

--- a/apps/web/src/components/IdentityPanel.tsx
+++ b/apps/web/src/components/IdentityPanel.tsx
@@ -1,0 +1,50 @@
+import type { ComponentRendererProps } from './layoutTypes.js';
+import { FieldRenderer } from './FieldRenderer.js';
+import styles from './IdentityPanel.module.css';
+
+/**
+ * Compact vertical list of field name/value pairs.
+ * Intended for the side rails (leftRail / rightRail) in the zoned record detail shell.
+ * Config: { fields: string[] } — array of field api_names to display.
+ */
+export function IdentityPanel({ component, record, fields }: ComponentRendererProps) {
+  const rawFields = component.config.fields;
+  const fieldNames = Array.isArray(rawFields)
+    ? (rawFields.filter((n) => typeof n === 'string') as string[])
+    : [];
+
+  if (fieldNames.length === 0) {
+    return (
+      <div className={styles.empty} data-testid="identity-panel-empty">
+        No fields configured
+      </div>
+    );
+  }
+
+  const rows = fieldNames
+    .map((apiName) => {
+      const def = fields.find((f) => f.apiName === apiName);
+      if (!def) return null;
+      const value = record.fieldValues[apiName] ?? null;
+      const isEmpty = value === null || value === undefined || value === '';
+      return { apiName, def, value, isEmpty };
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+
+  return (
+    <dl className={styles.list} data-testid="identity-panel">
+      {rows.map(({ apiName, def, value, isEmpty }) => (
+        <div key={apiName} className={styles.row}>
+          <dt className={styles.label}>{def.label}</dt>
+          <dd className={styles.value}>
+            {isEmpty ? (
+              <span className={styles.empty}>—</span>
+            ) : (
+              <FieldRenderer fieldType={def.fieldType} value={value} />
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/components/LayoutComponent.tsx
+++ b/apps/web/src/components/LayoutComponent.tsx
@@ -5,6 +5,9 @@ import { LayoutFieldRenderer } from './LayoutFieldRenderer.js';
 import { RelatedListRenderer } from './RelatedListRenderer.js';
 import { PlaceholderWidget } from './PlaceholderWidget.js';
 import { SalesTargetsRenderer } from './SalesTargetsRenderer.js';
+import { IdentityPanel } from './IdentityPanel.js';
+import { ContactsPanel } from './ContactsPanel.js';
+import { ActivityFeed } from './ActivityFeed.js';
 
 // ─── Component registry (map, not switch) ─────────────────────────────────────
 
@@ -12,6 +15,9 @@ const COMPONENT_RENDERERS: Record<string, ComponentType<ComponentRendererProps>>
   field: LayoutFieldRenderer,
   related_list: RelatedListRenderer,
   sales_targets: SalesTargetsRenderer,
+  identity: IdentityPanel,
+  contacts: ContactsPanel,
+  activity: ActivityFeed,
   activity_timeline: PlaceholderWidget,
   notes: PlaceholderWidget,
   stage_history: PlaceholderWidget,


### PR DESCRIPTION
Closes #518.

## Summary

Adds the three core rail-zone components referenced by the zoned record detail shell (#516):

- `IdentityPanel` — compact label/value field list (mono labels, right-aligned values).
- `ContactsPanel` — avatar-initial rows with name, role, optional `PRIMARY` badge; reuses the same relationship fetch logic as `RelatedListRenderer`.
- `ActivityFeed` — thin adapter around the existing `ActivityPanel`. Real wiring is tracked in #384.

Each is registered with `allowedZones: ['leftRail', 'rightRail', 'main']`. The backend validator now threads the zone name through section / component validation and rejects any component placed in a zone outside its whitelist — so a rail-only component in `kpi` fails validation with a clear message.

Existing components (field, related_list, sales_targets, …) have no `allowedZones` declared and remain permitted in every zone (back-compat).

## Changes

- `apps/api/src/lib/componentRegistry.ts` — adds `ComponentZone`, `allowedZones`, `isComponentAllowedInZone`, plus three new registry entries.
- `apps/api/src/services/pageLayoutService.ts` — `validateSection` / `validateComponent` take a `zone`; zone whitelist enforced for kpi, leftRail, rightRail, and main (tab sections).
- `apps/web/src/components/IdentityPanel.tsx` + `.module.css`
- `apps/web/src/components/ContactsPanel.tsx` + `.module.css`
- `apps/web/src/components/ActivityFeed.tsx`
- `apps/web/src/components/LayoutComponent.tsx` — wires the three new types into the renderer map.

## Tests

- `componentRegistry.test.ts` — registry exposes rail palette; `isComponentAllowedInZone` allows rails + main, rejects kpi, back-compat for components without `allowedZones`.
- `pageLayoutService.test.ts` — new "zone whitelist" block: accepts identity in leftRail, contacts in rightRail, activity in a main-zone section; rejects all three when placed in the kpi zone with a message containing `not allowed in zone "kpi"`.
- `IdentityPanel.test.tsx` — renders configured fields in order, em-dash for empty values, skips unknown fields, empty-state for no config.
- `ContactsPanel.test.tsx` — initials / name / role, single `PRIMARY` badge, link href, limit config, empty-state, null render for unknown relationship.
- `ActivityFeed.test.tsx` — renders adapter + empty-state, accepts types filter.

## Test plan

- [x] `apps/api` vitest — 1542 passed, 1 skipped
- [x] `apps/web` vitest — 700 passed
- [x] `apps/web` typecheck clean
- [x] `apps/web` eslint clean on changed files

https://claude.ai/code/session_01YVFDH9suBsw3gupeoPWQ8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVFDH9suBsw3gupeoPWQ8M)_