### PR TITLE
feat(records): add dropdown filters to /objects/:apiName list page

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -104,6 +104,33 @@
         "required": [
           "error"
         ]
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "hasMore"
+        ]
       }
     },
     "parameters": {}
@@ -774,18 +801,24 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Maximum number of items to return (default 50, max 200).",
+              "example": "50"
             },
             "required": false,
-            "name": "page",
+            "description": "Maximum number of items to return (default 50, max 200).",
+            "name": "limit",
             "in": "query"
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Number of items to skip before returning results (default 0).",
+              "example": "0"
             },
             "required": false,
-            "name": "limit",
+            "description": "Number of items to skip before returning results (default 0).",
+            "name": "offset",
             "in": "query"
           }
         ],
@@ -886,22 +919,24 @@
                         ]
                       }
                     },
-                    "total": {
-                      "type": "number"
-                    },
-                    "page": {
-                      "type": "number"
-                    },
-                    "limit": {
-                      "type": "number"
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
                     }
                   },
                   "required": [
                     "data",
-                    "total",
-                    "page",
-                    "limit"
+                    "pagination"
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             }
@@ -5885,22 +5920,6 @@
               "type": "string"
             },
             "required": false,
-            "name": "page",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": false,
             "name": "sort_by",
             "in": "query"
           },
@@ -5914,6 +5933,28 @@
             },
             "required": false,
             "name": "sort_dir",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Maximum number of items to return (default 50, max 200).",
+              "example": "50"
+            },
+            "required": false,
+            "description": "Maximum number of items to return (default 50, max 200).",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Number of items to skip before returning results (default 0).",
+              "example": "0"
+            },
+            "required": false,
+            "description": "Number of items to skip before returning results (default 0).",
+            "name": "offset",
             "in": "query"
           }
         ],
@@ -5975,14 +6016,8 @@
                         ]
                       }
                     },
-                    "total": {
-                      "type": "number"
-                    },
-                    "page": {
-                      "type": "number"
-                    },
-                    "limit": {
-                      "type": "number"
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
                     },
                     "object": {
                       "type": "object",
@@ -6013,11 +6048,19 @@
                   },
                   "required": [
                     "data",
-                    "total",
-                    "page",
-                    "limit",
+                    "pagination",
                     "object"
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             }
@@ -7615,17 +7658,23 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Maximum number of items to return (default 50, max 200).",
+              "example": "50"
             },
             "required": false,
+            "description": "Maximum number of items to return (default 50, max 200).",
             "name": "limit",
             "in": "query"
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Number of items to skip before returning results (default 0).",
+              "example": "0"
             },
             "required": false,
+            "description": "Number of items to skip before returning results (default 0).",
             "name": "offset",
             "in": "query"
           }
@@ -7638,7 +7687,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenants": {
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -7675,22 +7724,24 @@
                         ]
                       }
                     },
-                    "total": {
-                      "type": "number"
-                    },
-                    "limit": {
-                      "type": "number"
-                    },
-                    "offset": {
-                      "type": "number"
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
                     }
                   },
                   "required": [
-                    "tenants",
-                    "total",
-                    "limit",
-                    "offset"
+                    "data",
+                    "pagination"
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             }
@@ -8559,18 +8610,24 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Maximum number of items to return (default 50, max 200).",
+              "example": "50"
             },
             "required": false,
-            "name": "page",
+            "description": "Maximum number of items to return (default 50, max 200).",
+            "name": "limit",
             "in": "query"
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "description": "Number of items to skip before returning results (default 0).",
+              "example": "0"
             },
             "required": false,
-            "name": "limit",
+            "description": "Number of items to skip before returning results (default 0).",
+            "name": "offset",
             "in": "query"
           }
         ],
@@ -8608,22 +8665,24 @@
                         }
                       }
                     },
-                    "total": {
-                      "type": "number"
-                    },
-                    "page": {
-                      "type": "number"
-                    },
-                    "limit": {
-                      "type": "number"
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
                     }
                   },
                   "required": [
                     "data",
-                    "total",
-                    "page",
-                    "limit"
+                    "pagination"
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
                 }
               }
             }

