### PR TITLE
test(web): deflake RecordListPage column-header lookup test

### DIFF
--- a/apps/web/src/__tests__/RecordListPage.test.tsx
+++ b/apps/web/src/__tests__/RecordListPage.test.tsx
@@ -452,13 +452,17 @@ describe('RecordListPage', () => {
       expect(link).toHaveAttribute('href', '/objects/account/rec-1');
     });
 
-    // The column header should show "Account Name", not a separate "Name"
-    const columnHeaders = screen.getAllByRole('columnheader');
-    const headerTexts = columnHeaders.map((th) => th.textContent);
-    expect(headerTexts).toContain('Account Name');
-    expect(headerTexts).toContain('Industry');
-    // There should be no standalone "Name" column header
-    expect(headerTexts).not.toContain('Name');
+    // The column header should show "Account Name", not a separate "Name".
+    // Wrapped in waitFor because the default "Name" column briefly appears
+    // before the layout-driven columns swap in, racing the link assertion above.
+    await waitFor(() => {
+      const headerTexts = screen
+        .getAllByRole('columnheader')
+        .map((th) => th.textContent);
+      expect(headerTexts).toContain('Account Name');
+      expect(headerTexts).toContain('Industry');
+      expect(headerTexts).not.toContain('Name');
+    });
   });
 
   it('renders an Owner column with the owner name', async () => {


### PR DESCRIPTION
## Summary

Fixes a flaky test in `apps/web/src/__tests__/RecordListPage.test.tsx`
that surfaced on PR #590's CI run with:

```
AssertionError: expected [ 'Name', 'Account Name', …(2) ] to not include 'Name'
  ❯ src/__tests__/RecordListPage.test.tsx:461
```

The lookup-field column-header test `await`s the "Acme Corp" link to
appear, then synchronously reads `getAllByRole('columnheader')`. In CI
the default "Name" column from the table's first render briefly appears
while the layout-driven columns (`Account Name`, `Industry`) load, so
the synchronous read sometimes catches the in-between state and the
`not.toContain('Name')` assertion fails.

Wrap the column-header assertions in `waitFor` so they retry until the
table settles on the layout-driven columns. No production code changes.

Locally: 5/5 consecutive runs pass after the fix (and the test passed
locally before the fix too — the race only surfaces under CI load).

## Test plan

- [ ] Confirm CI on this PR passes the lint/typecheck/test job.
- [ ] Re-run CI on PR #590 once this lands; the doc-only PR should go
      green without further changes.

https://claude.ai/code/session_01M9xMiKTtQVtcuWAve6Gt67

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9xMiKTtQVtcuWAve6Gt67)_