### PR TITLE
feat(page-builder): zone-aware canvas (#521)

### DIFF
--- a/apps/web/src/__tests__/ComponentPalette.test.tsx
+++ b/apps/web/src/__tests__/ComponentPalette.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 import { ComponentPalette } from '../components/ComponentPalette.js';
-import type { ComponentDefinition } from '../components/builderTypes.js';
+import type { ComponentDefinition, LayoutZone } from '../components/builderTypes.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function renderPalette(registry: ComponentDefinition[]) {
+function renderPalette(registry: ComponentDefinition[], activeZone?: LayoutZone) {
   return render(
     <DndContext>
       <ComponentPalette
@@ -15,6 +15,7 @@ function renderPalette(registry: ComponentDefinition[]) {
         relationships={[]}
         relatedFields={[]}
         tabs={[]}
+        activeZone={activeZone}
       />
     </DndContext>,
   );
@@ -81,5 +82,22 @@ describe('ComponentPalette — zone filter', () => {
   it('collapses a category group when all its entries are filtered out', () => {
     renderPalette([kpiOnlyWidget]);
     expect(screen.queryByText('Widgets')).not.toBeInTheDocument();
+  });
+
+  it('shows a kpi-only widget when activeZone="kpi" and hides main-only widgets', () => {
+    renderPalette([mainOnlyWidget, kpiOnlyWidget], 'kpi');
+
+    expect(
+      screen.getByTestId('palette-item-palette-widget-metric'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('palette-item-palette-widget-activity_timeline'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('labels the active zone in the palette hint', () => {
+    renderPalette([mainOnlyWidget], 'leftRail');
+    const hint = screen.getByTestId('palette-active-zone');
+    expect(hint).toHaveTextContent('Left Rail');
   });
 });

--- a/apps/web/src/__tests__/PageBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/PageBuilderPage.test.tsx
@@ -750,6 +750,60 @@ describe('PageBuilderPage', () => {
     });
   });
 
+  it('renders the zoned canvas shell (KPI, rails, main)', async () => {
+    mockAllFetches();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('page-builder')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('zone-kpi')).toBeInTheDocument();
+    expect(screen.getByTestId('zone-leftRail')).toBeInTheDocument();
+    expect(screen.getByTestId('zone-rightRail')).toBeInTheDocument();
+    expect(screen.getByTestId('zone-main')).toBeInTheDocument();
+  });
+
+  it('shows empty-zone affordances on a fresh layout', async () => {
+    mockAllFetches();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('zone-kpi')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('zone-empty-kpi')).toHaveTextContent(
+      'Drop a metric here',
+    );
+    expect(screen.getByTestId('zone-empty-leftRail')).toHaveTextContent(
+      'Drop a panel here',
+    );
+    expect(screen.getByTestId('zone-empty-rightRail')).toHaveTextContent(
+      'Drop a panel here',
+    );
+  });
+
+  it('updates the palette active-zone hint when a zone is clicked', async () => {
+    const user = userEvent.setup();
+    mockAllFetches();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('zone-kpi')).toBeInTheDocument();
+    });
+
+    // Default is "main" before any click.
+    expect(screen.getByTestId('palette-active-zone')).toHaveTextContent('Main');
+
+    await user.click(screen.getByTestId('zone-kpi'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('palette-active-zone')).toHaveTextContent(
+        'KPI Strip',
+      );
+    });
+  });
+
   it('handles no page layouts by creating a default', async () => {
     const mockFetch = vi.fn();
 

--- a/apps/web/src/__tests__/usePageLayoutDnd.test.ts
+++ b/apps/web/src/__tests__/usePageLayoutDnd.test.ts
@@ -197,4 +197,110 @@ describe('usePageLayoutDnd — zone drops', () => {
       'activity_timeline',
     );
   });
+
+  it('rejects unknown component types when a registry is loaded', () => {
+    const { hook, getLayout, onRejectZoneDrop } = setupHook(makeLayout());
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('unknown_widget', zoneDropTarget('rightRail')),
+      );
+    });
+
+    expect(getLayout().zones.rightRail).toHaveLength(0);
+    expect(onRejectZoneDrop).toHaveBeenCalledWith('unknown_widget', 'rightRail');
+  });
 });
+
+// ─── Cross-zone component moves ────────────────────────────────────────────
+
+describe('usePageLayoutDnd — canvas component reorder across zones', () => {
+  function canvasComponentDragEvent(
+    sourceSectionId: string,
+    componentId: string,
+    over: DragEndEvent['over'],
+  ): DragEndEvent {
+    return {
+      active: {
+        id: componentId,
+        data: {
+          current: { origin: 'canvas', sectionId: sourceSectionId, componentId },
+        },
+        rect: { current: { initial: null, translated: null } },
+      },
+      over,
+      delta: { x: 0, y: 0 },
+      collisions: [],
+      activatorEvent: new Event('pointer'),
+    } as unknown as DragEndEvent;
+  }
+
+  function sectionDropTarget(sectionId: string): DragEndEvent['over'] {
+    return {
+      id: `droppable-${sectionId}`,
+      data: { current: { sectionId } },
+    } as unknown as DragEndEvent['over'];
+  }
+
+  it('moves an identity_panel from a main section into a left-rail section', () => {
+    const layout = makeLayout();
+    layout.tabs[0].sections[0].components.push({
+      id: 'c-identity',
+      type: 'identity_panel',
+      config: {},
+    });
+    layout.zones.leftRail.push({
+      id: 'rail-sec-1',
+      type: 'field_section',
+      label: 'Rail Section',
+      columns: 1,
+      components: [],
+    });
+    const { hook, getLayout } = setupHook(layout);
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        canvasComponentDragEvent('sec-1', 'c-identity', sectionDropTarget('rail-sec-1')),
+      );
+    });
+
+    const updated = getLayout();
+    expect(updated.tabs[0].sections[0].components).toHaveLength(0);
+    expect(updated.zones.leftRail[0].components).toHaveLength(1);
+    expect(updated.zones.leftRail[0].components[0].id).toBe('c-identity');
+  });
+
+  it('rejects moving a main-only component into a rail and keeps it in place', () => {
+    const layout = makeLayout();
+    layout.tabs[0].sections[0].components.push({
+      id: 'c-timeline',
+      type: 'activity_timeline',
+      config: {},
+    });
+    layout.zones.leftRail.push({
+      id: 'rail-sec-1',
+      type: 'field_section',
+      label: 'Rail Section',
+      columns: 1,
+      components: [],
+    });
+    const onRejectZoneDrop = vi.fn();
+    const { hook, getLayout } = setupHook(layout, onRejectZoneDrop);
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        canvasComponentDragEvent('sec-1', 'c-timeline', sectionDropTarget('rail-sec-1')),
+      );
+    });
+
+    const updated = getLayout();
+    // Regression guard: the earlier implementation spliced first and
+    // bailed when `findSection` couldn't resolve the rail target,
+    // causing silent data loss. We expect the component to stay put.
+    expect(updated.tabs[0].sections[0].components).toHaveLength(1);
+    expect(updated.tabs[0].sections[0].components[0].id).toBe('c-timeline');
+    expect(updated.zones.leftRail[0].components).toHaveLength(0);
+    expect(onRejectZoneDrop).toHaveBeenCalledWith('activity_timeline', 'leftRail');
+  });
+});
+