--- a/apps/api/src/routes/__tests__/records.test.ts
+++ b/apps/api/src/routes/__tests__/records.test.ts
@@ -384,6 +384,7 @@ describe('GET /objects/:apiName/records', () => {
       offset: 0,
       sortBy: undefined,
       sortDir: undefined,
+      filters: {},
     });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
@@ -415,7 +416,30 @@ describe('GET /objects/:apiName/records', () => {
       offset: 20,
       sortBy: 'name',
       sortDir: 'asc',
+      filters: {},
     });
+  });
+
+  it('forwards dropdown field filters from filter[<field>] query params', async () => {
+    mockListRecords.mockResolvedValue({ data: [], total: 0, limit: 50, offset: 0, object: {} });
+
+    // Express's `qs` parser turns `filter[type]=Customer&filter[status]=Active`
+    // into `req.query.filter = { type: 'Customer', status: 'Active' }`.
+    const req = mockReq(
+      {},
+      undefined,
+      { apiName: 'account' },
+      { filter: { type: 'Customer', status: 'Active' } as unknown as string },
+    );
+    const res = mockRes();
+
+    await handleListRecords(req, res);
+
+    expect(mockListRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: { type: 'Customer', status: 'Active' },
+      }),
+    );
   });
 
   it('rejects limit greater than the max with HTTP 400', async () => {

--- a/apps/api/src/routes/records.ts
+++ b/apps/api/src/routes/records.ts
@@ -132,6 +132,7 @@ export async function handleCreateRecord(
  *   offset?: number   — number of results to skip (default 0)
  *   sort_by?: string  — field api_name or "name"/"created_at"/"updated_at"
  *   sort_dir?: string — "asc" or "desc"
+ *   filter[<field>]?: string — exact match on a dropdown field's value
  *
  * Responses:
  *   200  – { data, pagination: { total, limit, offset, hasMore }, object }
@@ -154,6 +155,7 @@ export async function handleListRecords(
     offset?: string;
     sort_by?: string;
     sort_dir?: string;
+    filter?: Record<string, unknown>;
   };
 
   let pagination;
@@ -169,6 +171,15 @@ export async function handleListRecords(
     throw err;
   }
 
+  // Express parses `filter[type]=Customer` into `{ filter: { type: 'Customer' } }`.
+  // Coerce to a flat string→string map and drop anything that isn't a string.
+  const filters: Record<string, string> = {};
+  if (query.filter && typeof query.filter === 'object' && !Array.isArray(query.filter)) {
+    for (const [k, v] of Object.entries(query.filter)) {
+      if (typeof v === 'string' && v.length > 0) filters[k] = v;
+    }
+  }
+
   try {
     const result = await listRecords({
       tenantId: req.user!.tenantId!,
@@ -179,6 +190,7 @@ export async function handleListRecords(
       offset: pagination.offset,
       sortBy: query.sort_by,
       sortDir: query.sort_dir,
+      filters,
     });
 
     const envelope = paginatedResponse(result.data, result.total, pagination);

--- a/apps/api/src/services/recordService.ts
+++ b/apps/api/src/services/recordService.ts
@@ -695,13 +695,28 @@ export async function listRecords(params: {
   offset: number;
   sortBy?: string;
   sortDir?: string;
+  filters?: Record<string, string>;
 }): Promise<ListRecordsResult> {
-  const { tenantId, apiName, ownerId, search, limit, offset, sortBy, sortDir } = params;
+  const { tenantId, apiName, ownerId, search, limit, offset, sortBy, sortDir, filters } = params;
   // ownerId is currently used via filters at the route/service level (reserved for future scoping)
   void ownerId;
 
   const objectDef = await resolveObjectByApiName(tenantId, apiName);
   const fieldDefs = await getFieldDefinitions(tenantId, objectDef.id);
+
+  // Resolve dropdown filters → only fields that exist and are dropdowns are
+  // applied. We bind values as parameters; identifiers are validated to
+  // contain only the safe charset before being interpolated.
+  const dropdownFilters: Array<{ apiName: string; value: string }> = [];
+  if (filters) {
+    for (const [key, value] of Object.entries(filters)) {
+      if (typeof value !== 'string' || value.length === 0) continue;
+      const fieldDef = fieldDefs.find((fd) => fd.apiName === key);
+      if (!fieldDef || fieldDef.fieldType !== 'dropdown') continue;
+      if (!isSafeIdentifier(fieldDef.apiName)) continue;
+      dropdownFilters.push({ apiName: fieldDef.apiName, value });
+    }
+  }
 
   const trimmedSearch = search?.trim();
   const hasSearch = trimmedSearch !== undefined && trimmedSearch.length > 0;
@@ -739,6 +754,14 @@ export async function listRecords(params: {
     });
   }
 
+  for (const f of dropdownFilters) {
+    countQuery = countQuery.where(
+      sql<string>`r.field_values->>${f.apiName}`,
+      '=',
+      f.value,
+    );
+  }
+
   const countRow = await countQuery.executeTakeFirstOrThrow();
   const total = parseInt(countRow.total as unknown as string, 10);
 
@@ -759,6 +782,14 @@ export async function listRecords(params: {
       ];
       return eb.or(conds);
     });
+  }
+
+  for (const f of dropdownFilters) {
+    dataQuery = dataQuery.where(
+      sql<string>`r.field_values->>${f.apiName}`,
+      '=',
+      f.value,
+    );
   }
 
   // Sorting — defence-in-depth via isSafeIdentifier + parameter binding

--- a/apps/web/src/pages/RecordListPage.module.css
+++ b/apps/web/src/pages/RecordListPage.module.css
@@ -62,6 +62,52 @@
   border-color: var(--color-primary);
 }
 
+/* ── Filter dropdowns ─────────────────────────────────────── */
+
+.filterGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.filterSelect {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-subtle);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  cursor: pointer;
+  transition: border-color var(--transition-base);
+  max-width: 180px;
+}
+
+.filterSelect:focus {
+  border-color: var(--color-primary);
+}
+
+.filterSelectActive {
+  border-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.filterClear {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-base);
+}
+
+.filterClear:hover {
+  color: var(--color-text-primary);
+}
+
 /* ── Error alert ──────────────────────────────────────────── */
 
 .errorAlert {

--- a/apps/web/src/pages/RecordListPage.tsx
+++ b/apps/web/src/pages/RecordListPage.tsx
@@ -92,6 +92,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [sortBy, setSortBy] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [filters, setFilters] = useState<Record<string, string>>({});
 
   // Pipeline view toggle state
   const [viewMode, setViewMode] = useState<'list' | 'pipeline'>(initialView ?? 'list');
@@ -120,6 +121,7 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
     setDebouncedSearch('');
     setSortBy(null);
     setSortDir('asc');
+    setFilters({});
     userToggledView.current = false;
     // Always sync viewMode to the current pinned route — otherwise a
     // user who toggled to List before navigating between two pipeline
@@ -180,8 +182,13 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
       params.sort_by = sortBy;
       params.sort_dir = sortDir;
     }
+    // Field filters → encoded as `filter[<field>]=<value>` so Express's
+    // default `qs` parser deserialises them back into a nested object.
+    for (const [field, value] of Object.entries(filters)) {
+      if (value) params[`filter[${field}]`] = value;
+    }
     return params;
-  }, [page, debouncedSearch, sortBy, sortDir]);
+  }, [page, debouncedSearch, sortBy, sortDir, filters]);
 
   const recordsQuery = useRecords(apiName, recordsParams);
 
