### PR TITLE
fix(page-builder): address PR #526 review feedback

### DIFF
--- a/apps/web/src/__tests__/ComponentPalette.test.tsx
+++ b/apps/web/src/__tests__/ComponentPalette.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { ComponentPalette } from '../components/ComponentPalette.js';
+import type { ComponentDefinition } from '../components/builderTypes.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderPalette(registry: ComponentDefinition[]) {
+  return render(
+    <DndContext>
+      <ComponentPalette
+        registry={registry}
+        fields={[]}
+        relationships={[]}
+        relatedFields={[]}
+        tabs={[]}
+      />
+    </DndContext>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ComponentPalette — zone filter', () => {
+  const mainOnlyWidget: ComponentDefinition = {
+    type: 'activity_timeline',
+    label: 'Activity Timeline',
+    icon: 'clock',
+    category: 'widgets',
+    allowedZones: ['main', 'rightRail'],
+    configSchema: {},
+    defaultConfig: {},
+  };
+
+  const kpiOnlyWidget: ComponentDefinition = {
+    type: 'metric',
+    label: 'Metric Card',
+    icon: 'gauge',
+    category: 'widgets',
+    allowedZones: ['kpi'],
+    configSchema: {},
+    defaultConfig: {},
+  };
+
+  const legacyWidget: ComponentDefinition = {
+    // Simulates a response from an older API that doesn't yet emit allowedZones.
+    type: 'activity_timeline',
+    label: 'Activity Timeline',
+    icon: 'clock',
+    category: 'widgets',
+    configSchema: {},
+    defaultConfig: {},
+  };
+
+  it('hides components whose allowedZones does not include "main"', () => {
+    renderPalette([mainOnlyWidget, kpiOnlyWidget]);
+
+    expect(
+      screen.getByTestId('palette-item-palette-widget-activity_timeline'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('palette-item-palette-widget-metric'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows components whose allowedZones includes "main"', () => {
+    renderPalette([mainOnlyWidget]);
+    expect(
+      screen.getByTestId('palette-item-palette-widget-activity_timeline'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows registry entries that omit allowedZones (backwards compatible)', () => {
+    renderPalette([legacyWidget]);
+    expect(
+      screen.getByTestId('palette-item-palette-widget-activity_timeline'),
+    ).toBeInTheDocument();
+  });
+
+  it('collapses a category group when all its entries are filtered out', () => {
+    renderPalette([kpiOnlyWidget]);
+    expect(screen.queryByText('Widgets')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/MetricCard.test.tsx
+++ b/apps/web/src/__tests__/MetricCard.test.tsx
@@ -158,6 +158,20 @@ describe('MetricCard', () => {
     expect(fill.style.width).toBe('0%');
   });
 
+  it('exposes an accessible name on the progress bar that includes the metric label', () => {
+    renderMetric(
+      {
+        label: 'pipeline.open',
+        source: { kind: 'field', fieldApiName: 'v' },
+        target: { kind: 'literal', value: 100 },
+      },
+      { v: 40 },
+    );
+
+    const bar = screen.getByTestId('metric-progress');
+    expect(bar).toHaveAttribute('aria-label', 'pipeline.open: 40% of target');
+  });
+
   it('renders progress at 50% when value is half of target', () => {
     renderMetric(
       {

--- a/apps/web/src/__tests__/PropertiesPanel.test.tsx
+++ b/apps/web/src/__tests__/PropertiesPanel.test.tsx
@@ -86,6 +86,15 @@ describe('PropertiesPanel — object-typed config fields', () => {
     expect(sourceBlock.textContent).toMatch(/read-only/i);
   });
 
+  it('associates the object-field textarea with its label for screen readers', () => {
+    renderPanel(metricComponent, metricDef);
+
+    // getByLabelText only succeeds when <label htmlFor> matches the textarea's id.
+    const textarea = screen.getByLabelText('source') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea.readOnly).toBe(true);
+  });
+
   it('still renders editable string fields alongside object fields', () => {
     renderPanel(metricComponent, metricDef);
 

--- a/apps/web/src/__tests__/PropertiesPanel.test.tsx
+++ b/apps/web/src/__tests__/PropertiesPanel.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PropertiesPanel } from '../components/PropertiesPanel.js';
+import type {
+  BuilderComponent,
+  ComponentDefinition,
+} from '../components/builderTypes.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderPanel(
+  component: BuilderComponent,
+  def: ComponentDefinition,
+  handlers: Partial<
+    Parameters<typeof PropertiesPanel>[0]
+  > = {},
+) {
+  const props = {
+    selectedItem: { kind: 'component' as const, component, sectionId: 'sec-1' },
+    registry: [def],
+    fields: [],
+    onComponentChange: vi.fn(),
+    onComponentVisibilityChange: vi.fn(),
+    onSectionChange: vi.fn(),
+    onSectionVisibilityChange: vi.fn(),
+    ...handlers,
+  };
+  return { ...render(<PropertiesPanel {...props} />), props };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PropertiesPanel — object-typed config fields', () => {
+  const metricDef: ComponentDefinition = {
+    type: 'metric',
+    label: 'Metric Card',
+    icon: 'gauge',
+    category: 'widgets',
+    allowedZones: ['kpi'],
+    configSchema: {
+      label: { type: 'string', description: 'Display label' },
+      source: { type: 'object', description: 'Value source' },
+      target: { type: 'object', description: 'Optional target' },
+    },
+    defaultConfig: {
+      label: '',
+      source: { kind: 'field', fieldApiName: 'amount' },
+    },
+  };
+
+  const metricComponent: BuilderComponent = {
+    id: 'comp-1',
+    type: 'metric',
+    config: {
+      label: 'pipeline.open',
+      source: { kind: 'field', fieldApiName: 'amount' },
+    },
+  };
+
+  it('renders object-typed fields as read-only JSON previews', () => {
+    renderPanel(metricComponent, metricDef);
+
+    const sourceBlock = screen.getByTestId('prop-object-source');
+    const textarea = sourceBlock.querySelector('textarea')!;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveAttribute('readOnly');
+    expect(textarea.value).toContain('"kind": "field"');
+    expect(textarea.value).toContain('"fieldApiName": "amount"');
+  });
+
+  it('does not fire onChange when the user types in an object field textarea', () => {
+    const { props } = renderPanel(metricComponent, metricDef);
+
+    const sourceBlock = screen.getByTestId('prop-object-source');
+    const textarea = sourceBlock.querySelector('textarea')!;
+    // Read-only inputs swallow keystrokes, so firing an input event should
+    // not trigger a config update.
+    fireEvent.change(textarea, { target: { value: 'garbage' } });
+    expect(props.onComponentChange).not.toHaveBeenCalled();
+  });
+
+  it('flags the read-only state in the hint text', () => {
+    renderPanel(metricComponent, metricDef);
+
+    const sourceBlock = screen.getByTestId('prop-object-source');
+    expect(sourceBlock.textContent).toMatch(/read-only/i);
+  });
+
+  it('still renders editable string fields alongside object fields', () => {
+    renderPanel(metricComponent, metricDef);
+
+    const labelInput = screen.getByLabelText('label') as HTMLInputElement;
+    expect(labelInput).toBeInTheDocument();
+    expect(labelInput.readOnly).toBe(false);
+  });
+});

--- a/apps/web/src/components/ComponentPalette.tsx
+++ b/apps/web/src/components/ComponentPalette.tsx
@@ -8,9 +8,23 @@ import type {
   RelatedFieldRef,
   PaletteDragData,
   BuilderTab,
+  LayoutZone,
 } from './builderTypes.js';
 import { resolveIcon } from './iconMap.js';
 import styles from './ComponentPalette.module.css';
+
+// The page builder currently only edits tab sections (the `main` zone).
+// Other zones (kpi, rails) have dedicated editors / are not yet draggable.
+// We filter the palette to components valid in this zone so users can't
+// drop a component that would fail server-side zone validation on save.
+const BUILDER_ACTIVE_ZONE: LayoutZone = 'main';
+
+function isAllowedInActiveZone(def: ComponentDefinition): boolean {
+  // `allowedZones` is optional for backwards compatibility with API responses
+  // from older deployments — treat "missing" as "no restriction".
+  if (!def.allowedZones) return true;
+  return def.allowedZones.includes(BUILDER_ACTIVE_ZONE);
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -128,10 +142,12 @@ export function ComponentPalette({
     ? fields.filter((f) => f.label.toLowerCase().includes(fieldSearch.toLowerCase()))
     : fields;
 
+  const zoneFilteredRegistry = registry.filter(isAllowedInActiveZone);
+
   const grouped = CATEGORY_ORDER
     .map((cat) => ({
       category: cat,
-      items: registry.filter((r) => r.category === cat),
+      items: zoneFilteredRegistry.filter((r) => r.category === cat),
     }))
     .filter((g) => g.items.length > 0);
 

--- a/apps/web/src/components/MetricCard.tsx
+++ b/apps/web/src/components/MetricCard.tsx
@@ -150,6 +150,11 @@ export function MetricCard({ component, record }: ComponentRendererProps) {
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={Math.round(progressRatio * 100)}
+          aria-label={
+            label
+              ? `${label}: ${Math.round(progressRatio * 100)}% of target`
+              : `${Math.round(progressRatio * 100)}% of target`
+          }
           data-testid="metric-progress"
         >
           <div

--- a/apps/web/src/components/PropertiesPanel.tsx
+++ b/apps/web/src/components/PropertiesPanel.tsx
@@ -116,8 +116,11 @@ function ConfigField({
           })();
     return (
       <div className={styles.field} data-testid={`prop-object-${name}`}>
-        <label className={styles.fieldLabel}>{name}</label>
+        <label className={styles.fieldLabel} htmlFor={`prop-${name}`}>
+          {name}
+        </label>
         <textarea
+          id={`prop-${name}`}
           className={styles.textarea}
           value={json}
           readOnly

--- a/apps/web/src/components/PropertiesPanel.tsx
+++ b/apps/web/src/components/PropertiesPanel.tsx
@@ -99,6 +99,39 @@ function ConfigField({
     );
   }
 
+  // Object-typed fields (e.g. `source`/`target` on metric cards) need a
+  // structured editor. Until one ships, render a read-only JSON preview so
+  // the text input fallback doesn't silently overwrite a nested object with
+  // a string value.
+  if (type === 'object') {
+    const json =
+      value === undefined || value === null
+        ? ''
+        : (() => {
+            try {
+              return JSON.stringify(value, null, 2);
+            } catch {
+              return String(value);
+            }
+          })();
+    return (
+      <div className={styles.field} data-testid={`prop-object-${name}`}>
+        <label className={styles.fieldLabel}>{name}</label>
+        <textarea
+          className={styles.textarea}
+          value={json}
+          readOnly
+          rows={Math.min(6, Math.max(2, json.split('\n').length))}
+        />
+        <span className={styles.hint}>
+          {description
+            ? `${description} (read-only — editor coming soon)`
+            : 'Read-only — a structured editor for this field is coming soon.'}
+        </span>
+      </div>
+    );
+  }
+
   // Default: string
   return (
     <div className={styles.field}>

--- a/apps/web/src/components/builderTypes.ts
+++ b/apps/web/src/components/builderTypes.ts
@@ -11,11 +11,19 @@ import type {
 
 export type ComponentCategory = 'fields' | 'layout' | 'related' | 'widgets';
 
+export type LayoutZone = 'header' | 'kpi' | 'leftRail' | 'main' | 'rightRail';
+
 export interface ComponentDefinition {
   type: string;
   label: string;
   icon: string;
   category: ComponentCategory;
+  /**
+   * Zones in which this component is valid. Older API responses may omit
+   * this — consumers should treat `undefined` as "no restriction" so the
+   * legacy registry keeps working until the API is redeployed.
+   */
+  allowedZones?: readonly LayoutZone[];
   configSchema: Record<string, ConfigSchemaEntry>;
   defaultConfig: Record<string, unknown>;
 }


### PR DESCRIPTION
Follow-up to #526 / #517 addressing the four unresolved review comments.

## Summary

1. **Palette zone filter (P1 Codex + Copilot)** — `ComponentPalette` now
   hides registry entries whose `allowedZones` doesn't include the
   builder's active zone (hard-coded to `main` for now). This stops
   users from dragging a `metric` card into a tab section and getting a
   server-side 400 on save. Entries without an `allowedZones` field are
   still shown, so responses from older API builds keep working.

2. **Object-typed config fields (P2 Codex)** — `PropertiesPanel`'s
   generic `ConfigField` renderer now handles `type: 'object'`
   explicitly, rendering a read-only JSON preview with a
   "editor coming soon" hint instead of a text input that would
   silently overwrite a nested object (`source`/`target` on the metric
   card) with a string. A structured editor for those fields is still
   future work.

3. **Progress bar accessible name (Copilot)** — `MetricCard`'s
   progressbar now carries `aria-label="<label>: <pct>% of target"`, so
   screen readers get an interpretable name for the bar.

## Test plan

- [x] New `ComponentPalette.test.tsx`: hides KPI-only entries, keeps
      main entries, keeps legacy entries without `allowedZones`,
      collapses empty categories.
- [x] New `PropertiesPanel.test.tsx`: object fields render as read-only
      JSON, don't fire `onComponentChange`, and flag "read-only" in the
      hint.
- [x] Added `MetricCard` aria-label case to `MetricCard.test.tsx`.
- [x] `npx vitest run` (web): 52 files / 711 tests pass.
- [x] `tsc --noEmit` clean.
- [x] ESLint clean on touched files.

https://claude.ai/code/session_018ggoJzwUTEuP9SeKhfp22P

---
_Generated by [Claude Code](https://claude.ai/code/session_018ggoJzwUTEuP9SeKhfp22P)_