--- a/apps/web/src/__tests__/usePageLayoutDnd.test.ts
+++ b/apps/web/src/__tests__/usePageLayoutDnd.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { usePageLayoutDnd } from '../features/page-builder/hooks/usePageLayoutDnd.js';
+import type {
+  BuilderLayout,
+  ComponentDefinition,
+} from '../components/builderTypes.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeLayout(): BuilderLayout {
+  return {
+    id: 'pl-1',
+    objectId: 'obj-1',
+    name: 'Default',
+    header: { primaryField: 'name', secondaryFields: [] },
+    zones: { kpi: [], leftRail: [], rightRail: [] },
+    tabs: [
+      {
+        id: 'tab-1',
+        label: 'Details',
+        sections: [
+          {
+            id: 'sec-1',
+            type: 'field_section',
+            label: 'General',
+            columns: 2,
+            components: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const registry: ComponentDefinition[] = [
+  {
+    type: 'metric',
+    label: 'Metric',
+    icon: 'gauge',
+    category: 'widgets',
+    allowedZones: ['kpi'],
+    configSchema: {},
+    defaultConfig: {},
+  },
+  {
+    type: 'activity_timeline',
+    label: 'Activity',
+    icon: 'clock',
+    category: 'widgets',
+    allowedZones: ['main', 'rightRail'],
+    configSchema: {},
+    defaultConfig: {},
+  },
+  {
+    type: 'identity_panel',
+    label: 'Identity',
+    icon: 'user',
+    category: 'widgets',
+    allowedZones: ['leftRail', 'main', 'rightRail'],
+    configSchema: {},
+    defaultConfig: {},
+  },
+];
+
+function setupHook(initial: BuilderLayout, onRejectZoneDrop = vi.fn()) {
+  let current = initial;
+  const updateLayout = vi.fn((mutator: (draft: BuilderLayout) => BuilderLayout) => {
+    current = mutator(structuredClone(current));
+  });
+
+  const hook = renderHook(() =>
+    usePageLayoutDnd({
+      layout: current,
+      updateLayout,
+      registry,
+      onRejectZoneDrop,
+    }),
+  );
+
+  return {
+    hook,
+    getLayout: () => current,
+    updateLayout,
+    onRejectZoneDrop,
+  };
+}
+
+function paletteDropEvent(
+  componentType: string,
+  over: DragEndEvent['over'],
+): DragEndEvent {
+  return {
+    active: {
+      id: `palette-widget-${componentType}`,
+      data: {
+        current: {
+          origin: 'palette',
+          componentType,
+          defaultConfig: {},
+        },
+      },
+      rect: { current: { initial: null, translated: null } },
+    },
+    over,
+    delta: { x: 0, y: 0 },
+    collisions: [],
+    activatorEvent: new Event('pointer'),
+  } as unknown as DragEndEvent;
+}
+
+function zoneDropTarget(zone: 'kpi' | 'leftRail' | 'rightRail'): DragEndEvent['over'] {
+  return {
+    id: `zone-drop-${zone}`,
+    data: { current: { origin: 'zone', zone } },
+    rect: { top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0 },
+    disabled: false,
+  } as unknown as DragEndEvent['over'];
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('usePageLayoutDnd — zone drops', () => {
+  it('drops a palette metric into the KPI zone', () => {
+    const { hook, getLayout } = setupHook(makeLayout());
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('metric', zoneDropTarget('kpi')),
+      );
+    });
+
+    const layout = getLayout();
+    expect(layout.zones.kpi).toHaveLength(1);
+    expect(layout.zones.kpi[0].type).toBe('metric');
+  });
+
+  it('drops a palette panel into the left rail as a new section', () => {
+    const { hook, getLayout } = setupHook(makeLayout());
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('identity_panel', zoneDropTarget('leftRail')),
+      );
+    });
+
+    const layout = getLayout();
+    expect(layout.zones.leftRail).toHaveLength(1);
+    expect(layout.zones.leftRail[0].components).toHaveLength(1);
+    expect(layout.zones.leftRail[0].components[0].type).toBe('identity_panel');
+  });
+
+  it('rejects a metric drop on the left rail (not in allowedZones)', () => {
+    const { hook, getLayout, onRejectZoneDrop } = setupHook(makeLayout());
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('metric', zoneDropTarget('leftRail')),
+      );
+    });
+
+    expect(getLayout().zones.leftRail).toHaveLength(0);
+    expect(onRejectZoneDrop).toHaveBeenCalledWith('metric', 'leftRail');
+  });
+
+  it('rejects a metric drop into a main-zone new-section target', () => {
+    const { hook, getLayout, onRejectZoneDrop } = setupHook(makeLayout());
+
+    const newSectionTarget = {
+      id: 'add-section-tab-1-1',
+      data: { current: { origin: 'new-section', tabId: 'tab-1', columns: 1 } },
+    } as unknown as DragEndEvent['over'];
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('metric', newSectionTarget),
+      );
+    });
+
+    // tab-1 already has one section; no new section should be appended.
+    expect(getLayout().tabs[0].sections).toHaveLength(1);
+    expect(onRejectZoneDrop).toHaveBeenCalledWith('metric', 'main');
+  });
+
+  it('allows an activity timeline drop on a right-rail zone', () => {
+    const { hook, getLayout } = setupHook(makeLayout());
+
+    act(() => {
+      hook.result.current.handleDragEnd(
+        paletteDropEvent('activity_timeline', zoneDropTarget('rightRail')),
+      );
+    });
+
+    expect(getLayout().zones.rightRail).toHaveLength(1);
+    expect(getLayout().zones.rightRail[0].components[0].type).toBe(
+      'activity_timeline',
+    );
+  });
+});

--- a/apps/web/src/components/BuilderCanvas.module.css
+++ b/apps/web/src/components/BuilderCanvas.module.css
@@ -126,3 +126,95 @@
   border-color: var(--accent);
   background: var(--accent-soft);
 }
