### PR TITLE
feat(page-builder): AI prompt entry point stub (#522)

### DIFF
--- a/apps/web/src/__tests__/AiPromptModal.test.tsx
+++ b/apps/web/src/__tests__/AiPromptModal.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AiPromptModal } from '../components/AiPromptModal.js';
+
+describe('AiPromptModal', () => {
+  it('renders dialog with autofocused textarea', () => {
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={vi.fn()} />);
+
+    const dialog = screen.getByTestId('ai-prompt-modal');
+    expect(dialog).toHaveAttribute('role', 'dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    const textarea = screen.getByTestId('ai-prompt-textarea');
+    expect(textarea).toHaveFocus();
+  });
+
+  it('disables submit until prompt is non-empty', async () => {
+    const user = userEvent.setup();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={vi.fn()} />);
+
+    const submit = screen.getByTestId('ai-prompt-submit');
+    expect(submit).toBeDisabled();
+
+    await user.type(screen.getByTestId('ai-prompt-textarea'), 'Move Notes');
+    expect(submit).not.toBeDisabled();
+  });
+
+  it('calls onSubmit with the trimmed prompt', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AiPromptModal onSubmit={onSubmit} onClose={vi.fn()} />);
+
+    await user.type(
+      screen.getByTestId('ai-prompt-textarea'),
+      '  Replace my opportunities  ',
+    );
+    await user.click(screen.getByTestId('ai-prompt-submit'));
+
+    expect(onSubmit).toHaveBeenCalledWith('Replace my opportunities');
+  });
+
+  it('clicking an example pill fills the textarea', async () => {
+    const user = userEvent.setup();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={vi.fn()} />);
+
+    await user.click(
+      screen.getByTestId('ai-prompt-example-move-notes-under-opportunities'),
+    );
+
+    expect(screen.getByTestId('ai-prompt-textarea')).toHaveValue(
+      'Move Notes under Opportunities',
+    );
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={onClose} />);
+
+    await user.click(screen.getByTestId('ai-prompt-cancel'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={onClose} />);
+
+    await user.click(screen.getByTestId('ai-prompt-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={onClose} />);
+
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not submit when prompt is whitespace only', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<AiPromptModal onSubmit={onSubmit} onClose={vi.fn()} />);
+
+    await user.type(screen.getByTestId('ai-prompt-textarea'), '   ');
+    expect(screen.getByTestId('ai-prompt-submit')).toBeDisabled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/AiPromptModal.test.tsx
+++ b/apps/web/src/__tests__/AiPromptModal.test.tsx
@@ -80,6 +80,22 @@ describe('AiPromptModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('focus trap wraps from the last enabled control even when submit is disabled', async () => {
+    const user = userEvent.setup();
+    render(<AiPromptModal onSubmit={vi.fn()} onClose={vi.fn()} />);
+
+    // Submit is disabled with empty prompt — make sure Tab from the last
+    // *enabled* control (Cancel) wraps back to the close button rather than
+    // landing on the disabled submit and letting focus escape.
+    expect(screen.getByTestId('ai-prompt-submit')).toBeDisabled();
+
+    screen.getByTestId('ai-prompt-cancel').focus();
+    expect(screen.getByTestId('ai-prompt-cancel')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByTestId('ai-prompt-close')).toHaveFocus();
+  });
+
   it('does not submit when prompt is whitespace only', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/apps/web/src/__tests__/PageBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/PageBuilderPage.test.tsx
@@ -859,8 +859,10 @@ describe('PageBuilderPage', () => {
       );
       await user.click(screen.getByTestId('ai-prompt-submit'));
 
+      // logger.info routes through console.info with a "[cpcrm] " prefix in
+      // dev/test; in production it no-ops, so tenant data doesn't leak.
       expect(infoSpy).toHaveBeenCalledWith(
-        '[AI prompt stub]',
+        '[cpcrm] AI prompt stub',
         expect.objectContaining({ prompt: 'Replace opportunities with calls' }),
       );
       expect(screen.queryByTestId('ai-prompt-modal')).not.toBeInTheDocument();

--- a/apps/web/src/__tests__/PageBuilderPage.test.tsx
+++ b/apps/web/src/__tests__/PageBuilderPage.test.tsx
@@ -804,6 +804,93 @@ describe('PageBuilderPage', () => {
     });
   });
 
+  describe('AI prompt stub (#522)', () => {
+    it('renders the Ask button in the toolbar', async () => {
+      mockAllFetches();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ask-button')).toBeInTheDocument();
+      });
+    });
+
+    it('opens the AI prompt modal when Ask is clicked', async () => {
+      const user = userEvent.setup();
+      mockAllFetches();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ask-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('ask-button'));
+
+      expect(screen.getByTestId('ai-prompt-modal')).toBeInTheDocument();
+    });
+
+    it('opens the AI prompt modal via Cmd/Ctrl+K', async () => {
+      const user = userEvent.setup();
+      mockAllFetches();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('page-builder')).toBeInTheDocument();
+      });
+
+      await user.keyboard('{Control>}k{/Control}');
+
+      expect(screen.getByTestId('ai-prompt-modal')).toBeInTheDocument();
+    });
+
+    it('logs the prompt and shows a coming-soon toast on submit, then closes the modal', async () => {
+      const user = userEvent.setup();
+      mockAllFetches();
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ask-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('ask-button'));
+      await user.type(
+        screen.getByTestId('ai-prompt-textarea'),
+        'Replace opportunities with calls',
+      );
+      await user.click(screen.getByTestId('ai-prompt-submit'));
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[AI prompt stub]',
+        expect.objectContaining({ prompt: 'Replace opportunities with calls' }),
+      );
+      expect(screen.queryByTestId('ai-prompt-modal')).not.toBeInTheDocument();
+      expect(screen.getByTestId('ai-toast')).toHaveTextContent(
+        'AI editing is coming soon. Your request has been logged.',
+      );
+
+      infoSpy.mockRestore();
+    });
+
+    it('does not call the network when the AI prompt is submitted', async () => {
+      const user = userEvent.setup();
+      const mockFetch = mockAllFetches();
+      vi.spyOn(console, 'info').mockImplementation(() => {});
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ask-button')).toBeInTheDocument();
+      });
+
+      const callsBefore = mockFetch.mock.calls.length;
+
+      await user.click(screen.getByTestId('ask-button'));
+      await user.type(screen.getByTestId('ai-prompt-textarea'), 'do a thing');
+      await user.click(screen.getByTestId('ai-prompt-submit'));
+
+      expect(mockFetch.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
   it('handles no page layouts by creating a default', async () => {
     const mockFetch = vi.fn();
 

--- a/apps/web/src/components/AiPromptModal.module.css
+++ b/apps/web/src/components/AiPromptModal.module.css
@@ -1,0 +1,138 @@
+/* ============================================================
+   AiPromptModal — Natural-language page editing prompt (stub)
+   ============================================================ */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.modal {
+  width: 100%;
+  max-width: 560px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.titleSparkle {
+  font-size: var(--font-size-base);
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  font-size: var(--font-size-xl);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-md);
+  line-height: 1;
+  transition: color var(--transition-base);
+}
+
+.closeBtn:hover {
+  color: var(--text-primary);
+}
+
+.body {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.textarea {
+  width: 100%;
+  min-height: 96px;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-page);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  resize: vertical;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.examples {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.examplesLabel {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pillRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.pill {
+  background: var(--bg-page);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+  padding: 4px 10px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.pill:hover {
+  background: var(--accent-bg, var(--bg-surface));
+  color: var(--accent-text, var(--text-primary));
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border-default);
+}

--- a/apps/web/src/components/AiPromptModal.tsx
+++ b/apps/web/src/components/AiPromptModal.tsx
@@ -27,9 +27,14 @@ export function AiPromptModal({ onSubmit, onClose }: AiPromptModalProps) {
       }
 
       if (e.key === 'Tab' && modalRef.current) {
-        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
-          'input, select, textarea, button, [tabindex]:not([tabindex="-1"])',
-        );
+        // Exclude disabled controls so the trap's first/last anchors stay on
+        // elements that can actually receive focus — otherwise Tab from the
+        // last enabled control wouldn't wrap and focus could escape.
+        const focusable = Array.from(
+          modalRef.current.querySelectorAll<HTMLElement>(
+            'input, select, textarea, button, [tabindex]:not([tabindex="-1"])',
+          ),
+        ).filter((el) => !el.hasAttribute('disabled'));
         if (focusable.length === 0) return;
 
         const first = focusable[0];

--- a/apps/web/src/components/AiPromptModal.tsx
+++ b/apps/web/src/components/AiPromptModal.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PrimaryButton } from './PrimaryButton.js';
+import styles from './AiPromptModal.module.css';
+
+const EXAMPLE_PROMPTS = [
+  'Move Notes under Opportunities',
+  'Add a KPI for days since last call',
+  'Replace my opportunities section with recent calls',
+];
+
+interface AiPromptModalProps {
+  onSubmit: (prompt: string) => void;
+  onClose: () => void;
+}
+
+export function AiPromptModal({ onSubmit, onClose }: AiPromptModalProps) {
+  const [prompt, setPrompt] = useState('');
+  const modalRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+          'input, select, textarea, button, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ai-prompt-modal-title"
+      data-testid="ai-prompt-modal"
+    >
+      <div className={styles.modal} ref={modalRef} tabIndex={-1}>
+        <div className={styles.header}>
+          <h2 id="ai-prompt-modal-title" className={styles.title}>
+            <span className={styles.titleSparkle} aria-hidden="true">✨</span>
+            Ask AI to edit this page
+          </h2>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Close AI prompt"
+            data-testid="ai-prompt-close"
+          >
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.body}>
+            <label className={styles.label} htmlFor="ai-prompt-textarea">
+              Describe the change you want
+            </label>
+            <textarea
+              id="ai-prompt-textarea"
+              ref={textareaRef}
+              className={styles.textarea}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Replace my opportunities section with recent calls"
+              data-testid="ai-prompt-textarea"
+            />
+
+            <div className={styles.examples}>
+              <span className={styles.examplesLabel}>Try one of these</span>
+              <div className={styles.pillRow}>
+                {EXAMPLE_PROMPTS.map((example) => (
+                  <button
+                    key={example}
+                    type="button"
+                    className={styles.pill}
+                    onClick={() => setPrompt(example)}
+                    data-testid={`ai-prompt-example-${example
+                      .toLowerCase()
+                      .replace(/[^a-z0-9]+/g, '-')
+                      .replace(/^-|-$/g, '')}`}
+                  >
+                    {example}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.footer}>
+            <PrimaryButton
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              type="button"
+              data-testid="ai-prompt-cancel"
+            >
+              Cancel
+            </PrimaryButton>
+            <PrimaryButton
+              size="sm"
+              type="submit"
+              disabled={prompt.trim().length === 0}
+              data-testid="ai-prompt-submit"
+            >
+              Ask AI
+            </PrimaryButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/BuilderToolbar.tsx
+++ b/apps/web/src/components/BuilderToolbar.tsx
@@ -17,6 +17,8 @@ interface BuilderToolbarProps {
   onSaveDraft: () => void;
   onPublish: () => void;
   onPreview: () => void;
+  /** Open the AI prompt modal. Stub for natural-language editing (#522). */
+  onAsk?: () => void;
   /** Role-based layout support */
   allLayouts?: RoleLayout[];
   selectedLayoutId?: string | null;
@@ -36,6 +38,7 @@ export function BuilderToolbar({
   onSaveDraft,
   onPublish,
   onPreview,
+  onAsk,
   allLayouts,
   selectedLayoutId,
   onRoleChange,
@@ -131,6 +134,17 @@ export function BuilderToolbar({
             data-testid="reset-to-default-button"
           >
             Reset to default
+          </PrimaryButton>
+        )}
+        {onAsk && (
+          <PrimaryButton
+            variant="ghost"
+            size="sm"
+            onClick={onAsk}
+            data-testid="ask-button"
+            aria-keyshortcuts="Control+K Meta+K"
+          >
+            <span aria-hidden="true">✨</span> Ask
           </PrimaryButton>
         )}
         <PrimaryButton

--- a/apps/web/src/features/page-builder/PageBuilderPage.module.css
+++ b/apps/web/src/features/page-builder/PageBuilderPage.module.css
@@ -128,3 +128,20 @@
 .saveErrorDismiss:hover {
   opacity: 0.7;
 }
+
+/* ── AI prompt toast (#522 stub) ─────────────────────────── */
+
+.aiToast {
+  position: fixed;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-sm);
+  z-index: 1100;
+}

--- a/apps/web/src/features/page-builder/PageBuilderPage.tsx
+++ b/apps/web/src/features/page-builder/PageBuilderPage.tsx
@@ -5,6 +5,7 @@ import type { RoleLayout } from '../../components/BuilderToolbar.js';
 import { VersionHistoryPanel } from '../../components/VersionHistoryPanel.js';
 import { CopyLayoutModal } from '../../components/CopyLayoutModal.js';
 import { AiPromptModal } from '../../components/AiPromptModal.js';
+import { logger } from '../../lib/logger.js';
 import { usePageLayout } from './hooks/usePageLayout.js';
 import { usePageLayoutDnd } from './hooks/usePageLayoutDnd.js';
 import { usePageLayoutActions } from './hooks/usePageLayoutActions.js';
@@ -67,8 +68,10 @@ export function PageBuilderPage() {
     (prompt: string) => {
       // Real backend lands after the contract spike (#523). For now: log the
       // prompt + current layout JSON so we can sanity-check the affordance,
-      // then close the modal and show a coming-soon toast.
-      console.info('[AI prompt stub]', {
+      // then close the modal and show a coming-soon toast. logger.info no-ops
+      // in production so tenant layout data doesn't leak to the browser
+      // console there.
+      logger.info('AI prompt stub', {
         prompt,
         layout: pl.layout,
       });
@@ -78,7 +81,7 @@ export function PageBuilderPage() {
     [pl.layout],
   );
 
-  // ── Loading / error states ──────────���──────────────────────
+  // ── Loading / error states ────────────────────────────────
 
   if (pl.loading) {
     return <div className={styles.page} data-testid="page-builder-loading">Loading&hellip;</div>;

--- a/apps/web/src/features/page-builder/PageBuilderPage.tsx
+++ b/apps/web/src/features/page-builder/PageBuilderPage.tsx
@@ -1,14 +1,18 @@
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { BuilderToolbar } from '../../components/BuilderToolbar.js';
 import type { RoleLayout } from '../../components/BuilderToolbar.js';
 import { VersionHistoryPanel } from '../../components/VersionHistoryPanel.js';
 import { CopyLayoutModal } from '../../components/CopyLayoutModal.js';
+import { AiPromptModal } from '../../components/AiPromptModal.js';
 import { usePageLayout } from './hooks/usePageLayout.js';
 import { usePageLayoutDnd } from './hooks/usePageLayoutDnd.js';
 import { usePageLayoutActions } from './hooks/usePageLayoutActions.js';
 import { LayoutCanvas } from './components/LayoutCanvas.js';
 import { PreviewPane } from './components/PreviewPane.js';
 import styles from './PageBuilderPage.module.css';
+
+const AI_TOAST_TIMEOUT_MS = 4000;
 
 export function PageBuilderPage() {
   const { objectId } = useParams<{ objectId: string }>();
@@ -33,6 +37,46 @@ export function PageBuilderPage() {
     setAllLayouts: pl.setAllLayouts,
     loadLayoutDetail: pl.loadLayoutDetail,
   });
+
+  // ── AI prompt stub (#522) ──────────────────────────────────
+  // The real LLM contract is being designed in #523; this is purely a UX
+  // freeze so everything around the affordance can be built.
+  const [showAiPrompt, setShowAiPrompt] = useState(false);
+  const [aiToast, setAiToast] = useState<string | null>(null);
+
+  const openAiPrompt = useCallback(() => setShowAiPrompt(true), []);
+
+  useEffect(() => {
+    if (!aiToast) return;
+    const timer = window.setTimeout(() => setAiToast(null), AI_TOAST_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [aiToast]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setShowAiPrompt(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const handleAskSubmit = useCallback(
+    (prompt: string) => {
+      // Real backend lands after the contract spike (#523). For now: log the
+      // prompt + current layout JSON so we can sanity-check the affordance,
+      // then close the modal and show a coming-soon toast.
+      console.info('[AI prompt stub]', {
+        prompt,
+        layout: pl.layout,
+      });
+      setShowAiPrompt(false);
+      setAiToast('AI editing is coming soon. Your request has been logged.');
+    },
+    [pl.layout],
+  );
 
   // ── Loading / error states ──────────���──────────────────────
 
@@ -81,6 +125,7 @@ export function PageBuilderPage() {
         onSaveDraft={() => void actions.handleSaveDraft()}
         onPublish={() => void actions.handlePublish()}
         onPreview={() => actions.setShowPreview(true)}
+        onAsk={openAiPrompt}
         allLayouts={allLayoutsForToolbar}
         selectedLayoutId={pl.selectedLayoutId}
         onRoleChange={(layoutId, role) => void actions.handleRoleChange(layoutId, role)}
@@ -152,6 +197,24 @@ export function PageBuilderPage() {
           onRevert={(version) => void actions.handleRevert(version)}
           onClose={() => actions.setShowHistory(false)}
         />
+      )}
+
+      {showAiPrompt && (
+        <AiPromptModal
+          onSubmit={handleAskSubmit}
+          onClose={() => setShowAiPrompt(false)}
+        />
+      )}
+
+      {aiToast && (
+        <div
+          className={styles.aiToast}
+          role="status"
+          aria-live="polite"
+          data-testid="ai-toast"
+        >
+          {aiToast}
+        </div>
       )}
 
       {actions.showCopyModal && (


### PR DESCRIPTION
Closes #522.

Wires up the UX affordance for natural-language page editing so everything around it can be built. The actual LLM call lands after the contract spike in #523 — this PR is purely a UX freeze.

## Summary

- Added an **Ask** button (sparkle icon) to `BuilderToolbar`, between `History`/`Copy from…` and `Preview`. Hidden when `onAsk` isn't wired so existing callers stay opt-in.
- New `AiPromptModal` component:
  - Autofocused multi-line textarea
  - Example prompt pills (clicking fills the textarea)
  - Submit + Cancel buttons
  - Focus trap, `Escape` to close, `role="dialog"` + `aria-modal` + labelled controls
- `PageBuilderPage`:
  - Stub handler `console.info`s the prompt + current layout JSON, closes the modal, and shows a transient toast: *"AI editing is coming soon. Your request has been logged."*
  - **No network call** is made.
  - `Cmd/Ctrl+K` opens the modal whenever the builder page is mounted.

## Tasks

- [x] Add `onAsk` prop to `BuilderToolbar` and render the button.
- [x] New component `AiPromptModal.tsx` + CSS module.
- [x] Wire in `PageBuilderPage.tsx` with a stub handler.
- [x] Cmd/Ctrl+K shortcut via a one-off listener scoped to the builder page.
- [x] Tests: clicking Ask opens the modal; submitting logs and closes; Cmd+K opens.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` clean (no new warnings/errors)
- [x] Full vitest suite green (`753 passed`)
- [x] New `AiPromptModal.test.tsx` covers focus, disabled-until-input, submit-trims, example pill, Cancel, close (×), Escape
- [x] New tests in `PageBuilderPage.test.tsx` cover Ask button render, Ask click → modal, `Cmd+K` → modal, submit logs + toast + closes, submit makes no network calls

## Out of scope

- Calling an LLM (#523 designs the contract first)
- Applying a returned patch to the layout (later, once contract is signed off)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYAFSi7ZtaLtruMJA1Dpj3)_