@@ -253,6 +260,22 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
   // Show an "Account" column when any record has a linked parent account
   const showAccountColumn = records.some((r) => r.linkedParent != null);
 
+  // Dropdown fields from the list layout — each becomes a filter <select>
+  // in the toolbar. Hidden when the layout doesn't expose any dropdowns.
+  const filterFields: Array<{ apiName: string; label: string; choices: string[] }> =
+    (layoutColumns ?? [])
+      .filter((lf) => lf.fieldType === 'dropdown')
+      .map((lf) => {
+        const raw = (lf.fieldOptions?.choices ?? []) as unknown;
+        const choices = Array.isArray(raw)
+          ? raw.filter((c): c is string => typeof c === 'string')
+          : [];
+        return { apiName: lf.fieldApiName, label: lf.fieldLabel, choices };
+      })
+      .filter((f) => f.choices.length > 0);
+
+  const hasActiveFilters = Object.values(filters).some((v) => v);
+
   const pluralLabel = objectDef?.pluralLabel ?? apiName ?? 'Records';
   const singularLabel = objectDef?.label ?? apiName ?? 'Record';
 
@@ -273,6 +296,50 @@ export function RecordListPage({ initialView }: RecordListPageProps = {}) {
             <span className={styles.recordCount}>
               {total} {total === 1 ? singularLabel.toLowerCase() : pluralLabel.toLowerCase()}
             </span>
+          )}
+          {filterFields.length > 0 && (
+            <div className={styles.filterGroup} data-testid="record-filters">
+              {filterFields.map((f) => {
+                const value = filters[f.apiName] ?? '';
+                return (
+                  <select
+                    key={f.apiName}
+                    className={`${styles.filterSelect} ${value ? styles.filterSelectActive : ''}`}
+                    aria-label={`Filter by ${f.label}`}
+                    value={value}
+                    onChange={(e) => {
+                      const next = e.target.value;
+                      setFilters((prev) => {
+                        const updated = { ...prev };
+                        if (next) updated[f.apiName] = next;
+                        else delete updated[f.apiName];
+                        return updated;
+                      });
+                      setPage(1);
+                    }}
+                  >
+                    <option value="">All {f.label.toLowerCase()}</option>
+                    {f.choices.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                );
+              })}
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  className={styles.filterClear}
+                  onClick={() => {
+                    setFilters({});
+                    setPage(1);
+                  }}
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
           )}
         </div>
         <div className={styles.toolbarRight}>


### PR DESCRIPTION
## Summary

Adds dropdown filters to the toolbar of every record list page (`/objects/:apiName`). On Accounts, that surfaces filters for **Type**, **Industry**, and **Status** — exactly to the right of the "12 accounts" count, where the screenshot mock-up requested them. Selecting a value narrows the list and the count; "Clear filters" resets them all.

The implementation is generic, so the same UI lights up for any object whose list layout exposes dropdown fields (Opportunities, Leads, etc.) — no per-object code.

### Frontend
- `RecordListPage` derives filterable fields from the list layout (`fieldType === 'dropdown'`, choices pulled from `fieldOptions.choices`) and renders a `<select>` per field with an "All ..." default option plus a "Clear filters" button.
- Filter state is reset when navigating between objects, and resets the page index back to 1 on change.
- Filters are sent to the API as `filter[<field>]=<value>` query params and folded into the React Query key so cached results don't bleed across filter combinations.

### Backend
- `listRecords` now accepts a `filters` map and applies one parameterised JSONB equality predicate per dropdown field. Anything that isn't a known dropdown is silently ignored (defence-in-depth: identifier regex check before SQL interpolation, value bound as a parameter).
- The `GET /objects/:apiName/records` route parses `filter[<field>]=<value>` (Express's default `qs` parser deserialises this into a nested object).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` (api) — 1572 passed, 1 skipped
- [x] `npm test` (web) — 754 passed
- [x] `npm run build` — passes, OpenAPI regenerated
- [ ] Manual: open `/objects/account`, confirm Type / Industry / Status filters appear and narrow the list correctly, and Clear filters resets them
- [ ] Manual: confirm the same filters appear on other objects with dropdown fields (e.g. Opportunities)

https://claude.ai/code/session_01EGgZXrLrMJz95LtvMZNNBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGgZXrLrMJz95LtvMZNNBu)_