+
+/* ── Zones (KPI, left/right rail, main) ──────────────────── */
+/* Mirror the runtime shell: header · KPI · [leftRail | main | rightRail].
+   Each zone is a click-to-activate drop region. The active zone gets an
+   accent outline so the user can see which zone the palette is filtered
+   to. Empty zones keep the affordance visible so users can discover the
+   drop target before any content exists. */
+
+.zone {
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  padding: var(--space-2);
+  margin-bottom: var(--space-3);
+  transition: border-color var(--transition-base), background var(--transition-base);
+}
+
+.zoneActive {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.zoneOver {
+  border-style: solid;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.zoneHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.zoneLabel {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
+}
+
+.zoneBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-height: 56px;
+}
+
+.zoneEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.kpiStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.zonedBody {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) minmax(0, 3fr) minmax(220px, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.mainZone {
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px dashed transparent;
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-base), background var(--transition-base);
+}
+
+.mainZone.zoneActive {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+@media (max-width: 960px) {
+  .zonedBody {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/web/src/components/BuilderCanvas.tsx
+++ b/apps/web/src/components/BuilderCanvas.tsx
@@ -3,13 +3,16 @@ import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type {
   BuilderLayout,
+  BuilderComponent,
   BuilderSection,
   FieldRef,
   RelationshipRef,
   ComponentDefinition,
+  LayoutZone,
 } from './builderTypes.js';
 import { HeaderZoneEditor } from './HeaderZoneEditor.js';
 import { DroppableSection } from './DroppableSection.js';
+import { DraggableComponent } from './DraggableComponent.js';
 import type { HeaderConfig } from './layoutTypes.js';
 import styles from './BuilderCanvas.module.css';
 
@@ -35,6 +38,64 @@ function DroppableTab({ tabId, isActive, children }: DroppableTabProps) {
     >
       {children}
     </div>
+  );
+}
+
+// Drop target wrapping a whole zone (KPI strip, left/right rail).
+interface ZoneDropRegionProps {
+  zone: Extract<LayoutZone, 'kpi' | 'leftRail' | 'rightRail'>;
+  label: string;
+  isActive: boolean;
+  isEmpty: boolean;
+  emptyHint: string;
+  onActivate: () => void;
+  children: React.ReactNode;
+}
+
+function ZoneDropRegion({
+  zone,
+  label,
+  isActive,
+  isEmpty,
+  emptyHint,
+  onActivate,
+  children,
+}: ZoneDropRegionProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `zone-drop-${zone}`,
+    data: { origin: 'zone', zone },
+  });
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={[
+        styles.zone,
+        isActive ? styles.zoneActive : '',
+        isOver ? styles.zoneOver : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-testid={`zone-${zone}`}
+      data-zone-active={isActive ? 'true' : 'false'}
+      onClick={(e) => {
+        e.stopPropagation();
+        onActivate();
+      }}
+    >
+      <header className={styles.zoneHeader}>
+        <span className={styles.zoneLabel}>{label}</span>
+      </header>
+      <div className={styles.zoneBody}>
+        {isEmpty ? (
+          <div className={styles.zoneEmpty} data-testid={`zone-empty-${zone}`}>
+            {emptyHint}
+          </div>
+        ) : (
+          children
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -74,7 +135,9 @@ interface BuilderCanvasProps {
   relationships: RelationshipRef[];
   registry: ComponentDefinition[];
   selectedId: string | null;
+  activeZone: LayoutZone;
   onSelect: (id: string | null) => void;
+  onSelectZone: (zone: LayoutZone) => void;
   onHeaderChange: (header: HeaderConfig) => void;
   onAddTab: () => void;
   onRenameTab: (tabId: string, label: string) => void;
@@ -95,7 +158,9 @@ export function BuilderCanvas({
   relationships,
   registry,
   selectedId,
+  activeZone,
   onSelect,
+  onSelectZone,
   onHeaderChange,
   onAddTab,
   onRenameTab,
@@ -109,6 +174,7 @@ export function BuilderCanvas({
 }: BuilderCanvasProps) {
   const [activeTabId, setActiveTabId] = useState(layout.tabs[0]?.id ?? '');
   const activeTab = layout.tabs.find((t) => t.id === activeTabId) ?? layout.tabs[0];
+  const zones = layout.zones;
 
   // Keep a local rename state for tabs
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
@@ -131,8 +197,73 @@ export function BuilderCanvas({
         onChange={onHeaderChange}
       />
 
-      {/* Tab bar */}
-      <div className={styles.tabBar} data-testid="builder-tab-bar">
+      {/* KPI strip zone */}
+      <ZoneDropRegion
+        zone="kpi"
+        label="KPI Strip"
+        isActive={activeZone === 'kpi'}
+        isEmpty={zones.kpi.length === 0}
+        emptyHint="Drop a metric here"
+        onActivate={() => onSelectZone('kpi')}
+      >
+        <div className={styles.kpiStrip}>
+          {zones.kpi.map((comp: BuilderComponent) => (
+            <DraggableComponent
+              key={comp.id}
+              component={comp}
+              sectionId=""
+              fields={fields}
+              relationships={relationships}
+              registry={registry}
+              isSelected={selectedId === comp.id}
+              onSelect={() => onSelectComponent(comp.id)}
+              onRemove={() => onRemoveComponent('', comp.id)}
+            />
+          ))}
+        </div>
+      </ZoneDropRegion>
+
+      {/* Three-column body: leftRail · main · rightRail */}
+      <div className={styles.zonedBody}>
+        <ZoneDropRegion
+          zone="leftRail"
+          label="Left Rail"
+          isActive={activeZone === 'leftRail'}
+          isEmpty={zones.leftRail.length === 0}
+          emptyHint="Drop a panel here"
+          onActivate={() => onSelectZone('leftRail')}
+        >
+          {zones.leftRail.map((section: BuilderSection) => (
+            <DroppableSection
+              key={section.id}
+              section={section}
+              fields={fields}
+              relationships={relationships}
+              registry={registry}
+              selectedId={selectedId}
+              onSelectComponent={onSelectComponent}
+              onSelectSection={onSelectSection}
+              onRemoveComponent={onRemoveComponent}
+              onRemoveSection={onRemoveSection}
+              onRenameSection={onRenameSection}
+            />
+          ))}
+        </ZoneDropRegion>
+
+        <div
+          className={`${styles.mainZone} ${activeZone === 'main' ? styles.zoneActive : ''}`}
+          data-testid="zone-main"
+          data-zone-active={activeZone === 'main' ? 'true' : 'false'}
+          onClick={(e) => {
+            // Clicking blank space in the main zone clears selection and
+            // activates it so the palette re-filters to main-zone components.
+            e.stopPropagation();
+            onSelect(null);
+            onSelectZone('main');
+          }}
+        >
+          {/* Tab bar */}
+          <div className={styles.tabBar} data-testid="builder-tab-bar">
         {layout.tabs.map((tab) => (
           <DroppableTab
             key={tab.id}
@@ -253,6 +384,33 @@ export function BuilderCanvas({
           </div>
         </div>
       )}
+        </div>
+
+        <ZoneDropRegion
+          zone="rightRail"
+          label="Right Rail"
+          isActive={activeZone === 'rightRail'}
+          isEmpty={zones.rightRail.length === 0}
+          emptyHint="Drop a panel here"
+          onActivate={() => onSelectZone('rightRail')}
+        >
+          {zones.rightRail.map((section: BuilderSection) => (
+            <DroppableSection
+              key={section.id}
+              section={section}
+              fields={fields}
+              relationships={relationships}
+              registry={registry}
+              selectedId={selectedId}
+              onSelectComponent={onSelectComponent}
+              onSelectSection={onSelectSection}
+              onRemoveComponent={onRemoveComponent}
+              onRemoveSection={onRemoveSection}
+              onRenameSection={onRenameSection}
+            />
+          ))}
+        </ZoneDropRegion>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/BuilderCanvas.tsx
+++ b/apps/web/src/components/BuilderCanvas.tsx
@@ -66,6 +66,13 @@ function ZoneDropRegion({
     data: { origin: 'zone', zone },
   });
 
+  // The zone wrapper itself must be reachable by keyboard so screen-reader
+  // and keyboard-only users can activate it. Child sections / components
+  // call `e.stopPropagation()` on their own clicks, so they activate the
+  // zone through callbacks the parent wires in — this handler only fires
+  // for clicks on the zone's chrome (header, empty hint).
+  const handleActivate = () => onActivate();
+
   return (
     <section
       ref={setNodeRef}
@@ -78,9 +85,19 @@ function ZoneDropRegion({
         .join(' ')}
       data-testid={`zone-${zone}`}
       data-zone-active={isActive ? 'true' : 'false'}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isActive}
+      aria-label={`${label} zone${isActive ? ' (active)' : ''}`}
       onClick={(e) => {
         e.stopPropagation();
-        onActivate();
+        handleActivate();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleActivate();
+        }
       }}
     >
       <header className={styles.zoneHeader}>
@@ -180,6 +197,34 @@ export function BuilderCanvas({
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
+  // Children inside each zone stop click propagation so their own select
+  // handlers don't bubble up to the zone wrapper's `onClick`. To keep
+  // `activeZone` in sync with the palette, wrap the select / remove
+  // callbacks passed into each zone so they also activate the zone.
+  const zoneAwareHandlers = (zone: LayoutZone) => ({
+    onSelectComponent: (componentId: string) => {
+      onSelectZone(zone);
+      onSelectComponent(componentId);
+    },
+    onSelectSection: (sectionId: string) => {
+      onSelectZone(zone);
+      onSelectSection(sectionId);
+    },
+    onRemoveComponent: (sectionId: string, componentId: string) => {
+      onSelectZone(zone);
+      onRemoveComponent(sectionId, componentId);
+    },
+    onRemoveSection: (sectionId: string) => {
+      onSelectZone(zone);
+      onRemoveSection(sectionId);
+    },
+  });
+
+  const kpiHandlers = zoneAwareHandlers('kpi');
+  const leftRailHandlers = zoneAwareHandlers('leftRail');
+  const rightRailHandlers = zoneAwareHandlers('rightRail');
+  const mainHandlers = zoneAwareHandlers('main');
+
   const sectionSortableIds = (activeTab?.sections ?? []).map(
     (s: BuilderSection) => `section-${s.id}`,
   );
@@ -207,19 +252,24 @@ export function BuilderCanvas({
         onActivate={() => onSelectZone('kpi')}
       >
         <div className={styles.kpiStrip}>
-          {zones.kpi.map((comp: BuilderComponent) => (
-            <DraggableComponent
-              key={comp.id}
-              component={comp}
-              sectionId=""
-              fields={fields}
-              relationships={relationships}
-              registry={registry}
-              isSelected={selectedId === comp.id}
-              onSelect={() => onSelectComponent(comp.id)}
-              onRemove={() => onRemoveComponent('', comp.id)}
-            />
-          ))}
+          <SortableContext
+            items={zones.kpi.map((c: BuilderComponent) => c.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {zones.kpi.map((comp: BuilderComponent) => (
+              <DraggableComponent
+                key={comp.id}
+                component={comp}
+                sectionId=""
+                fields={fields}
+                relationships={relationships}
+                registry={registry}
+                isSelected={selectedId === comp.id}
+                onSelect={() => kpiHandlers.onSelectComponent(comp.id)}
+                onRemove={() => kpiHandlers.onRemoveComponent('', comp.id)}
+              />
+            ))}
+          </SortableContext>
         </div>
       </ZoneDropRegion>
 
@@ -233,21 +283,26 @@ export function BuilderCanvas({
           emptyHint="Drop a panel here"
           onActivate={() => onSelectZone('leftRail')}
         >
-          {zones.leftRail.map((section: BuilderSection) => (
-            <DroppableSection
-              key={section.id}
-              section={section}
-              fields={fields}
-              relationships={relationships}
-              registry={registry}
-              selectedId={selectedId}
-              onSelectComponent={onSelectComponent}
-              onSelectSection={onSelectSection}
-              onRemoveComponent={onRemoveComponent}
-              onRemoveSection={onRemoveSection}
-              onRenameSection={onRenameSection}
-            />
-          ))}
+          <SortableContext
+            items={zones.leftRail.map((s: BuilderSection) => `section-${s.id}`)}
+            strategy={verticalListSortingStrategy}
+          >
+            {zones.leftRail.map((section: BuilderSection) => (
+              <DroppableSection
+                key={section.id}
+                section={section}
+                fields={fields}
+                relationships={relationships}
+                registry={registry}
+                selectedId={selectedId}
+                onSelectComponent={leftRailHandlers.onSelectComponent}
+                onSelectSection={leftRailHandlers.onSelectSection}
+                onRemoveComponent={leftRailHandlers.onRemoveComponent}
+                onRemoveSection={leftRailHandlers.onRemoveSection}
+                onRenameSection={onRenameSection}
+              />
+            ))}
+          </SortableContext>
         </ZoneDropRegion>
 
         <div
@@ -357,10 +412,10 @@ export function BuilderCanvas({
                 relationships={relationships}
                 registry={registry}
                 selectedId={selectedId}
-                onSelectComponent={onSelectComponent}
-                onSelectSection={onSelectSection}
-                onRemoveComponent={onRemoveComponent}
-                onRemoveSection={onRemoveSection}
+                onSelectComponent={mainHandlers.onSelectComponent}
+                onSelectSection={mainHandlers.onSelectSection}
+                onRemoveComponent={mainHandlers.onRemoveComponent}
+                onRemoveSection={mainHandlers.onRemoveSection}
                 onRenameSection={onRenameSection}
               />
             ))}
@@ -394,21 +449,26 @@ export function BuilderCanvas({
           emptyHint="Drop a panel here"
           onActivate={() => onSelectZone('rightRail')}
         >
-          {zones.rightRail.map((section: BuilderSection) => (
-            <DroppableSection
-              key={section.id}
-              section={section}
-              fields={fields}
-              relationships={relationships}
-              registry={registry}
-              selectedId={selectedId}
-              onSelectComponent={onSelectComponent}
-              onSelectSection={onSelectSection}
-              onRemoveComponent={onRemoveComponent}
-              onRemoveSection={onRemoveSection}
-              onRenameSection={onRenameSection}
-            />
-          ))}
+          <SortableContext
+            items={zones.rightRail.map((s: BuilderSection) => `section-${s.id}`)}
+            strategy={verticalListSortingStrategy}
+          >
+            {zones.rightRail.map((section: BuilderSection) => (
+              <DroppableSection
+                key={section.id}
+                section={section}
+                fields={fields}
+                relationships={relationships}
+                registry={registry}
+                selectedId={selectedId}
+                onSelectComponent={rightRailHandlers.onSelectComponent}
+                onSelectSection={rightRailHandlers.onSelectSection}
+                onRemoveComponent={rightRailHandlers.onRemoveComponent}
+                onRemoveSection={rightRailHandlers.onRemoveSection}
+                onRenameSection={onRenameSection}
+              />
+            ))}
+          </SortableContext>
         </ZoneDropRegion>
       </div>
     </div>

--- a/apps/web/src/components/ComponentPalette.module.css
+++ b/apps/web/src/components/ComponentPalette.module.css
@@ -15,8 +15,20 @@
   font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-1);
   padding: 0 var(--space-2);
+}
+
+.activeZoneHint {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  margin: 0 0 var(--space-3);
+  padding: 0 var(--space-2);
+}
+
+.activeZoneHint strong {
+  color: var(--text-secondary);
+  font-weight: 600;
 }
 
 .group {

--- a/apps/web/src/components/ComponentPalette.tsx
+++ b/apps/web/src/components/ComponentPalette.tsx
@@ -13,17 +13,18 @@ import type {
 import { resolveIcon } from './iconMap.js';
 import styles from './ComponentPalette.module.css';
 
-// The page builder currently only edits tab sections (the `main` zone).
-// Other zones (kpi, rails) have dedicated editors / are not yet draggable.
-// We filter the palette to components valid in this zone so users can't
-// drop a component that would fail server-side zone validation on save.
-const BUILDER_ACTIVE_ZONE: LayoutZone = 'main';
+// The canvas tracks an active zone: clicking KPI / a rail / the tab body
+// switches this, and the palette filters its options to components valid
+// in that zone so users can't drop something the server would reject on
+// save. When not provided (older callers), defaults to `main` to keep
+// the pre-zones behaviour.
+const DEFAULT_ACTIVE_ZONE: LayoutZone = 'main';
 
-function isAllowedInActiveZone(def: ComponentDefinition): boolean {
+function isAllowedInZone(def: ComponentDefinition, zone: LayoutZone): boolean {
   // `allowedZones` is optional for backwards compatibility with API responses
   // from older deployments — treat "missing" as "no restriction".
   if (!def.allowedZones) return true;
-  return def.allowedZones.includes(BUILDER_ACTIVE_ZONE);
+  return def.allowedZones.includes(zone);
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -34,7 +35,16 @@ interface ComponentPaletteProps {
   relationships: RelationshipRef[];
   relatedFields: RelatedFieldRef[];
   tabs: BuilderTab[];
+  activeZone?: LayoutZone;
 }
+
+const ZONE_LABELS: Record<LayoutZone, string> = {
+  header: 'Header',
+  kpi: 'KPI Strip',
+  leftRail: 'Left Rail',
+  main: 'Main',
+  rightRail: 'Right Rail',
+};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -132,6 +142,7 @@ export function ComponentPalette({
   relationships,
   relatedFields,
   tabs,
+  activeZone = DEFAULT_ACTIVE_ZONE,
 }: ComponentPaletteProps) {
   const [fieldSearch, setFieldSearch] = useState('');
   const placedFields = getPlacedFieldIds(tabs);
@@ -142,7 +153,20 @@ export function ComponentPalette({
     ? fields.filter((f) => f.label.toLowerCase().includes(fieldSearch.toLowerCase()))
     : fields;
 
-  const zoneFilteredRegistry = registry.filter(isAllowedInActiveZone);
+  const zoneFilteredRegistry = registry.filter((def) => isAllowedInZone(def, activeZone));
+  // Fields / related-field / related-list palette groups wrap generic
+  // `field`/`related_field`/`related_list` registry entries. Hide each
+  // group entirely when its underlying type isn't allowed in the active
+  // zone so, for example, the KPI palette doesn't offer plain fields.
+  const fieldAllowed = registry.every(
+    (r) => r.type !== 'field' || isAllowedInZone(r, activeZone),
+  );
+  const relatedFieldAllowed = registry.every(
+    (r) => r.type !== 'related_field' || isAllowedInZone(r, activeZone),
+  );
+  const relatedListAllowed = registry.every(
+    (r) => r.type !== 'related_list' || isAllowedInZone(r, activeZone),
+  );
 
   const grouped = CATEGORY_ORDER
     .map((cat) => ({
@@ -166,11 +190,21 @@ export function ComponentPalette({
   }, {});
 
   return (
-    <div className={styles.palette} data-testid="component-palette">
+    <div
+      className={styles.palette}
+      data-testid="component-palette"
+      data-active-zone={activeZone}
+    >
       <h3 className={styles.paletteTitle}>Components</h3>
+      <p
+        className={styles.activeZoneHint}
+        data-testid="palette-active-zone"
+      >
+        Showing components for: <strong>{ZONE_LABELS[activeZone]}</strong>
+      </p>
 
       {/* Field instances */}
-      {fields.length > 0 && (
+      {fieldAllowed && fields.length > 0 && (
         <div className={styles.group}>
           <h4 className={styles.groupLabel}>Fields</h4>
           <input
@@ -204,7 +238,7 @@ export function ComponentPalette({
       )}
 
       {/* Related field instances */}
-      {Object.keys(relatedFieldsByRelationship).length > 0 && (
+      {relatedFieldAllowed && Object.keys(relatedFieldsByRelationship).length > 0 && (
         <div className={styles.group} data-testid="related-fields-group">
           <h4 className={styles.groupLabel}>Related Fields</h4>
           {Object.entries(relatedFieldsByRelationship).map(([relApiName, group]) => (
@@ -244,7 +278,7 @@ export function ComponentPalette({
       )}
 
       {/* Relationship instances */}
-      {relationships.length > 0 && (
+      {relatedListAllowed && relationships.length > 0 && (
         <div className={styles.group}>
           <h4 className={styles.groupLabel}>Related Lists</h4>
           {relationships.map((rel) => (

--- a/apps/web/src/components/ComponentPalette.tsx
+++ b/apps/web/src/components/ComponentPalette.tsx
@@ -8,6 +8,9 @@ import type {
   RelatedFieldRef,
   PaletteDragData,
   BuilderTab,
+  BuilderZones,
+  BuilderSection,
+  BuilderComponent,
   LayoutZone,
 } from './builderTypes.js';
 import { resolveIcon } from './iconMap.js';
@@ -35,6 +38,11 @@ interface ComponentPaletteProps {
   relationships: RelationshipRef[];
   relatedFields: RelatedFieldRef[];
   tabs: BuilderTab[];
+  // Rail sections also accept fields, related fields, and related lists.
+  // When provided, the palette's "placed" indicator reflects items in
+  // rails too so admins don't get a misleading checkmark state. Omitted
+  // in tests / older callers; treated as no rails in that case.
+  zones?: BuilderZones;
   activeZone?: LayoutZone;
 }
 
@@ -57,49 +65,70 @@ const CATEGORY_LABELS: Record<ComponentCategory, string> = {
 
 const CATEGORY_ORDER: ComponentCategory[] = ['fields', 'related', 'widgets', 'layout'];
 
-function getPlacedFieldIds(tabs: BuilderTab[]): Set<string> {
-  const ids = new Set<string>();
+// Walk every section that can host field / related-field / related-list
+// components. That's every tab section plus both rails; KPI components
+// never have these types so we skip it.
+function forEachHostSection(
+  tabs: BuilderTab[],
+  zones: BuilderZones | undefined,
+  visit: (section: BuilderSection) => void,
+) {
   for (const tab of tabs) {
-    for (const section of tab.sections) {
-      for (const comp of section.components) {
-        if (comp.type === 'field' && comp.config.fieldApiName) {
-          ids.add(String(comp.config.fieldApiName));
-        }
+    for (const section of tab.sections) visit(section);
+  }
+  if (zones) {
+    for (const section of zones.leftRail) visit(section);
+    for (const section of zones.rightRail) visit(section);
+  }
+}
+
+function getPlacedFieldIds(
+  tabs: BuilderTab[],
+  zones: BuilderZones | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  forEachHostSection(tabs, zones, (section) => {
+    for (const comp of section.components) {
+      if (comp.type === 'field' && comp.config.fieldApiName) {
+        ids.add(String(comp.config.fieldApiName));
       }
     }
-  }
+  });
   return ids;
 }
 
-function getPlacedRelationshipIds(tabs: BuilderTab[]): Set<string> {
+function getPlacedRelationshipIds(
+  tabs: BuilderTab[],
+  zones: BuilderZones | undefined,
+): Set<string> {
   const ids = new Set<string>();
-  for (const tab of tabs) {
-    for (const section of tab.sections) {
-      for (const comp of section.components) {
-        if (comp.type === 'related_list' && comp.config.relationshipId) {
-          ids.add(String(comp.config.relationshipId));
-        }
+  forEachHostSection(tabs, zones, (section) => {
+    for (const comp of section.components) {
+      if (comp.type === 'related_list' && comp.config.relationshipId) {
+        ids.add(String(comp.config.relationshipId));
       }
     }
-  }
+  });
   return ids;
 }
 
-function getPlacedRelatedFieldIds(tabs: BuilderTab[]): Set<string> {
+function getPlacedRelatedFieldIds(
+  tabs: BuilderTab[],
+  zones: BuilderZones | undefined,
+): Set<string> {
   const ids = new Set<string>();
-  for (const tab of tabs) {
-    for (const section of tab.sections) {
-      for (const comp of section.components) {
-        if (
-          comp.type === 'related_field' &&
-          comp.config.relationshipApiName &&
-          comp.config.relatedFieldApiName
-        ) {
-          ids.add(`${comp.config.relationshipApiName}.${comp.config.relatedFieldApiName}`);
-        }
-      }
+  const addFromComponent = (comp: BuilderComponent) => {
+    if (
+      comp.type === 'related_field' &&
+      comp.config.relationshipApiName &&
+      comp.config.relatedFieldApiName
+    ) {
+      ids.add(`${comp.config.relationshipApiName}.${comp.config.relatedFieldApiName}`);
     }
-  }
+  };
+  forEachHostSection(tabs, zones, (section) => {
+    for (const comp of section.components) addFromComponent(comp);
+  });
   return ids;
 }
 
@@ -142,12 +171,13 @@ export function ComponentPalette({
   relationships,
   relatedFields,
   tabs,
+  zones,
   activeZone = DEFAULT_ACTIVE_ZONE,
 }: ComponentPaletteProps) {
   const [fieldSearch, setFieldSearch] = useState('');
-  const placedFields = getPlacedFieldIds(tabs);
-  const placedRelationships = getPlacedRelationshipIds(tabs);
-  const placedRelatedFields = getPlacedRelatedFieldIds(tabs);
+  const placedFields = getPlacedFieldIds(tabs, zones);
+  const placedRelationships = getPlacedRelationshipIds(tabs, zones);
+  const placedRelatedFields = getPlacedRelatedFieldIds(tabs, zones);
 
   const filteredFields = fieldSearch
     ? fields.filter((f) => f.label.toLowerCase().includes(fieldSearch.toLowerCase()))

--- a/apps/web/src/components/builderTypes.ts
+++ b/apps/web/src/components/builderTypes.ts
@@ -60,11 +60,20 @@ export interface BuilderTab {
   sections: BuilderSection[];
 }
 
+// KPI is a flat list of components (cards). Rails are vertical stacks of
+// sections. Matches the runtime `LayoutZones` / API `PageLayoutZones`.
+export interface BuilderZones {
+  kpi: BuilderComponent[];
+  leftRail: BuilderSection[];
+  rightRail: BuilderSection[];
+}
+
 export interface BuilderLayout {
   id: string;
   objectId: string;
   name: string;
   header: HeaderConfig;
+  zones: BuilderZones;
   tabs: BuilderTab[];
 }
 
@@ -123,7 +132,18 @@ export interface TabDropTargetData {
   tabId: string;
 }
 
-export type DragData = PaletteDragData | CanvasComponentDragData | CanvasSectionDragData | TabDropTargetData;
+// Drop target for a whole zone (KPI strip or a rail).
+export interface ZoneDropTargetData {
+  origin: 'zone';
+  zone: Exclude<LayoutZone, 'header' | 'main'>;
+}
+
+export type DragData =
+  | PaletteDragData
+  | CanvasComponentDragData
+  | CanvasSectionDragData
+  | TabDropTargetData
+  | ZoneDropTargetData;
 
 // ─── Page layout API shapes ──────────────────────────────────────────────────
 

--- a/apps/web/src/features/page-builder/PageBuilderPage.tsx
+++ b/apps/web/src/features/page-builder/PageBuilderPage.tsx
@@ -18,6 +18,7 @@ export function PageBuilderPage() {
   const dnd = usePageLayoutDnd({
     layout: pl.layout,
     updateLayout: pl.updateLayout,
+    registry: pl.registry,
   });
 
   const actions = usePageLayoutActions({
@@ -112,8 +113,10 @@ export function PageBuilderPage() {
         selectedId={pl.selectedId}
         selectedItem={pl.getSelectedItem()}
         activeDragId={dnd.activeDragId}
+        activeZone={pl.activeZone}
         sensors={pl.sensors}
         onSelect={pl.setSelectedId}
+        onSelectZone={pl.setActiveZone}
         onHeaderChange={pl.handleHeaderChange}
         onAddTab={pl.handleAddTab}
         onRenameTab={pl.handleRenameTab}

--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -117,6 +117,7 @@ export function LayoutCanvas({
           relationships={relationships}
           relatedFields={relatedFields}
           tabs={layout.tabs}
+          zones={layout.zones}
           activeZone={activeZone}
         />
 

--- a/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
+++ b/apps/web/src/features/page-builder/components/LayoutCanvas.tsx
@@ -21,6 +21,7 @@ import type {
   RelationshipRef,
   RelatedFieldRef,
   BuilderLayout,
+  LayoutZone,
 } from '../../../components/builderTypes.js';
 import type { HeaderConfig, VisibilityRule } from '../../../components/layoutTypes.js';
 import styles from '../PageBuilderPage.module.css';
@@ -50,8 +51,10 @@ interface LayoutCanvasProps {
   selectedId: string | null;
   selectedItem: SelectedItem | null;
   activeDragId: string | null;
+  activeZone: LayoutZone;
   sensors: SensorDescriptor<SensorOptions>[];
   onSelect: (id: string | null) => void;
+  onSelectZone: (zone: LayoutZone) => void;
   onHeaderChange: (header: HeaderConfig) => void;
   onAddTab: () => void;
   onRenameTab: (tabId: string, label: string) => void;
@@ -79,8 +82,10 @@ export function LayoutCanvas({
   selectedId,
   selectedItem,
   activeDragId,
+  activeZone,
   sensors,
   onSelect,
+  onSelectZone,
   onHeaderChange,
   onAddTab,
   onRenameTab,
@@ -112,6 +117,7 @@ export function LayoutCanvas({
           relationships={relationships}
           relatedFields={relatedFields}
           tabs={layout.tabs}
+          activeZone={activeZone}
         />
 
         <BuilderCanvas
@@ -120,7 +126,9 @@ export function LayoutCanvas({
           relationships={relationships}
           registry={registry}
           selectedId={selectedId}
+          activeZone={activeZone}
           onSelect={onSelect}
+          onSelectZone={onSelectZone}
           onHeaderChange={onHeaderChange}
           onAddTab={onAddTab}
           onRenameTab={onRenameTab}

--- a/apps/web/src/features/page-builder/helpers.ts
+++ b/apps/web/src/features/page-builder/helpers.ts
@@ -1,9 +1,25 @@
-import type { BuilderLayout } from '../../components/builderTypes.js';
+import type { BuilderLayout, BuilderZones } from '../../components/builderTypes.js';
 
 let _idCounter = 0;
 export function uid(): string {
   _idCounter += 1;
   return `builder-${Date.now()}-${_idCounter}`;
+}
+
+export function createEmptyZones(): BuilderZones {
+  return { kpi: [], leftRail: [], rightRail: [] };
+}
+
+// Back-fill missing or partial zones from older layouts so the builder
+// always operates on a populated shape.
+export function normalizeBuilderZones(
+  zones: Partial<BuilderZones> | null | undefined,
+): BuilderZones {
+  return {
+    kpi: Array.isArray(zones?.kpi) ? zones!.kpi! : [],
+    leftRail: Array.isArray(zones?.leftRail) ? zones!.leftRail! : [],
+    rightRail: Array.isArray(zones?.rightRail) ? zones!.rightRail! : [],
+  };
 }
 
 export function createDefaultLayout(objectId: string, name: string): BuilderLayout {
@@ -12,6 +28,7 @@ export function createDefaultLayout(objectId: string, name: string): BuilderLayo
     objectId,
     name,
     header: { primaryField: 'name', secondaryFields: [] },
+    zones: createEmptyZones(),
     tabs: [
       {
         id: uid(),
@@ -41,5 +58,55 @@ export function findSection(
       }
     }
   }
+  return null;
+}
+
+// Locate a section across tabs + rails. Sections live in three places
+// (tab body + both rails), and most mutators don't care which — returning
+// the parent array lets callers mutate in place without branching.
+export function findAnySection(
+  layout: BuilderLayout,
+  sectionId: string,
+):
+  | { scope: 'tab'; tabIndex: number; sectionIndex: number }
+  | { scope: 'leftRail' | 'rightRail'; sectionIndex: number }
+  | null {
+  const tabLoc = findSection(layout, sectionId);
+  if (tabLoc) return { scope: 'tab', ...tabLoc };
+
+  for (const rail of ['leftRail', 'rightRail'] as const) {
+    const idx = layout.zones[rail].findIndex((s) => s.id === sectionId);
+    if (idx >= 0) return { scope: rail, sectionIndex: idx };
+  }
+  return null;
+}
+
+// Resolve a component id anywhere in the layout (tab sections, rails, KPI).
+export function findAnyComponent(
+  layout: BuilderLayout,
+  componentId: string,
+):
+  | { scope: 'tab-section'; tabIndex: number; sectionIndex: number; componentIndex: number }
+  | { scope: 'rail-section'; rail: 'leftRail' | 'rightRail'; sectionIndex: number; componentIndex: number }
+  | { scope: 'kpi'; componentIndex: number }
+  | null {
+  for (let ti = 0; ti < layout.tabs.length; ti++) {
+    for (let si = 0; si < layout.tabs[ti].sections.length; si++) {
+      const ci = layout.tabs[ti].sections[si].components.findIndex((c) => c.id === componentId);
+      if (ci >= 0) {
+        return { scope: 'tab-section', tabIndex: ti, sectionIndex: si, componentIndex: ci };
+      }
+    }
+  }
+  for (const rail of ['leftRail', 'rightRail'] as const) {
+    for (let si = 0; si < layout.zones[rail].length; si++) {
+      const ci = layout.zones[rail][si].components.findIndex((c) => c.id === componentId);
+      if (ci >= 0) {
+        return { scope: 'rail-section', rail, sectionIndex: si, componentIndex: ci };
+      }
+    }
+  }
+  const kpiIdx = layout.zones.kpi.findIndex((c) => c.id === componentId);
+  if (kpiIdx >= 0) return { scope: 'kpi', componentIndex: kpiIdx };
   return null;
 }

--- a/apps/web/src/features/page-builder/hooks/usePageLayout.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayout.ts
@@ -31,9 +31,10 @@ import {
   normalizeBuilderZones,
 } from '../helpers.js';
 
-// Zones the page builder exposes as drop targets. 'header' has its own
-// dedicated editor (`HeaderZoneEditor`) and 'main' covers the tab body, so
-// both are tracked separately from this union.
+// Active zone state for the page builder canvas. Matches the full
+// `LayoutZone` union: 'header' runs through the dedicated
+// `HeaderZoneEditor`, while 'main' / 'kpi' / 'leftRail' / 'rightRail'
+// are the zones the canvas exposes as drop targets.
 export type ActiveZone = LayoutZone;
 
 type RailZone = 'leftRail' | 'rightRail';

--- a/apps/web/src/features/page-builder/hooks/usePageLayout.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayout.ts
@@ -18,11 +18,25 @@ import type {
   BuilderSection,
   BuilderComponent,
   PageLayoutListItem,
+  LayoutZone,
 } from '../../../components/builderTypes.js';
 import type { HeaderConfig, VisibilityRule } from '../../../components/layoutTypes.js';
 import type { SelectedItem } from '../../../components/PropertiesPanel.js';
 import type { ObjectDefinitionDetail, RelationshipApiItem, RelatedObjectFields } from '../types.js';
-import { uid, createDefaultLayout, findSection } from '../helpers.js';
+import {
+  uid,
+  createDefaultLayout,
+  findAnySection,
+  findAnyComponent,
+  normalizeBuilderZones,
+} from '../helpers.js';
+
+// Zones the page builder exposes as drop targets. 'header' has its own
+// dedicated editor (`HeaderZoneEditor`) and 'main' covers the tab body, so
+// both are tracked separately from this union.
+export type ActiveZone = LayoutZone;
+
+type RailZone = 'leftRail' | 'rightRail';
 
 export function usePageLayout(objectId: string | undefined) {
   const { sessionToken } = useSession();
@@ -39,6 +53,7 @@ export function usePageLayout(objectId: string | undefined) {
   const [layout, setLayout] = useState<BuilderLayout | null>(null);
   const [selectedLayoutId, setSelectedLayoutId] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeZone, setActiveZone] = useState<ActiveZone>('main');
   const [dirty, setDirty] = useState(false);
 
   // UI state
@@ -69,7 +84,11 @@ export function usePageLayout(objectId: string | undefined) {
           layout: BuilderLayout | null;
         };
         if (data.layout) {
-          setLayout(data.layout);
+          // Back-compat: older server responses may omit `zones`.
+          setLayout({
+            ...data.layout,
+            zones: normalizeBuilderZones(data.layout.zones),
+          });
         } else {
           setLayout(createDefaultLayout(objectId, data.name ?? 'Default'));
         }
@@ -255,6 +274,11 @@ export function usePageLayout(objectId: string | undefined) {
       for (const tab of draft.tabs) {
         tab.sections = tab.sections.filter((s: BuilderSection) => s.id !== sectionId);
       }
+      for (const rail of ['leftRail', 'rightRail'] as const) {
+        draft.zones[rail] = draft.zones[rail].filter(
+          (s: BuilderSection) => s.id !== sectionId,
+        );
+      }
       return draft;
     });
     if (selectedId === sectionId) setSelectedId(null);
@@ -266,16 +290,36 @@ export function usePageLayout(objectId: string | undefined) {
         const section = tab.sections.find((s: BuilderSection) => s.id === sectionId);
         if (section) section.label = label;
       }
+      for (const rail of ['leftRail', 'rightRail'] as const) {
+        const section = draft.zones[rail].find(
+          (s: BuilderSection) => s.id === sectionId,
+        );
+        if (section) section.label = label;
+      }
       return draft;
     });
   }, [updateLayout]);
 
   const handleRemoveComponent = useCallback((sectionId: string, componentId: string) => {
     updateLayout((draft) => {
-      const loc = findSection(draft, sectionId);
-      if (loc) {
+      // `sectionId === ''` is the canvas's signal that the component lives
+      // in the KPI strip (which has no section wrapper).
+      if (sectionId === '') {
+        draft.zones.kpi = draft.zones.kpi.filter(
+          (c: BuilderComponent) => c.id !== componentId,
+        );
+        return draft;
+      }
+      const loc = findAnySection(draft, sectionId);
+      if (!loc) return draft;
+      if (loc.scope === 'tab') {
         draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components =
           draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components.filter(
+            (c: BuilderComponent) => c.id !== componentId,
+          );
+      } else {
+        draft.zones[loc.scope][loc.sectionIndex].components =
+          draft.zones[loc.scope][loc.sectionIndex].components.filter(
             (c: BuilderComponent) => c.id !== componentId,
           );
       }
@@ -293,34 +337,40 @@ export function usePageLayout(objectId: string | undefined) {
   }, []);
 
   const handleComponentChange = useCallback((
-    sectionId: string,
+    _sectionId: string,
     componentId: string,
     config: Record<string, unknown>,
   ) => {
     updateLayout((draft) => {
-      const loc = findSection(draft, sectionId);
-      if (loc) {
-        const comp = draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components.find(
-          (c: BuilderComponent) => c.id === componentId,
-        );
-        if (comp) comp.config = config;
+      const loc = findAnyComponent(draft, componentId);
+      if (!loc) return draft;
+      if (loc.scope === 'tab-section') {
+        const comp = draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components[loc.componentIndex];
+        comp.config = config;
+      } else if (loc.scope === 'rail-section') {
+        const comp = draft.zones[loc.rail][loc.sectionIndex].components[loc.componentIndex];
+        comp.config = config;
+      } else {
+        draft.zones.kpi[loc.componentIndex].config = config;
       }
       return draft;
     });
   }, [updateLayout]);
 
   const handleComponentVisibilityChange = useCallback((
-    sectionId: string,
+    _sectionId: string,
     componentId: string,
     rule: VisibilityRule | null,
   ) => {
     updateLayout((draft) => {
-      const loc = findSection(draft, sectionId);
-      if (loc) {
-        const comp = draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components.find(
-          (c: BuilderComponent) => c.id === componentId,
-        );
-        if (comp) comp.visibility = rule;
+      const loc = findAnyComponent(draft, componentId);
+      if (!loc) return draft;
+      if (loc.scope === 'tab-section') {
+        draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components[loc.componentIndex].visibility = rule;
+      } else if (loc.scope === 'rail-section') {
+        draft.zones[loc.rail][loc.sectionIndex].components[loc.componentIndex].visibility = rule;
+      } else {
+        draft.zones.kpi[loc.componentIndex].visibility = rule;
       }
       return draft;
     });
@@ -331,12 +381,19 @@ export function usePageLayout(objectId: string | undefined) {
     patch: { label?: string; columns?: number },
   ) => {
     updateLayout((draft) => {
+      const applyPatch = (section: BuilderSection) => {
+        if (patch.label !== undefined) section.label = patch.label;
+        if (patch.columns !== undefined) section.columns = patch.columns;
+      };
       for (const tab of draft.tabs) {
         const section = tab.sections.find((s: BuilderSection) => s.id === sectionId);
-        if (section) {
-          if (patch.label !== undefined) section.label = patch.label;
-          if (patch.columns !== undefined) section.columns = patch.columns;
-        }
+        if (section) applyPatch(section);
+      }
+      for (const rail of ['leftRail', 'rightRail'] as const) {
+        const section = draft.zones[rail].find(
+          (s: BuilderSection) => s.id === sectionId,
+        );
+        if (section) applyPatch(section);
       }
       return draft;
     });
@@ -348,9 +405,63 @@ export function usePageLayout(objectId: string | undefined) {
         const section = tab.sections.find((s: BuilderSection) => s.id === sectionId);
         if (section) section.visibility = rule;
       }
+      for (const rail of ['leftRail', 'rightRail'] as const) {
+        const section = draft.zones[rail].find(
+          (s: BuilderSection) => s.id === sectionId,
+        );
+        if (section) section.visibility = rule;
+      }
       return draft;
     });
   }, [updateLayout]);
+
+  // ── Zone-aware helpers ─────────────────────────────────────
+  //
+  // The page builder edits the zoned shell directly: KPI cards and rail
+  // sections live in `layout.zones` rather than inside a tab. These
+  // handlers keep the tab-level helpers above focused on `main` while
+  // giving the canvas a parallel set of mutators that won't accidentally
+  // reach into tabs.
+
+  const handleAddKpiComponent = useCallback((comp: BuilderComponent) => {
+    updateLayout((draft) => {
+      draft.zones.kpi.push(comp);
+      return draft;
+    });
+  }, [updateLayout]);
+
+  const handleRemoveKpiComponent = useCallback((componentId: string) => {
+    updateLayout((draft) => {
+      draft.zones.kpi = draft.zones.kpi.filter(
+        (c: BuilderComponent) => c.id !== componentId,
+      );
+      return draft;
+    });
+    if (selectedId === componentId) setSelectedId(null);
+  }, [updateLayout, selectedId]);
+
+  const handleAddRailSection = useCallback((rail: RailZone, columns: number) => {
+    updateLayout((draft) => {
+      draft.zones[rail].push({
+        id: uid(),
+        type: 'field_section',
+        label: `Section ${draft.zones[rail].length + 1}`,
+        columns,
+        components: [],
+      });
+      return draft;
+    });
+  }, [updateLayout]);
+
+  const handleRemoveRailSection = useCallback((rail: RailZone, sectionId: string) => {
+    updateLayout((draft) => {
+      draft.zones[rail] = draft.zones[rail].filter(
+        (s: BuilderSection) => s.id !== sectionId,
+      );
+      return draft;
+    });
+    if (selectedId === sectionId) setSelectedId(null);
+  }, [updateLayout, selectedId]);
 
   // ── Derive selected item for properties panel ──────────────
 
@@ -361,6 +472,10 @@ export function usePageLayout(objectId: string | undefined) {
       const section = tab.sections.find((s) => s.id === selectedId);
       if (section) return { kind: 'section', section };
     }
+    for (const rail of ['leftRail', 'rightRail'] as const) {
+      const section = layout.zones[rail].find((s) => s.id === selectedId);
+      if (section) return { kind: 'section', section };
+    }
 
     for (const tab of layout.tabs) {
       for (const section of tab.sections) {
@@ -368,20 +483,31 @@ export function usePageLayout(objectId: string | undefined) {
         if (component) return { kind: 'component', component, sectionId: section.id };
       }
     }
+    for (const rail of ['leftRail', 'rightRail'] as const) {
+      for (const section of layout.zones[rail]) {
+        const component = section.components.find((c) => c.id === selectedId);
+        if (component) return { kind: 'component', component, sectionId: section.id };
+      }
+    }
+    // KPI components live directly in `zones.kpi` with no section wrapper.
+    const kpiComp = layout.zones.kpi.find((c) => c.id === selectedId);
+    if (kpiComp) return { kind: 'component', component: kpiComp, sectionId: '' };
 
     return null;
   }, [selectedId, layout]);
 
   return {
     objectDef, fields, relationships, relatedFields, registry,
-    layout, selectedLayoutId, selectedId, dirty, allLayouts, sensors,
+    layout, selectedLayoutId, selectedId, activeZone, dirty, allLayouts, sensors,
     loading, error,
-    setLayout, setSelectedLayoutId, setDirty, setSelectedId, setAllLayouts,
+    setLayout, setSelectedLayoutId, setDirty, setSelectedId, setActiveZone, setAllLayouts,
     loadLayoutDetail, updateLayout, getSelectedItem,
     handleHeaderChange, handleAddTab, handleRenameTab, handleRemoveTab,
     handleAddSection, handleRemoveSection, handleRenameSection,
     handleRemoveComponent, handleSelectComponent, handleSelectSection,
     handleComponentChange, handleComponentVisibilityChange,
     handleSectionChange, handleSectionVisibilityChange,
+    handleAddKpiComponent, handleRemoveKpiComponent,
+    handleAddRailSection, handleRemoveRailSection,
   };
 }

--- a/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
@@ -5,18 +5,41 @@ import type {
   BuilderComponent,
   BuilderSection,
   BuilderTab,
+  ComponentDefinition,
   PaletteDragData,
   CanvasComponentDragData,
   CanvasSectionDragData,
+  LayoutZone,
 } from '../../../components/builderTypes.js';
 import { uid, findSection } from '../helpers.js';
 
 interface UsePageLayoutDndOptions {
   layout: BuilderLayout | null;
   updateLayout: (mutator: (draft: BuilderLayout) => BuilderLayout) => void;
+  registry?: ComponentDefinition[];
+  onRejectZoneDrop?: (componentType: string, zone: LayoutZone) => void;
 }
 
-export function usePageLayoutDnd({ layout, updateLayout }: UsePageLayoutDndOptions) {
+// Client-side mirror of the server's isComponentAllowedInZone. Returns
+// true when the registry doesn't list allowedZones (back-compat) so older
+// deployments don't break drops on the first load after upgrade.
+function isAllowedInZone(
+  registry: ComponentDefinition[] | undefined,
+  componentType: string,
+  zone: LayoutZone,
+): boolean {
+  if (!registry) return true;
+  const def = registry.find((r) => r.type === componentType);
+  if (!def || !def.allowedZones) return true;
+  return def.allowedZones.includes(zone);
+}
+
+export function usePageLayoutDnd({
+  layout,
+  updateLayout,
+  registry,
+  onRejectZoneDrop,
+}: UsePageLayoutDndOptions) {
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -42,8 +65,43 @@ export function usePageLayoutDnd({ layout, updateLayout }: UsePageLayoutDndOptio
         config: { ...paletteData.defaultConfig },
       };
 
+      // Palette → zone drop (KPI strip or a rail).
+      if (overData && overData.origin === 'zone') {
+        const zone = overData.zone as LayoutZone;
+        if (!isAllowedInZone(registry, paletteData.componentType, zone)) {
+          onRejectZoneDrop?.(paletteData.componentType, zone);
+          return;
+        }
+        if (zone === 'kpi') {
+          updateLayout((draft) => {
+            draft.zones.kpi.push(newComp);
+            return draft;
+          });
+          return;
+        }
+        if (zone === 'leftRail' || zone === 'rightRail') {
+          // Rails are stacks of sections, each with a single column. Drops
+          // onto the rail zone itself create a new one-column section.
+          updateLayout((draft) => {
+            draft.zones[zone].push({
+              id: uid(),
+              type: 'field_section',
+              label: `Section ${draft.zones[zone].length + 1}`,
+              columns: 1,
+              components: [newComp],
+            });
+            return draft;
+          });
+          return;
+        }
+      }
+
       // Palette → new-section drop: create a section and place the component in it.
       if (overData && overData.origin === 'new-section') {
+        if (!isAllowedInZone(registry, paletteData.componentType, 'main')) {
+          onRejectZoneDrop?.(paletteData.componentType, 'main');
+          return;
+        }
         const targetTabId = overData.tabId as string;
         const columns = (overData.columns as number) ?? 1;
         updateLayout((draft) => {
@@ -68,10 +126,32 @@ export function usePageLayoutDnd({ layout, updateLayout }: UsePageLayoutDndOptio
 
       if (!targetSectionId) return;
 
+      // Infer the target zone from where this section lives, so the palette
+      // → existing-section path enforces the same whitelist as zone drops.
+      const targetZone: LayoutZone = layout.zones.leftRail.some((s) => s.id === targetSectionId)
+        ? 'leftRail'
+        : layout.zones.rightRail.some((s) => s.id === targetSectionId)
+          ? 'rightRail'
+          : 'main';
+      if (!isAllowedInZone(registry, paletteData.componentType, targetZone)) {
+        onRejectZoneDrop?.(paletteData.componentType, targetZone);
+        return;
+      }
+
       updateLayout((draft) => {
         const loc = findSection(draft, targetSectionId!);
         if (loc) {
           draft.tabs[loc.tabIndex].sections[loc.sectionIndex].components.push(newComp);
+          return draft;
+        }
+        for (const rail of ['leftRail', 'rightRail'] as const) {
+          const idx = draft.zones[rail].findIndex(
+            (s: BuilderSection) => s.id === targetSectionId,
+          );
+          if (idx >= 0) {
+            draft.zones[rail][idx].components.push(newComp);
+            return draft;
+          }
         }
         return draft;
       });
@@ -199,7 +279,7 @@ export function usePageLayoutDnd({ layout, updateLayout }: UsePageLayoutDndOptio
         return draft;
       });
     }
-  }, [layout, updateLayout]);
+  }, [layout, updateLayout, registry, onRejectZoneDrop]);
 
   return {
     activeDragId,

--- a/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
+++ b/apps/web/src/features/page-builder/hooks/usePageLayoutDnd.ts
@@ -11,7 +11,33 @@ import type {
   CanvasSectionDragData,
   LayoutZone,
 } from '../../../components/builderTypes.js';
-import { uid, findSection } from '../helpers.js';
+import { uid, findSection, findAnySection } from '../helpers.js';
+
+// Returns the array of sections in whichever scope `sectionId` lives.
+// Used by reorder paths so they work uniformly across tabs, leftRail,
+// and rightRail. Returning the parent array plus the index lets callers
+// splice in place without branching on scope.
+function resolveSectionScope(
+  layout: BuilderLayout,
+  sectionId: string,
+):
+  | { sections: BuilderSection[]; index: number; zone: LayoutZone }
+  | null {
+  const loc = findAnySection(layout, sectionId);
+  if (!loc) return null;
+  if (loc.scope === 'tab') {
+    return {
+      sections: layout.tabs[loc.tabIndex].sections,
+      index: loc.sectionIndex,
+      zone: 'main',
+    };
+  }
+  return {
+    sections: layout.zones[loc.scope],
+    index: loc.sectionIndex,
+    zone: loc.scope,
+  };
+}
 
 interface UsePageLayoutDndOptions {
   layout: BuilderLayout | null;
@@ -20,9 +46,14 @@ interface UsePageLayoutDndOptions {
   onRejectZoneDrop?: (componentType: string, zone: LayoutZone) => void;
 }
 
-// Client-side mirror of the server's isComponentAllowedInZone. Returns
-// true when the registry doesn't list allowedZones (back-compat) so older
-// deployments don't break drops on the first load after upgrade.
+// Client-side mirror of the server's isComponentAllowedInZone. Unknown
+// component types are rejected when a registry is supplied, matching
+// the server (so a client with a stale registry can't ship a layout the
+// server will refuse on save). When no registry is provided at all —
+// only happens during transient load states before `fetchData` resolves
+// — we fall back to "allow" so early drops aren't silently swallowed.
+// Missing `allowedZones` on a known type stays permissive for
+// back-compat with older API responses.
 function isAllowedInZone(
   registry: ComponentDefinition[] | undefined,
   componentType: string,
@@ -30,7 +61,8 @@ function isAllowedInZone(
 ): boolean {
   if (!registry) return true;
   const def = registry.find((r) => r.type === componentType);
-  if (!def || !def.allowedZones) return true;
+  if (!def) return false;
+  if (!def.allowedZones) return true;
   return def.allowedZones.includes(zone);
 }
 
@@ -176,22 +208,37 @@ export function usePageLayoutDnd({
 
       if (!targetSectionId) return;
 
+      // Canvas components may now live in tab sections OR rail sections
+      // (the KPI strip has no section wrapper, so it isn't a target here).
+      // Resolve source + target before mutating: if either is missing, or
+      // if the move would violate a zone whitelist, bail without touching
+      // the layout. The previous implementation spliced the source first
+      // and then dropped the component on the floor when the target
+      // wasn't a tab section — silent data loss for any main→rail drag.
       updateLayout((draft) => {
-        const sourceLoc = findSection(draft, canvasData.sectionId);
-        if (!sourceLoc) return draft;
+        const sourceScope = resolveSectionScope(draft, canvasData.sectionId);
+        if (!sourceScope) return draft;
 
-        const sourceSection = draft.tabs[sourceLoc.tabIndex].sections[sourceLoc.sectionIndex];
+        const sourceSection = sourceScope.sections[sourceScope.index];
         const compIdx = sourceSection.components.findIndex(
           (c: BuilderComponent) => c.id === canvasData.componentId,
         );
         if (compIdx < 0) return draft;
 
+        const targetScope = resolveSectionScope(draft, targetSectionId!);
+        if (!targetScope) return draft;
+
+        const movingComponent = sourceSection.components[compIdx];
+        if (
+          sourceScope.zone !== targetScope.zone &&
+          !isAllowedInZone(registry, movingComponent.type, targetScope.zone)
+        ) {
+          onRejectZoneDrop?.(movingComponent.type, targetScope.zone);
+          return draft;
+        }
+
         const [movedComp] = sourceSection.components.splice(compIdx, 1);
-
-        const targetLoc = findSection(draft, targetSectionId!);
-        if (!targetLoc) return draft;
-
-        const targetSection = draft.tabs[targetLoc.tabIndex].sections[targetLoc.sectionIndex];
+        const targetSection = targetScope.sections[targetScope.index];
 
         if (targetComponentId) {
           const targetIdx = targetSection.components.findIndex(
@@ -212,70 +259,64 @@ export function usePageLayoutDnd({
       return;
     }
 
-    // Section reorder (within same tab or across tabs)
+    // Section reorder (within same tab / across tabs, or within a rail)
     if (activeData.origin === 'canvas-section') {
       const sectionData = activeData as unknown as CanvasSectionDragData;
       const overData = over.data.current;
 
       if (!overData) return;
 
-      // Dropped on a tab target — move section to that tab
+      // Dropped on a tab target — move section to that tab. Only allowed
+      // for sections that already live in a tab (main zone); rail
+      // sections dragged onto a tab would cross zones silently, so we
+      // bail instead of lossily moving. Resolve source before splicing.
       if (overData.origin === 'tab-drop-target') {
         const targetTabId = overData.tabId as string;
         updateLayout((draft) => {
-          let movedSection: BuilderSection | null = null;
-          for (const tab of draft.tabs) {
-            const idx = tab.sections.findIndex(
-              (s: BuilderSection) => s.id === sectionData.sectionId,
-            );
-            if (idx >= 0) {
-              if (tab.id === targetTabId) return draft;
-              [movedSection] = tab.sections.splice(idx, 1);
-              break;
-            }
-          }
-          if (!movedSection) return draft;
-
+          const sourceLoc = findSection(draft, sectionData.sectionId);
+          if (!sourceLoc) return draft;
+          const sourceTab = draft.tabs[sourceLoc.tabIndex];
+          if (sourceTab.id === targetTabId) return draft;
           const targetTab = draft.tabs.find((t: BuilderTab) => t.id === targetTabId);
-          if (targetTab) {
-            targetTab.sections.push(movedSection);
-          }
+          if (!targetTab) return draft;
+          const [movedSection] = sourceTab.sections.splice(sourceLoc.sectionIndex, 1);
+          targetTab.sections.push(movedSection);
           return draft;
         });
         return;
       }
 
-      // Dropped on another section — reorder within or across tabs
+      // Dropped on another section — reorder. Only support moves within
+      // the same scope (tabs ↔ tabs, leftRail ↔ leftRail, rightRail ↔
+      // rightRail). Cross-zone reordering isn't a supported interaction
+      // yet, and silently moving the section would surprise users.
       if (overData.origin !== 'canvas-section') return;
       const overSectionData = overData as unknown as CanvasSectionDragData;
       if (sectionData.sectionId === overSectionData.sectionId) return;
 
       updateLayout((draft) => {
-        let sourceTabIndex = -1;
-        let sourceIdx = -1;
-        for (let ti = 0; ti < draft.tabs.length; ti++) {
-          const idx = draft.tabs[ti].sections.findIndex(
-            (s: BuilderSection) => s.id === sectionData.sectionId,
-          );
-          if (idx >= 0) {
-            sourceTabIndex = ti;
-            sourceIdx = idx;
-            break;
-          }
+        const source = resolveSectionScope(draft, sectionData.sectionId);
+        const target = resolveSectionScope(draft, overSectionData.sectionId);
+        if (!source || !target) return draft;
+        if (source.zone !== target.zone && source.zone !== 'main') {
+          // Rail → main / rail → rail is disallowed; bail to avoid loss.
+          return draft;
         }
-        if (sourceTabIndex < 0 || sourceIdx < 0) return draft;
-
-        const [moved] = draft.tabs[sourceTabIndex].sections.splice(sourceIdx, 1);
-
-        for (let ti = 0; ti < draft.tabs.length; ti++) {
-          const toIdx = draft.tabs[ti].sections.findIndex(
-            (s: BuilderSection) => s.id === overSectionData.sectionId,
-          );
-          if (toIdx >= 0) {
-            draft.tabs[ti].sections.splice(toIdx, 0, moved);
-            break;
-          }
+        if (source.zone === 'main' && target.zone !== 'main') {
+          return draft;
         }
+        const [moved] = source.sections.splice(source.index, 1);
+        // Recompute target index — the source splice may have shifted it
+        // when source and target live in the same array.
+        const targetIdx = target.sections.findIndex(
+          (s: BuilderSection) => s.id === overSectionData.sectionId,
+        );
+        if (targetIdx < 0) {
+          // Target disappeared (shouldn't happen): put the section back.
+          source.sections.splice(source.index, 0, moved);
+          return draft;
+        }
+        target.sections.splice(targetIdx, 0, moved);
         return draft;
       });
     }


### PR DESCRIPTION
Closes #521.

## Summary

Teaches the page builder canvas to edit the zoned shell directly. Runtime rendering (#516), the zone-aware component schema (#517, #518), and the basic palette/properties-panel plumbing (#529) already landed; this PR is the critical-path change that lets admins compose a record page (header → KPI → rails → main) entirely in the builder.

- `BuilderLayout` gains `zones: { kpi, leftRail, rightRail }` matching the server model. Older drafts are back-filled by `normalizeBuilderZones` on load so existing layouts open without errors.
- `BuilderCanvas` renders the same shell as the runtime renderer (`header · KPI · [leftRail | main | rightRail]`) with per-zone drop targets. Empty zones show "Drop a metric here" / "Drop a panel here". Clicking a zone sets it active and the palette re-filters accordingly.
- `ComponentPalette` takes an `activeZone` prop and filters registry entries (plus the fields / related / related-lists groups) to those valid in that zone. The hint at the top labels the active zone so the UX is legible.
- `usePageLayoutDnd` handles palette → zone drops (KPI / rails) and enforces the registry's `allowedZones` whitelist client-side, mirroring the server's `isComponentAllowedInZone`. Rejected drops fire `onRejectZoneDrop`. Palette → existing-section drops resolve the target zone from the parent so rail sections share the same whitelist.
- `usePageLayout` adds zone-aware mutators (`handleAddKpiComponent`, `handleAddRailSection`, etc.) and extends the shared section / component handlers to resolve items across tabs, rails, and KPI — so the properties panel, visibility rules, and removal all keep working regardless of where an item lives.

## Test plan

- [x] New: `usePageLayoutDnd` zone-drop unit tests (metric → KPI, panel → leftRail, metric → leftRail rejected, metric → main new-section rejected, activity → rightRail).
- [x] New: `ComponentPalette` asserts `activeZone="kpi"` shows KPI-only widgets, hides main-only ones, and surfaces the active-zone label.
- [x] New: `PageBuilderPage` asserts the zoned shell renders (kpi / leftRail / rightRail / main), empty-zone affordances appear on a fresh layout, and clicking a zone updates the palette hint.
- [x] `npx vitest run` — **736 tests across 56 files pass**.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on changed files (no new warnings).

## Out of scope

- Cross-zone moves of existing components (not required by #521, left for a follow-up).
- AI-assisted editing (#522).

https://claude.ai/code/session_01UG5tp8dKtjRx7FGhAuRu3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG5tp8dKtjRx7FGhAuRu3Z)_