### PR TITLE
Add AI page-editor edit contract and reducer

### DIFF
--- a/apps/api/src/services/__tests__/pipelineAnalyticsService.test.ts
+++ b/apps/api/src/services/__tests__/pipelineAnalyticsService.test.ts
@@ -425,22 +425,32 @@ describe('getPipelineSummary', () => {
   });
 
   it('counts wonThisMonth and lostThisMonth from stage history', async () => {
-    seedPipeline();
-    seedStages();
+    // Pin "now" to mid-month so seedHistory's small daysAgo offsets land
+    // inside the same calendar month as Date.now(). Without this, runs on
+    // the 1st or 2nd of any month bleed into the previous month and
+    // wonThisMonth comes back as 0.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+    try {
+      seedPipeline();
+      seedStages();
 
-    // Record that was moved to won this month
-    seedRecord('rec-won', 'stage-won', 50000, 2);
-    seedHistory('h-won', 'rec-won', 'stage-prospecting', 'stage-won', 1, 5);
+      // Record that was moved to won this month
+      seedRecord('rec-won', 'stage-won', 50000, 2);
+      seedHistory('h-won', 'rec-won', 'stage-prospecting', 'stage-won', 1, 5);
 
-    // Record that was moved to lost this month
-    seedRecord('rec-lost', 'stage-lost', 10000, 3);
-    seedHistory('h-lost', 'rec-lost', 'stage-prospecting', 'stage-lost', 2, 3);
+      // Record that was moved to lost this month
+      seedRecord('rec-lost', 'stage-lost', 10000, 3);
+      seedHistory('h-lost', 'rec-lost', 'stage-prospecting', 'stage-lost', 2, 3);
 
-    const result = await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
+      const result = await getPipelineSummary(TENANT_ID, PIPELINE_ID, OWNER_ID);
 
-    expect(result.totals.wonThisMonth).toBe(1);
-    expect(result.totals.wonValueThisMonth).toBe(50000);
-    expect(result.totals.lostThisMonth).toBe(1);
+      expect(result.totals.wonThisMonth).toBe(1);
+      expect(result.totals.wonValueThisMonth).toBe(50000);
+      expect(result.totals.lostThisMonth).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('excludes won/lost records from open deal totals', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7235,8 +7235,12 @@
             "packages/types": {
                   "name": "@cpcrm/types",
                   "version": "0.0.0",
+                  "dependencies": {
+                        "zod": "^4.3.6"
+                  },
                   "devDependencies": {
-                        "typescript": "^6.0.2"
+                        "typescript": "^6.0.2",
+                        "vitest": "^4.1.4"
                   }
             },
             "packages/ui": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,11 +6,15 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "echo 'test not yet implemented'",
+    "test": "vitest run",
     "lint": "echo 'lint not yet implemented'",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "echo 'lint not yet implemented'",
     "typecheck": "tsc --noEmit"

--- a/packages/types/src/__tests__/aiEdit.test.ts
+++ b/packages/types/src/__tests__/aiEdit.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   AddComponentOpSchema,
   AddSectionOpSchema,
+  AiEditContextSchema,
   AiEditResponseSchema,
   AiPageLayout,
+  AiPageLayoutSchema,
   applyOp,
   MoveComponentOpSchema,
   RemoveComponentOpSchema,
@@ -700,5 +702,140 @@ describe('per-op schema rejections', () => {
         position: 1.5,
       }).success,
     ).toBe(false);
+  });
+
+  it('rejects reorder_section with a negative position (no append sentinel)', () => {
+    expect(
+      ReorderSectionOpSchema.safeParse({
+        op: 'reorder_section',
+        id: 'op_1',
+        sectionId: 'sec_x',
+        position: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects add_component with a position below the -1 append sentinel', () => {
+    expect(
+      AddComponentOpSchema.safeParse({
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'zone', zone: 'kpi' },
+        position: -2,
+        component: { type: 'metric', config: {} },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects move_component with a position below -1', () => {
+    expect(
+      MoveComponentOpSchema.safeParse({
+        op: 'move_component',
+        id: 'op_1',
+        componentId: 'cmp_x',
+        to: { kind: 'zone', zone: 'kpi', position: -5 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects add_section with a position below -1', () => {
+    expect(
+      AddSectionOpSchema.safeParse({
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'leftRail' },
+        position: -2,
+        section: { label: 'X', columns: 1, components: [] },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('layout + context schemas', () => {
+  it('parses a minimal layout', () => {
+    const parsed = AiPageLayoutSchema.parse({
+      id: 'lay_1',
+      objectId: 'obj_1',
+      name: 'Default',
+      header: { primaryField: 'name', secondaryFields: [] },
+      tabs: [],
+    });
+    expect(parsed.id).toBe('lay_1');
+  });
+
+  it('rejects a layout with an extra top-level key', () => {
+    expect(
+      AiPageLayoutSchema.safeParse({
+        id: 'lay_1',
+        objectId: 'obj_1',
+        name: 'Default',
+        header: { primaryField: 'name', secondaryFields: [] },
+        tabs: [],
+        rogue: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('parses a context with fields and relationships', () => {
+    const parsed = AiEditContextSchema.parse({
+      layoutId: 'lay_1',
+      objectApiName: 'opportunity',
+      objectLabel: 'Opportunity',
+      layout: {
+        id: 'lay_1',
+        objectId: 'obj_1',
+        name: 'Default',
+        header: { primaryField: 'name', secondaryFields: [] },
+        tabs: [],
+      },
+      fields: [{ apiName: 'name', label: 'Name', fieldType: 'text' }],
+      relationships: [
+        {
+          relationshipId: 'rel_calls',
+          label: 'Calls',
+          relationshipType: 'parent_child',
+          relatedObjectApiName: 'call',
+        },
+      ],
+    });
+    expect(parsed.fields[0].apiName).toBe('name');
+  });
+
+  it('rejects a context with an unknown relationship type', () => {
+    expect(
+      AiEditContextSchema.safeParse({
+        layoutId: 'lay_1',
+        objectApiName: 'opportunity',
+        objectLabel: 'Opportunity',
+        layout: {
+          id: 'lay_1',
+          objectId: 'obj_1',
+          name: 'Default',
+          header: { primaryField: 'name', secondaryFields: [] },
+          tabs: [],
+        },
+        fields: [],
+        relationships: [
+          {
+            relationshipId: 'rel_x',
+            label: 'X',
+            relationshipType: 'sibling',
+            relatedObjectApiName: 'x',
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('applyOp exhaustiveness', () => {
+  it('throws on an unknown op kind that bypassed the schema', () => {
+    expect(() =>
+      // Cast through unknown — emulates a caller bypassing AiEditOpSchema.
+      applyOp({ id: 'l', objectId: 'o', name: 'n', header: { primaryField: 'p', secondaryFields: [] }, tabs: [] }, {
+        op: 'mutate_everything',
+        id: 'op_1',
+      } as unknown as Parameters<typeof applyOp>[1]),
+    ).toThrow(/unknown op kind/);
   });
 });

--- a/packages/types/src/__tests__/aiEdit.test.ts
+++ b/packages/types/src/__tests__/aiEdit.test.ts
@@ -317,6 +317,38 @@ describe('applyOp', () => {
         }),
       ).toThrow(/tab_missing/);
     });
+
+    it('defaults the section type to field_section when omitted', () => {
+      const result = applyOp(baseLayout(), {
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'rightRail' },
+        position: -1,
+        section: { label: 'New', columns: 1, components: [] },
+      });
+      expect(result.zones!.rightRail[0].type).toBe('field_section');
+    });
+
+    it('honours an explicit section type', () => {
+      const result = applyOp(baseLayout(), {
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'rightRail' },
+        position: -1,
+        section: {
+          type: 'related_list',
+          label: 'Calls',
+          columns: 1,
+          components: [
+            {
+              type: 'related_list',
+              config: { relationshipId: 'rel_recent_calls' },
+            },
+          ],
+        },
+      });
+      expect(result.zones!.rightRail[0].type).toBe('related_list');
+    });
   });
 
   describe('remove_section', () => {
@@ -363,6 +395,25 @@ describe('applyOp', () => {
       expect(replaced.columns).toBe(1);
       expect(replaced.components).toHaveLength(1);
       expect(replaced.components[0].type).toBe('related_list');
+    });
+
+    it('honours an explicit section type override', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'replace_section',
+        id: 'op_1',
+        sectionId: 'sec_opps',
+        section: {
+          type: 'related_list',
+          components: [
+            {
+              type: 'related_list',
+              config: { relationshipId: 'rel_recent_calls' },
+            },
+          ],
+        },
+      });
+      expect(result.zones!.leftRail[0].type).toBe('related_list');
     });
   });
 
@@ -599,6 +650,23 @@ describe('per-op schema rejections', () => {
         target: { kind: 'rail', rail: 'leftRail' },
         position: 0,
         section: { label: 'X', columns: 3, components: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects add_section with an unknown section type', () => {
+    expect(
+      AddSectionOpSchema.safeParse({
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'leftRail' },
+        position: 0,
+        section: {
+          type: 'mystery_section',
+          label: 'X',
+          columns: 1,
+          components: [],
+        },
       }).success,
     ).toBe(false);
   });

--- a/packages/types/src/__tests__/aiEdit.test.ts
+++ b/packages/types/src/__tests__/aiEdit.test.ts
@@ -1,0 +1,636 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AddComponentOpSchema,
+  AddSectionOpSchema,
+  AiEditResponseSchema,
+  AiPageLayout,
+  applyOp,
+  MoveComponentOpSchema,
+  RemoveComponentOpSchema,
+  RemoveSectionOpSchema,
+  ReorderSectionOpSchema,
+  ReplaceSectionOpSchema,
+  UpdateComponentConfigOpSchema,
+} from '../aiEdit.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function baseLayout(): AiPageLayout {
+  return {
+    id: 'lay_1',
+    objectId: 'obj_opp',
+    name: 'Default',
+    header: { primaryField: 'name', secondaryFields: ['stage'] },
+    zones: {
+      kpi: [
+        {
+          id: 'cmp_kpi_1',
+          type: 'metric',
+          config: { label: 'Amount', fieldApiName: 'amount' },
+        },
+      ],
+      leftRail: [
+        {
+          id: 'sec_opps',
+          label: 'Opportunities',
+          columns: 1,
+          components: [
+            {
+              id: 'cmp_field_name',
+              type: 'field',
+              config: { fieldApiName: 'name' },
+            },
+            {
+              id: 'cmp_field_amount',
+              type: 'field',
+              config: { fieldApiName: 'amount' },
+            },
+          ],
+        },
+      ],
+      rightRail: [],
+    },
+    tabs: [
+      {
+        id: 'tab_main',
+        label: 'About',
+        sections: [
+          {
+            id: 'sec_about',
+            label: 'About',
+            columns: 2,
+            components: [
+              {
+                id: 'cmp_notes',
+                type: 'field',
+                config: { fieldApiName: 'notes' },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ─── Reducer ───────────────────────────────────────────────────────────────
+
+describe('applyOp', () => {
+  it('does not mutate the input layout', () => {
+    const layout = baseLayout();
+    const snapshot = JSON.stringify(layout);
+    applyOp(layout, {
+      op: 'remove_component',
+      id: 'op_1',
+      componentId: 'cmp_kpi_1',
+    });
+    expect(JSON.stringify(layout)).toBe(snapshot);
+  });
+
+  describe('add_component', () => {
+    it('appends a KPI when position is -1', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'zone', zone: 'kpi' },
+        position: -1,
+        component: {
+          id: 'cmp_kpi_2',
+          type: 'metric',
+          config: { label: 'Stage' },
+        },
+      });
+      expect(result.zones!.kpi.map((c) => c.id)).toEqual([
+        'cmp_kpi_1',
+        'cmp_kpi_2',
+      ]);
+    });
+
+    it('inserts at a positional index inside a section', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'section', sectionId: 'sec_opps' },
+        position: 1,
+        component: {
+          id: 'cmp_field_stage',
+          type: 'field',
+          config: { fieldApiName: 'stage' },
+        },
+      });
+      expect(result.zones!.leftRail[0].components.map((c) => c.id)).toEqual([
+        'cmp_field_name',
+        'cmp_field_stage',
+        'cmp_field_amount',
+      ]);
+    });
+
+    it('generates a component id when none is supplied', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'zone', zone: 'kpi' },
+        position: -1,
+        component: { type: 'metric', config: {} },
+      });
+      const added = result.zones!.kpi[1];
+      expect(added.id).toMatch(/^cmp_/);
+      expect(added.id).not.toBe('');
+    });
+
+    it('throws when the target section does not exist', () => {
+      const layout = baseLayout();
+      expect(() =>
+        applyOp(layout, {
+          op: 'add_component',
+          id: 'op_1',
+          target: { kind: 'section', sectionId: 'sec_missing' },
+          position: 0,
+          component: { type: 'field', config: {} },
+        }),
+      ).toThrow(/sec_missing/);
+    });
+  });
+
+  describe('remove_component', () => {
+    it('removes a component from the KPI strip', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'remove_component',
+        id: 'op_1',
+        componentId: 'cmp_kpi_1',
+      });
+      expect(result.zones!.kpi).toEqual([]);
+    });
+
+    it('removes a component from a tab section', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'remove_component',
+        id: 'op_1',
+        componentId: 'cmp_notes',
+      });
+      expect(result.tabs[0].sections[0].components).toEqual([]);
+    });
+
+    it('throws when the component does not exist', () => {
+      expect(() =>
+        applyOp(baseLayout(), {
+          op: 'remove_component',
+          id: 'op_1',
+          componentId: 'cmp_ghost',
+        }),
+      ).toThrow(/cmp_ghost/);
+    });
+  });
+
+  describe('move_component', () => {
+    it('moves a component from a tab section into a rail section', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'move_component',
+        id: 'op_1',
+        componentId: 'cmp_notes',
+        to: { kind: 'section', sectionId: 'sec_opps', position: -1 },
+      });
+      expect(result.tabs[0].sections[0].components).toEqual([]);
+      expect(
+        result.zones!.leftRail[0].components.map((c) => c.id),
+      ).toEqual(['cmp_field_name', 'cmp_field_amount', 'cmp_notes']);
+    });
+
+    it('moves a component into the KPI strip at a specific position', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'move_component',
+        id: 'op_1',
+        componentId: 'cmp_field_amount',
+        to: { kind: 'zone', zone: 'kpi', position: 0 },
+      });
+      expect(result.zones!.kpi.map((c) => c.id)).toEqual([
+        'cmp_field_amount',
+        'cmp_kpi_1',
+      ]);
+      expect(result.zones!.leftRail[0].components.map((c) => c.id)).toEqual([
+        'cmp_field_name',
+      ]);
+    });
+
+    it('throws when the target section is missing', () => {
+      expect(() =>
+        applyOp(baseLayout(), {
+          op: 'move_component',
+          id: 'op_1',
+          componentId: 'cmp_field_name',
+          to: { kind: 'section', sectionId: 'sec_missing', position: 0 },
+        }),
+      ).toThrow(/sec_missing/);
+    });
+  });
+
+  describe('update_component_config', () => {
+    it('shallow-merges the patch into the existing config', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'update_component_config',
+        id: 'op_1',
+        componentId: 'cmp_kpi_1',
+        patch: { label: 'Total amount', accent: 'success' },
+      });
+      expect(result.zones!.kpi[0].config).toEqual({
+        label: 'Total amount',
+        fieldApiName: 'amount',
+        accent: 'success',
+      });
+    });
+
+    it('deletes a key when the patch value is null', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'update_component_config',
+        id: 'op_1',
+        componentId: 'cmp_kpi_1',
+        patch: { fieldApiName: null },
+      });
+      expect(result.zones!.kpi[0].config).toEqual({ label: 'Amount' });
+    });
+  });
+
+  describe('add_section', () => {
+    it('appends a section to a rail', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'rightRail' },
+        position: -1,
+        section: {
+          id: 'sec_recent_calls',
+          label: 'Recent Calls',
+          columns: 1,
+          components: [
+            {
+              id: 'cmp_rc',
+              type: 'related_list',
+              config: { relationshipId: 'rel_recent_calls' },
+            },
+          ],
+        },
+      });
+      expect(result.zones!.rightRail.map((s) => s.id)).toEqual([
+        'sec_recent_calls',
+      ]);
+      expect(result.zones!.rightRail[0].components[0].id).toBe('cmp_rc');
+    });
+
+    it('inserts a section into a tab at a specific position', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'tab', tabId: 'tab_main' },
+        position: 0,
+        section: {
+          id: 'sec_top',
+          label: 'Top',
+          columns: 1,
+          components: [],
+        },
+      });
+      expect(result.tabs[0].sections.map((s) => s.id)).toEqual([
+        'sec_top',
+        'sec_about',
+      ]);
+    });
+
+    it('throws when the tab id is unknown', () => {
+      expect(() =>
+        applyOp(baseLayout(), {
+          op: 'add_section',
+          id: 'op_1',
+          target: { kind: 'tab', tabId: 'tab_missing' },
+          position: 0,
+          section: { label: 'X', columns: 1, components: [] },
+        }),
+      ).toThrow(/tab_missing/);
+    });
+  });
+
+  describe('remove_section', () => {
+    it('removes a rail section', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'remove_section',
+        id: 'op_1',
+        sectionId: 'sec_opps',
+      });
+      expect(result.zones!.leftRail).toEqual([]);
+    });
+
+    it('removes a tab section', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'remove_section',
+        id: 'op_1',
+        sectionId: 'sec_about',
+      });
+      expect(result.tabs[0].sections).toEqual([]);
+    });
+  });
+
+  describe('replace_section', () => {
+    it('replaces components and preserves untouched metadata', () => {
+      const layout = baseLayout();
+      const result = applyOp(layout, {
+        op: 'replace_section',
+        id: 'op_1',
+        sectionId: 'sec_opps',
+        section: {
+          label: 'Recent Calls',
+          components: [
+            {
+              type: 'related_list',
+              config: { relationshipId: 'rel_recent_calls', limit: 5 },
+            },
+          ],
+        },
+      });
+      const replaced = result.zones!.leftRail[0];
+      expect(replaced.label).toBe('Recent Calls');
+      expect(replaced.columns).toBe(1);
+      expect(replaced.components).toHaveLength(1);
+      expect(replaced.components[0].type).toBe('related_list');
+    });
+  });
+
+  describe('reorder_section', () => {
+    it('reorders rail sections within their rail', () => {
+      const layout = baseLayout();
+      layout.zones!.leftRail.push({
+        id: 'sec_extra',
+        label: 'Extra',
+        columns: 1,
+        components: [],
+      });
+      const result = applyOp(layout, {
+        op: 'reorder_section',
+        id: 'op_1',
+        sectionId: 'sec_extra',
+        position: 0,
+      });
+      expect(result.zones!.leftRail.map((s) => s.id)).toEqual([
+        'sec_extra',
+        'sec_opps',
+      ]);
+    });
+
+    it('reorders sections inside a tab', () => {
+      const layout = baseLayout();
+      layout.tabs[0].sections.push({
+        id: 'sec_more',
+        label: 'More',
+        columns: 1,
+        components: [],
+      });
+      const result = applyOp(layout, {
+        op: 'reorder_section',
+        id: 'op_1',
+        sectionId: 'sec_more',
+        position: 0,
+      });
+      expect(result.tabs[0].sections.map((s) => s.id)).toEqual([
+        'sec_more',
+        'sec_about',
+      ]);
+    });
+  });
+
+  it('round-trips worked example 1 (replace section)', () => {
+    const layout = baseLayout();
+    const response = AiEditResponseSchema.parse({
+      summary: 'Replaces the Opportunities section with a Recent Calls list.',
+      ops: [
+        {
+          op: 'replace_section',
+          id: 'op_1',
+          sectionId: 'sec_opps',
+          section: {
+            label: 'Recent Calls',
+            components: [
+              {
+                type: 'related_list',
+                config: {
+                  relationshipId: 'rel_recent_calls',
+                  displayFields: ['name', 'called_at', 'outcome'],
+                  limit: 5,
+                  allowCreate: true,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const result = response.ops.reduce(applyOp, layout);
+    expect(result.zones!.leftRail[0].label).toBe('Recent Calls');
+    expect(result.zones!.leftRail[0].components[0].type).toBe('related_list');
+  });
+
+  it('round-trips worked example 2 (KPI add)', () => {
+    const layout = baseLayout();
+    const response = AiEditResponseSchema.parse({
+      summary: "Adds a 'Days since last call' metric.",
+      ops: [
+        {
+          op: 'add_component',
+          id: 'op_1',
+          target: { kind: 'zone', zone: 'kpi' },
+          position: -1,
+          component: {
+            type: 'metric',
+            config: {
+              label: 'Days since last call',
+              source: { kind: 'field', fieldApiName: 'last_call_at' },
+              format: 'duration',
+            },
+          },
+        },
+      ],
+    });
+    const result = response.ops.reduce(applyOp, layout);
+    expect(result.zones!.kpi).toHaveLength(2);
+    expect(result.zones!.kpi[1].config.label).toBe('Days since last call');
+  });
+
+  it('round-trips worked example 3 (move + add)', () => {
+    const layout = baseLayout();
+    const response = AiEditResponseSchema.parse({
+      summary: 'Moves notes and adds an activity feed.',
+      ops: [
+        {
+          op: 'move_component',
+          id: 'op_1',
+          componentId: 'cmp_notes',
+          to: { kind: 'section', sectionId: 'sec_opps', position: -1 },
+        },
+        {
+          op: 'add_component',
+          id: 'op_2',
+          target: { kind: 'section', sectionId: 'sec_opps' },
+          position: -1,
+          component: {
+            type: 'activity',
+            config: { limit: 10, types: ['opportunity', 'system'] },
+          },
+        },
+      ],
+    });
+    const result = response.ops.reduce(applyOp, layout);
+    const railIds = result.zones!.leftRail[0].components.map((c) => c.id);
+    expect(railIds[0]).toBe('cmp_field_name');
+    expect(railIds[1]).toBe('cmp_field_amount');
+    expect(railIds[2]).toBe('cmp_notes');
+    expect(result.zones!.leftRail[0].components[3].type).toBe('activity');
+    expect(result.tabs[0].sections[0].components).toEqual([]);
+  });
+});
+
+// ─── Schemas ───────────────────────────────────────────────────────────────
+
+describe('AiEditResponseSchema', () => {
+  it('accepts an empty op list with a clarification', () => {
+    const parsed = AiEditResponseSchema.parse({
+      summary: 'Need more info.',
+      ops: [],
+      clarification: 'Which section did you mean?',
+    });
+    expect(parsed.clarification).toBe('Which section did you mean?');
+  });
+
+  it('rejects a clarification combined with non-empty ops', () => {
+    expect(
+      AiEditResponseSchema.safeParse({
+        summary: 'x',
+        ops: [
+          {
+            op: 'remove_component',
+            id: 'op_1',
+            componentId: 'cmp_x',
+          },
+        ],
+        clarification: 'mixed',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an unknown op kind', () => {
+    expect(
+      AiEditResponseSchema.safeParse({
+        summary: 'x',
+        ops: [{ op: 'mutate_everything', id: 'op_1' }],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('per-op schema rejections', () => {
+  it('rejects add_component with an empty component type', () => {
+    expect(
+      AddComponentOpSchema.safeParse({
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'zone', zone: 'kpi' },
+        position: 0,
+        component: { type: '', config: {} },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects add_component with a non-kpi zone target', () => {
+    expect(
+      AddComponentOpSchema.safeParse({
+        op: 'add_component',
+        id: 'op_1',
+        target: { kind: 'zone', zone: 'leftRail' },
+        position: 0,
+        component: { type: 'metric', config: {} },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects remove_component with a missing componentId', () => {
+    expect(
+      RemoveComponentOpSchema.safeParse({
+        op: 'remove_component',
+        id: 'op_1',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects move_component without a position on the target', () => {
+    expect(
+      MoveComponentOpSchema.safeParse({
+        op: 'move_component',
+        id: 'op_1',
+        componentId: 'cmp_x',
+        to: { kind: 'zone', zone: 'kpi' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects update_component_config without a patch', () => {
+    expect(
+      UpdateComponentConfigOpSchema.safeParse({
+        op: 'update_component_config',
+        id: 'op_1',
+        componentId: 'cmp_x',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects add_section with columns outside the 1-2 range', () => {
+    expect(
+      AddSectionOpSchema.safeParse({
+        op: 'add_section',
+        id: 'op_1',
+        target: { kind: 'rail', rail: 'leftRail' },
+        position: 0,
+        section: { label: 'X', columns: 3, components: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects remove_section without a sectionId', () => {
+    expect(
+      RemoveSectionOpSchema.safeParse({
+        op: 'remove_section',
+        id: 'op_1',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects replace_section without a components array', () => {
+    expect(
+      ReplaceSectionOpSchema.safeParse({
+        op: 'replace_section',
+        id: 'op_1',
+        sectionId: 'sec_x',
+        section: { label: 'X' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects reorder_section with a non-integer position', () => {
+    expect(
+      ReorderSectionOpSchema.safeParse({
+        op: 'reorder_section',
+        id: 'op_1',
+        sectionId: 'sec_x',
+        position: 1.5,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/aiEdit.ts
+++ b/packages/types/src/aiEdit.ts
@@ -284,24 +284,123 @@ const ComponentInputSchema = z
   })
   .strict();
 
+// ─── Layout shape schemas ──────────────────────────────────────────────────
+//
+// Validates the layout payload the BE sends to the model in `AiEditContext`
+// and that the FE feeds into the reducer. Section `type` is intentionally
+// optional here because the FE in-memory shape (apps/web/src/components/
+// layoutTypes.ts) treats it as optional; the post-apply BE validator
+// re-checks it via validateSection.
+
+export const AiLayoutComponentSchema: z.ZodType<AiLayoutComponent> = z
+  .object({
+    id: NonEmptyString,
+    type: NonEmptyString,
+    config: z.record(z.string(), z.unknown()),
+    visibility: AiVisibilityRuleSchema.nullable().optional(),
+  })
+  .strict();
+
+export const AiLayoutSectionSchema: z.ZodType<AiLayoutSection> = z
+  .object({
+    id: NonEmptyString,
+    type: NonEmptyString.optional(),
+    label: z.string(),
+    columns: z.number().int(),
+    collapsed: z.boolean().optional(),
+    visibility: AiVisibilityRuleSchema.nullable().optional(),
+    components: z.array(AiLayoutComponentSchema),
+  })
+  .strict();
+
+export const AiLayoutTabSchema: z.ZodType<AiLayoutTab> = z
+  .object({
+    id: NonEmptyString,
+    label: z.string(),
+    sections: z.array(AiLayoutSectionSchema),
+  })
+  .strict();
+
+export const AiLayoutZonesSchema: z.ZodType<AiLayoutZones> = z
+  .object({
+    kpi: z.array(AiLayoutComponentSchema),
+    leftRail: z.array(AiLayoutSectionSchema),
+    rightRail: z.array(AiLayoutSectionSchema),
+  })
+  .strict();
+
+export const AiLayoutHeaderSchema: z.ZodType<AiLayoutHeader> = z
+  .object({
+    primaryField: z.string(),
+    secondaryFields: z.array(z.string()),
+  })
+  .strict();
+
+export const AiPageLayoutSchema: z.ZodType<AiPageLayout> = z
+  .object({
+    id: NonEmptyString,
+    objectId: NonEmptyString,
+    name: z.string(),
+    header: AiLayoutHeaderSchema,
+    zones: AiLayoutZonesSchema.optional(),
+    tabs: z.array(AiLayoutTabSchema),
+  })
+  .strict();
+
+// ─── Context schemas ───────────────────────────────────────────────────────
+
+export const AiEditContextFieldSchema: z.ZodType<AiEditContextField> = z
+  .object({
+    apiName: NonEmptyString,
+    label: z.string(),
+    fieldType: z.string(),
+  })
+  .strict();
+
+export const AiEditContextRelationshipSchema: z.ZodType<AiEditContextRelationship> =
+  z
+    .object({
+      relationshipId: NonEmptyString,
+      label: z.string(),
+      relationshipType: z.enum(['lookup', 'parent_child']),
+      relatedObjectApiName: NonEmptyString,
+    })
+    .strict();
+
+export const AiEditContextSchema: z.ZodType<AiEditContext> = z
+  .object({
+    layoutId: NonEmptyString,
+    objectApiName: NonEmptyString,
+    objectLabel: z.string(),
+    layout: AiPageLayoutSchema,
+    fields: z.array(AiEditContextFieldSchema),
+    relationships: z.array(AiEditContextRelationshipSchema),
+  })
+  .strict();
+
 const AddComponentTargetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('zone'), zone: z.literal('kpi') }).strict(),
   z.object({ kind: z.literal('section'), sectionId: NonEmptyString }).strict(),
 ]);
+
+// Positions are 0-based indices; -1 is the documented "append" sentinel.
+// Anything below -1 is a model bug — reject at gate 1 rather than silently
+// treating it as append.
+const PositionSchema = z.number().int().min(-1);
 
 const MoveComponentTargetSchema = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('zone'),
       zone: z.literal('kpi'),
-      position: z.number().int(),
+      position: PositionSchema,
     })
     .strict(),
   z
     .object({
       kind: z.literal('section'),
       sectionId: NonEmptyString,
-      position: z.number().int(),
+      position: PositionSchema,
     })
     .strict(),
 ]);
@@ -321,7 +420,7 @@ export const AddComponentOpSchema = z
     op: z.literal('add_component'),
     id: NonEmptyString,
     target: AddComponentTargetSchema,
-    position: z.number().int(),
+    position: PositionSchema,
     component: ComponentInputSchema,
   })
   .strict();
@@ -363,7 +462,7 @@ export const AddSectionOpSchema = z
     op: z.literal('add_section'),
     id: NonEmptyString,
     target: AddSectionTargetSchema,
-    position: z.number().int(),
+    position: PositionSchema,
     section: z
       .object({
         id: NonEmptyString.optional(),
@@ -407,7 +506,10 @@ export const ReorderSectionOpSchema = z
     op: z.literal('reorder_section'),
     id: NonEmptyString,
     sectionId: NonEmptyString,
-    position: z.number().int(),
+    // Reorder is "new 0-based index inside its current rail or tab" — no
+    // append sentinel. Negatives would be silently treated as "move to end"
+    // by moveTo, so reject them at gate 1.
+    position: z.number().int().min(0),
   })
   .strict();
 
@@ -520,8 +622,9 @@ function insertAt<T>(arr: readonly T[], position: number, item: T): T[] {
 function moveTo<T>(arr: readonly T[], fromIndex: number, position: number): T[] {
   const out = arr.slice();
   const [item] = out.splice(fromIndex, 1);
-  const insertAt = position < 0 || position > out.length ? out.length : position;
-  out.splice(insertAt, 0, item);
+  const insertIndex =
+    position < 0 || position > out.length ? out.length : position;
+  out.splice(insertIndex, 0, item);
   return out;
 }
 
@@ -920,5 +1023,14 @@ export function applyOp(layout: AiPageLayout, op: AiEditOp): AiPageLayout {
       return applyReplaceSection(layout, op);
     case 'reorder_section':
       return applyReorderSection(layout, op);
+    default: {
+      // Exhaustiveness guard: TS errors here if a new op kind is added
+      // without a case above, and at runtime we throw instead of returning
+      // undefined when a caller bypasses AiEditOpSchema.
+      const exhaustive: never = op;
+      throw new Error(
+        `applyOp: unknown op kind ${JSON.stringify((exhaustive as { op?: unknown }).op)}`,
+      );
+    }
   }
 }

--- a/packages/types/src/aiEdit.ts
+++ b/packages/types/src/aiEdit.ts
@@ -1,0 +1,904 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// AI page-editor edit contract
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Shared between the FE patch applicator and the BE endpoint so they cannot
+// drift. Mirrors `docs/page-builder/ai-edit-contract.md` and the FE layout
+// shape declared in `apps/web/src/components/layoutTypes.ts`.
+
+import { z } from 'zod';
+
+// ─── Layout shape (mirrors apps/web/src/components/layoutTypes.ts) ──────────
+//
+// These interfaces describe the in-memory layout used by the page builder.
+// They intentionally live here so the reducer below has a single source of
+// truth that both the FE and BE can import. They are structurally identical
+// to the types declared in `apps/web/src/components/layoutTypes.ts`.
+
+export type AiVisibilityOp =
+  | 'equals'
+  | 'not_equals'
+  | 'contains'
+  | 'not_empty'
+  | 'empty'
+  | 'greater_than'
+  | 'less_than'
+  | 'in'
+  | 'not_in';
+
+export interface AiVisibilityCondition {
+  field: string;
+  op: AiVisibilityOp;
+  value?: unknown;
+}
+
+export interface AiVisibilityRule {
+  operator: 'AND' | 'OR';
+  conditions: AiVisibilityCondition[];
+}
+
+export interface AiLayoutComponent {
+  id: string;
+  type: string;
+  config: Record<string, unknown>;
+  visibility?: AiVisibilityRule | null;
+}
+
+export interface AiLayoutSection {
+  id: string;
+  type?: string;
+  label: string;
+  columns: number;
+  collapsed?: boolean;
+  visibility?: AiVisibilityRule | null;
+  components: AiLayoutComponent[];
+}
+
+export interface AiLayoutTab {
+  id: string;
+  label: string;
+  sections: AiLayoutSection[];
+}
+
+export interface AiLayoutZones {
+  kpi: AiLayoutComponent[];
+  leftRail: AiLayoutSection[];
+  rightRail: AiLayoutSection[];
+}
+
+export interface AiLayoutHeader {
+  primaryField: string;
+  secondaryFields: string[];
+}
+
+export interface AiPageLayout {
+  id: string;
+  objectId: string;
+  name: string;
+  header: AiLayoutHeader;
+  zones?: AiLayoutZones;
+  tabs: AiLayoutTab[];
+}
+
+// ─── Per-request context the BE assembles for the model ────────────────────
+
+export type AiEditFieldType =
+  | 'text'
+  | 'long_text'
+  | 'number'
+  | 'currency'
+  | 'percent'
+  | 'boolean'
+  | 'date'
+  | 'datetime'
+  | 'picklist'
+  | 'multipicklist'
+  | 'reference'
+  | 'email'
+  | 'phone'
+  | 'url';
+
+export interface AiEditContextField {
+  apiName: string;
+  label: string;
+  fieldType: AiEditFieldType | string;
+}
+
+export interface AiEditContextRelationship {
+  relationshipId: string;
+  label: string;
+  relationshipType: 'lookup' | 'parent_child';
+  relatedObjectApiName: string;
+}
+
+export interface AiEditContext {
+  layoutId: string;
+  objectApiName: string;
+  objectLabel: string;
+  layout: AiPageLayout;
+  fields: AiEditContextField[];
+  relationships: AiEditContextRelationship[];
+}
+
+// ─── Op union ──────────────────────────────────────────────────────────────
+
+export type AiEditOpKind =
+  | 'add_component'
+  | 'remove_component'
+  | 'move_component'
+  | 'update_component_config'
+  | 'add_section'
+  | 'remove_section'
+  | 'replace_section'
+  | 'reorder_section';
+
+export interface AiEditComponentInput {
+  id?: string;
+  type: string;
+  config: Record<string, unknown>;
+  visibility?: AiVisibilityRule | null;
+}
+
+export interface AddComponentOp {
+  op: 'add_component';
+  id: string;
+  target:
+    | { kind: 'zone'; zone: 'kpi' }
+    | { kind: 'section'; sectionId: string };
+  /** 0-based index. Use -1 for "append". */
+  position: number;
+  component: AiEditComponentInput;
+}
+
+export interface RemoveComponentOp {
+  op: 'remove_component';
+  id: string;
+  componentId: string;
+}
+
+export interface MoveComponentOp {
+  op: 'move_component';
+  id: string;
+  componentId: string;
+  to:
+    | { kind: 'zone'; zone: 'kpi'; position: number }
+    | { kind: 'section'; sectionId: string; position: number };
+}
+
+export interface UpdateComponentConfigOp {
+  op: 'update_component_config';
+  id: string;
+  componentId: string;
+  /** Shallow merge into the existing config. Keys set to `null` are deleted. */
+  patch: Record<string, unknown>;
+}
+
+export interface AddSectionOp {
+  op: 'add_section';
+  id: string;
+  target:
+    | { kind: 'rail'; rail: 'leftRail' | 'rightRail' }
+    | { kind: 'tab'; tabId: string };
+  position: number;
+  section: {
+    id?: string;
+    label: string;
+    columns: number;
+    collapsed?: boolean;
+    components: AiEditComponentInput[];
+  };
+}
+
+export interface RemoveSectionOp {
+  op: 'remove_section';
+  id: string;
+  sectionId: string;
+}
+
+export interface ReplaceSectionOp {
+  op: 'replace_section';
+  id: string;
+  sectionId: string;
+  section: {
+    label?: string;
+    columns?: number;
+    collapsed?: boolean;
+    components: AiEditComponentInput[];
+  };
+}
+
+export interface ReorderSectionOp {
+  op: 'reorder_section';
+  id: string;
+  sectionId: string;
+  /** New 0-based index inside its current rail or tab. */
+  position: number;
+}
+
+export type AiEditOp =
+  | AddComponentOp
+  | RemoveComponentOp
+  | MoveComponentOp
+  | UpdateComponentConfigOp
+  | AddSectionOp
+  | RemoveSectionOp
+  | ReplaceSectionOp
+  | ReorderSectionOp;
+
+export interface AiEditResponse {
+  /** Short natural-language summary shown above the diff preview. */
+  summary: string;
+  /** Ordered list of operations to apply. May be empty (no-op). */
+  ops: AiEditOp[];
+  /**
+   * Optional clarifying question. When set, `ops` MUST be empty and the FE
+   * renders the question instead of a diff.
+   */
+  clarification?: string;
+}
+
+// ─── Zod schemas ───────────────────────────────────────────────────────────
+
+const NonEmptyString = z.string().min(1);
+
+const VisibilityOpSchema = z.enum([
+  'equals',
+  'not_equals',
+  'contains',
+  'not_empty',
+  'empty',
+  'greater_than',
+  'less_than',
+  'in',
+  'not_in',
+]);
+
+export const AiVisibilityConditionSchema = z
+  .object({
+    field: NonEmptyString,
+    op: VisibilityOpSchema,
+    value: z.unknown().optional(),
+  })
+  .strict();
+
+export const AiVisibilityRuleSchema = z
+  .object({
+    operator: z.enum(['AND', 'OR']),
+    conditions: z.array(AiVisibilityConditionSchema),
+  })
+  .strict();
+
+const ComponentInputSchema = z
+  .object({
+    id: NonEmptyString.optional(),
+    type: NonEmptyString,
+    config: z.record(z.string(), z.unknown()),
+    visibility: AiVisibilityRuleSchema.nullable().optional(),
+  })
+  .strict();
+
+const AddComponentTargetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('zone'), zone: z.literal('kpi') }).strict(),
+  z.object({ kind: z.literal('section'), sectionId: NonEmptyString }).strict(),
+]);
+
+const MoveComponentTargetSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('zone'),
+      zone: z.literal('kpi'),
+      position: z.number().int(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('section'),
+      sectionId: NonEmptyString,
+      position: z.number().int(),
+    })
+    .strict(),
+]);
+
+const AddSectionTargetSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('rail'),
+      rail: z.enum(['leftRail', 'rightRail']),
+    })
+    .strict(),
+  z.object({ kind: z.literal('tab'), tabId: NonEmptyString }).strict(),
+]);
+
+export const AddComponentOpSchema = z
+  .object({
+    op: z.literal('add_component'),
+    id: NonEmptyString,
+    target: AddComponentTargetSchema,
+    position: z.number().int(),
+    component: ComponentInputSchema,
+  })
+  .strict();
+
+export const RemoveComponentOpSchema = z
+  .object({
+    op: z.literal('remove_component'),
+    id: NonEmptyString,
+    componentId: NonEmptyString,
+  })
+  .strict();
+
+export const MoveComponentOpSchema = z
+  .object({
+    op: z.literal('move_component'),
+    id: NonEmptyString,
+    componentId: NonEmptyString,
+    to: MoveComponentTargetSchema,
+  })
+  .strict();
+
+export const UpdateComponentConfigOpSchema = z
+  .object({
+    op: z.literal('update_component_config'),
+    id: NonEmptyString,
+    componentId: NonEmptyString,
+    patch: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const AddSectionOpSchema = z
+  .object({
+    op: z.literal('add_section'),
+    id: NonEmptyString,
+    target: AddSectionTargetSchema,
+    position: z.number().int(),
+    section: z
+      .object({
+        id: NonEmptyString.optional(),
+        label: NonEmptyString,
+        columns: z.number().int().min(1).max(2),
+        collapsed: z.boolean().optional(),
+        components: z.array(ComponentInputSchema),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const RemoveSectionOpSchema = z
+  .object({
+    op: z.literal('remove_section'),
+    id: NonEmptyString,
+    sectionId: NonEmptyString,
+  })
+  .strict();
+
+export const ReplaceSectionOpSchema = z
+  .object({
+    op: z.literal('replace_section'),
+    id: NonEmptyString,
+    sectionId: NonEmptyString,
+    section: z
+      .object({
+        label: NonEmptyString.optional(),
+        columns: z.number().int().min(1).max(2).optional(),
+        collapsed: z.boolean().optional(),
+        components: z.array(ComponentInputSchema),
+      })
+      .strict(),
+  })
+  .strict();
+
+export const ReorderSectionOpSchema = z
+  .object({
+    op: z.literal('reorder_section'),
+    id: NonEmptyString,
+    sectionId: NonEmptyString,
+    position: z.number().int(),
+  })
+  .strict();
+
+export const AiEditOpSchema = z.discriminatedUnion('op', [
+  AddComponentOpSchema,
+  RemoveComponentOpSchema,
+  MoveComponentOpSchema,
+  UpdateComponentConfigOpSchema,
+  AddSectionOpSchema,
+  RemoveSectionOpSchema,
+  ReplaceSectionOpSchema,
+  ReorderSectionOpSchema,
+]);
+
+export const AiEditResponseSchema = z
+  .object({
+    summary: z.string(),
+    ops: z.array(AiEditOpSchema),
+    clarification: z.string().optional(),
+  })
+  .strict()
+  .refine(
+    (r) => !(r.clarification !== undefined && r.ops.length > 0),
+    { message: 'clarification responses must have an empty ops list' },
+  );
+
+// Compile-time guard that schemas and TS interfaces stay in sync. If the
+// schema starts producing a different shape, these assignments stop type-
+// checking — much cheaper than a runtime drift in production.
+type _AiEditOpFromSchema = z.infer<typeof AiEditOpSchema>;
+type _AiEditResponseFromSchema = z.infer<typeof AiEditResponseSchema>;
+const _opShapeCheck = (op: AiEditOp): _AiEditOpFromSchema => op;
+const _opShapeCheckBack = (op: _AiEditOpFromSchema): AiEditOp => op;
+const _responseShapeCheck = (r: AiEditResponse): _AiEditResponseFromSchema => r;
+const _responseShapeCheckBack = (
+  r: _AiEditResponseFromSchema,
+): AiEditResponse => r;
+void _opShapeCheck;
+void _opShapeCheckBack;
+void _responseShapeCheck;
+void _responseShapeCheckBack;
+
+// ─── applyOp reducer ───────────────────────────────────────────────────────
+//
+// `applyOp` is intentionally pure: it never mutates the input layout, and
+// callers can safely accumulate state with `ops.reduce(applyOp, layout)`.
+// All reference checks (componentId/sectionId/tabId existence, zone
+// compatibility, registry membership) live in a separate validator — this
+// reducer trusts that gates 2-4 from the contract have already passed.
+// When the reducer encounters a missing reference it throws, so a buggy
+// caller fails loudly rather than silently producing a corrupt layout.
+
+const ID_PREFIX_COMPONENT = 'cmp_';
+const ID_PREFIX_SECTION = 'sec_';
+
+function generateId(prefix: string): string {
+  // Prefer crypto.randomUUID where available (Node 20+, modern browsers).
+  // Fall back to Math.random for environments that lack it.
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (g.crypto && typeof g.crypto.randomUUID === 'function') {
+    return prefix + g.crypto.randomUUID();
+  }
+  return prefix + Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+function ensureZones(layout: AiPageLayout): AiLayoutZones {
+  return (
+    layout.zones ?? {
+      kpi: [],
+      leftRail: [],
+      rightRail: [],
+    }
+  );
+}
+
+function materialiseComponent(input: AiEditComponentInput): AiLayoutComponent {
+  return {
+    id: input.id ?? generateId(ID_PREFIX_COMPONENT),
+    type: input.type,
+    config: { ...input.config },
+    ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
+  };
+}
+
+function materialiseSection(
+  input: AddSectionOp['section'],
+): AiLayoutSection {
+  return {
+    id: input.id ?? generateId(ID_PREFIX_SECTION),
+    label: input.label,
+    columns: input.columns,
+    ...(input.collapsed !== undefined ? { collapsed: input.collapsed } : {}),
+    components: input.components.map(materialiseComponent),
+  };
+}
+
+function insertAt<T>(arr: readonly T[], position: number, item: T): T[] {
+  if (position < 0 || position > arr.length) {
+    return [...arr, item];
+  }
+  const out = arr.slice();
+  out.splice(position, 0, item);
+  return out;
+}
+
+function moveTo<T>(arr: readonly T[], fromIndex: number, position: number): T[] {
+  const out = arr.slice();
+  const [item] = out.splice(fromIndex, 1);
+  const insertAt = position < 0 || position > out.length ? out.length : position;
+  out.splice(insertAt, 0, item);
+  return out;
+}
+
+interface ComponentLocation {
+  kind: 'zone' | 'leftRail' | 'rightRail' | 'tab';
+  /** Index in zones.kpi for kind='zone'; otherwise the section index. */
+  containerIndex: number;
+  /** Tab index when kind='tab'. */
+  tabIndex?: number;
+  componentIndex: number;
+}
+
+function findComponent(
+  layout: AiPageLayout,
+  componentId: string,
+): ComponentLocation | null {
+  const zones = ensureZones(layout);
+
+  const kpiIdx = zones.kpi.findIndex((c) => c.id === componentId);
+  if (kpiIdx !== -1) {
+    return { kind: 'zone', containerIndex: kpiIdx, componentIndex: kpiIdx };
+  }
+
+  for (const railName of ['leftRail', 'rightRail'] as const) {
+    const rail = zones[railName];
+    for (let s = 0; s < rail.length; s++) {
+      const idx = rail[s].components.findIndex((c) => c.id === componentId);
+      if (idx !== -1) {
+        return { kind: railName, containerIndex: s, componentIndex: idx };
+      }
+    }
+  }
+
+  for (let t = 0; t < layout.tabs.length; t++) {
+    const sections = layout.tabs[t].sections;
+    for (let s = 0; s < sections.length; s++) {
+      const idx = sections[s].components.findIndex((c) => c.id === componentId);
+      if (idx !== -1) {
+        return {
+          kind: 'tab',
+          containerIndex: s,
+          tabIndex: t,
+          componentIndex: idx,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+interface SectionLocation {
+  kind: 'leftRail' | 'rightRail' | 'tab';
+  /** Tab index when kind='tab'. */
+  tabIndex?: number;
+  sectionIndex: number;
+}
+
+function findSection(layout: AiPageLayout, sectionId: string): SectionLocation | null {
+  const zones = ensureZones(layout);
+
+  for (const railName of ['leftRail', 'rightRail'] as const) {
+    const idx = zones[railName].findIndex((s) => s.id === sectionId);
+    if (idx !== -1) return { kind: railName, sectionIndex: idx };
+  }
+
+  for (let t = 0; t < layout.tabs.length; t++) {
+    const idx = layout.tabs[t].sections.findIndex((s) => s.id === sectionId);
+    if (idx !== -1) return { kind: 'tab', tabIndex: t, sectionIndex: idx };
+  }
+
+  return null;
+}
+
+function withZones(layout: AiPageLayout, zones: AiLayoutZones): AiPageLayout {
+  return { ...layout, zones };
+}
+
+function updateSection(
+  layout: AiPageLayout,
+  loc: SectionLocation,
+  update: (section: AiLayoutSection) => AiLayoutSection,
+): AiPageLayout {
+  if (loc.kind === 'tab') {
+    const tabIndex = loc.tabIndex!;
+    const tabs = layout.tabs.slice();
+    const sections = tabs[tabIndex].sections.slice();
+    sections[loc.sectionIndex] = update(sections[loc.sectionIndex]);
+    tabs[tabIndex] = { ...tabs[tabIndex], sections };
+    return { ...layout, tabs };
+  }
+
+  const zones = ensureZones(layout);
+  const rail = zones[loc.kind].slice();
+  rail[loc.sectionIndex] = update(rail[loc.sectionIndex]);
+  return withZones(layout, { ...zones, [loc.kind]: rail });
+}
+
+function removeSectionAt(layout: AiPageLayout, loc: SectionLocation): AiPageLayout {
+  if (loc.kind === 'tab') {
+    const tabIndex = loc.tabIndex!;
+    const tabs = layout.tabs.slice();
+    const sections = tabs[tabIndex].sections.slice();
+    sections.splice(loc.sectionIndex, 1);
+    tabs[tabIndex] = { ...tabs[tabIndex], sections };
+    return { ...layout, tabs };
+  }
+
+  const zones = ensureZones(layout);
+  const rail = zones[loc.kind].slice();
+  rail.splice(loc.sectionIndex, 1);
+  return withZones(layout, { ...zones, [loc.kind]: rail });
+}
+
+function applyAddComponent(
+  layout: AiPageLayout,
+  op: AddComponentOp,
+): AiPageLayout {
+  const component = materialiseComponent(op.component);
+
+  if (op.target.kind === 'zone') {
+    const zones = ensureZones(layout);
+    return withZones(layout, {
+      ...zones,
+      kpi: insertAt(zones.kpi, op.position, component),
+    });
+  }
+
+  const sectionLoc = findSection(layout, op.target.sectionId);
+  if (!sectionLoc) {
+    throw new Error(
+      `applyOp(add_component): section "${op.target.sectionId}" not found`,
+    );
+  }
+  return updateSection(layout, sectionLoc, (section) => ({
+    ...section,
+    components: insertAt(section.components, op.position, component),
+  }));
+}
+
+function applyRemoveComponent(
+  layout: AiPageLayout,
+  op: RemoveComponentOp,
+): AiPageLayout {
+  const loc = findComponent(layout, op.componentId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(remove_component): component "${op.componentId}" not found`,
+    );
+  }
+
+  if (loc.kind === 'zone') {
+    const zones = ensureZones(layout);
+    const kpi = zones.kpi.slice();
+    kpi.splice(loc.componentIndex, 1);
+    return withZones(layout, { ...zones, kpi });
+  }
+
+  if (loc.kind === 'tab') {
+    return updateSection(
+      layout,
+      { kind: 'tab', tabIndex: loc.tabIndex, sectionIndex: loc.containerIndex },
+      (section) => {
+        const components = section.components.slice();
+        components.splice(loc.componentIndex, 1);
+        return { ...section, components };
+      },
+    );
+  }
+
+  return updateSection(
+    layout,
+    { kind: loc.kind, sectionIndex: loc.containerIndex },
+    (section) => {
+      const components = section.components.slice();
+      components.splice(loc.componentIndex, 1);
+      return { ...section, components };
+    },
+  );
+}
+
+function applyMoveComponent(
+  layout: AiPageLayout,
+  op: MoveComponentOp,
+): AiPageLayout {
+  const loc = findComponent(layout, op.componentId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(move_component): component "${op.componentId}" not found`,
+    );
+  }
+
+  // Pull the component out without mutating the input.
+  let component: AiLayoutComponent;
+  let intermediate: AiPageLayout;
+  if (loc.kind === 'zone') {
+    const zones = ensureZones(layout);
+    component = zones.kpi[loc.componentIndex];
+    const kpi = zones.kpi.slice();
+    kpi.splice(loc.componentIndex, 1);
+    intermediate = withZones(layout, { ...zones, kpi });
+  } else if (loc.kind === 'tab') {
+    const sectionLoc: SectionLocation = {
+      kind: 'tab',
+      tabIndex: loc.tabIndex,
+      sectionIndex: loc.containerIndex,
+    };
+    const section =
+      layout.tabs[loc.tabIndex!].sections[loc.containerIndex];
+    component = section.components[loc.componentIndex];
+    intermediate = updateSection(layout, sectionLoc, (s) => {
+      const components = s.components.slice();
+      components.splice(loc.componentIndex, 1);
+      return { ...s, components };
+    });
+  } else {
+    const railName = loc.kind;
+    const sectionLoc: SectionLocation = {
+      kind: railName,
+      sectionIndex: loc.containerIndex,
+    };
+    const zones = ensureZones(layout);
+    component = zones[railName][loc.containerIndex].components[loc.componentIndex];
+    intermediate = updateSection(layout, sectionLoc, (s) => {
+      const components = s.components.slice();
+      components.splice(loc.componentIndex, 1);
+      return { ...s, components };
+    });
+  }
+
+  // Insert at the new location.
+  if (op.to.kind === 'zone') {
+    const zones = ensureZones(intermediate);
+    return withZones(intermediate, {
+      ...zones,
+      kpi: insertAt(zones.kpi, op.to.position, component),
+    });
+  }
+
+  const targetLoc = findSection(intermediate, op.to.sectionId);
+  if (!targetLoc) {
+    throw new Error(
+      `applyOp(move_component): target section "${op.to.sectionId}" not found`,
+    );
+  }
+  return updateSection(intermediate, targetLoc, (section) => ({
+    ...section,
+    components: insertAt(section.components, op.to.position, component),
+  }));
+}
+
+function applyUpdateComponentConfig(
+  layout: AiPageLayout,
+  op: UpdateComponentConfigOp,
+): AiPageLayout {
+  const loc = findComponent(layout, op.componentId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(update_component_config): component "${op.componentId}" not found`,
+    );
+  }
+
+  const merge = (existing: AiLayoutComponent): AiLayoutComponent => {
+    const config = { ...existing.config };
+    for (const [key, value] of Object.entries(op.patch)) {
+      if (value === null) {
+        delete config[key];
+      } else {
+        config[key] = value;
+      }
+    }
+    return { ...existing, config };
+  };
+
+  if (loc.kind === 'zone') {
+    const zones = ensureZones(layout);
+    const kpi = zones.kpi.slice();
+    kpi[loc.componentIndex] = merge(kpi[loc.componentIndex]);
+    return withZones(layout, { ...zones, kpi });
+  }
+
+  const sectionLoc: SectionLocation =
+    loc.kind === 'tab'
+      ? { kind: 'tab', tabIndex: loc.tabIndex, sectionIndex: loc.containerIndex }
+      : { kind: loc.kind, sectionIndex: loc.containerIndex };
+
+  return updateSection(layout, sectionLoc, (section) => {
+    const components = section.components.slice();
+    components[loc.componentIndex] = merge(components[loc.componentIndex]);
+    return { ...section, components };
+  });
+}
+
+function applyAddSection(layout: AiPageLayout, op: AddSectionOp): AiPageLayout {
+  const section = materialiseSection(op.section);
+
+  if (op.target.kind === 'rail') {
+    const zones = ensureZones(layout);
+    return withZones(layout, {
+      ...zones,
+      [op.target.rail]: insertAt(zones[op.target.rail], op.position, section),
+    });
+  }
+
+  const tabId = op.target.tabId;
+  const tabIndex = layout.tabs.findIndex((t) => t.id === tabId);
+  if (tabIndex === -1) {
+    throw new Error(`applyOp(add_section): tab "${tabId}" not found`);
+  }
+  const tabs = layout.tabs.slice();
+  tabs[tabIndex] = {
+    ...tabs[tabIndex],
+    sections: insertAt(tabs[tabIndex].sections, op.position, section),
+  };
+  return { ...layout, tabs };
+}
+
+function applyRemoveSection(
+  layout: AiPageLayout,
+  op: RemoveSectionOp,
+): AiPageLayout {
+  const loc = findSection(layout, op.sectionId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(remove_section): section "${op.sectionId}" not found`,
+    );
+  }
+  return removeSectionAt(layout, loc);
+}
+
+function applyReplaceSection(
+  layout: AiPageLayout,
+  op: ReplaceSectionOp,
+): AiPageLayout {
+  const loc = findSection(layout, op.sectionId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(replace_section): section "${op.sectionId}" not found`,
+    );
+  }
+  return updateSection(layout, loc, (existing) => ({
+    ...existing,
+    ...(op.section.label !== undefined ? { label: op.section.label } : {}),
+    ...(op.section.columns !== undefined ? { columns: op.section.columns } : {}),
+    ...(op.section.collapsed !== undefined
+      ? { collapsed: op.section.collapsed }
+      : {}),
+    components: op.section.components.map(materialiseComponent),
+  }));
+}
+
+function applyReorderSection(
+  layout: AiPageLayout,
+  op: ReorderSectionOp,
+): AiPageLayout {
+  const loc = findSection(layout, op.sectionId);
+  if (!loc) {
+    throw new Error(
+      `applyOp(reorder_section): section "${op.sectionId}" not found`,
+    );
+  }
+
+  if (loc.kind === 'tab') {
+    const tabIndex = loc.tabIndex!;
+    const tabs = layout.tabs.slice();
+    tabs[tabIndex] = {
+      ...tabs[tabIndex],
+      sections: moveTo(tabs[tabIndex].sections, loc.sectionIndex, op.position),
+    };
+    return { ...layout, tabs };
+  }
+
+  const zones = ensureZones(layout);
+  return withZones(layout, {
+    ...zones,
+    [loc.kind]: moveTo(zones[loc.kind], loc.sectionIndex, op.position),
+  });
+}
+
+export function applyOp(layout: AiPageLayout, op: AiEditOp): AiPageLayout {
+  switch (op.op) {
+    case 'add_component':
+      return applyAddComponent(layout, op);
+    case 'remove_component':
+      return applyRemoveComponent(layout, op);
+    case 'move_component':
+      return applyMoveComponent(layout, op);
+    case 'update_component_config':
+      return applyUpdateComponentConfig(layout, op);
+    case 'add_section':
+      return applyAddSection(layout, op);
+    case 'remove_section':
+      return applyRemoveSection(layout, op);
+    case 'replace_section':
+      return applyReplaceSection(layout, op);
+    case 'reorder_section':
+      return applyReorderSection(layout, op);
+  }
+}

--- a/packages/types/src/aiEdit.ts
+++ b/packages/types/src/aiEdit.ts
@@ -173,6 +173,10 @@ export interface UpdateComponentConfigOp {
   patch: Record<string, unknown>;
 }
 
+export type AiSectionType = 'field_section' | 'related_list' | 'widget_section';
+
+export const DEFAULT_SECTION_TYPE: AiSectionType = 'field_section';
+
 export interface AddSectionOp {
   op: 'add_section';
   id: string;
@@ -182,6 +186,8 @@ export interface AddSectionOp {
   position: number;
   section: {
     id?: string;
+    /** Defaults to DEFAULT_SECTION_TYPE when omitted. */
+    type?: AiSectionType;
     label: string;
     columns: number;
     collapsed?: boolean;
@@ -201,6 +207,7 @@ export interface ReplaceSectionOp {
   sectionId: string;
   section: {
     label?: string;
+    type?: AiSectionType;
     columns?: number;
     collapsed?: boolean;
     components: AiEditComponentInput[];
@@ -345,6 +352,12 @@ export const UpdateComponentConfigOpSchema = z
   })
   .strict();
 
+const SectionTypeSchema = z.enum([
+  'field_section',
+  'related_list',
+  'widget_section',
+]);
+
 export const AddSectionOpSchema = z
   .object({
     op: z.literal('add_section'),
@@ -354,6 +367,7 @@ export const AddSectionOpSchema = z
     section: z
       .object({
         id: NonEmptyString.optional(),
+        type: SectionTypeSchema.optional(),
         label: NonEmptyString,
         columns: z.number().int().min(1).max(2),
         collapsed: z.boolean().optional(),
@@ -379,6 +393,7 @@ export const ReplaceSectionOpSchema = z
     section: z
       .object({
         label: NonEmptyString.optional(),
+        type: SectionTypeSchema.optional(),
         columns: z.number().int().min(1).max(2).optional(),
         collapsed: z.boolean().optional(),
         components: z.array(ComponentInputSchema),
@@ -480,8 +495,12 @@ function materialiseComponent(input: AiEditComponentInput): AiLayoutComponent {
 function materialiseSection(
   input: AddSectionOp['section'],
 ): AiLayoutSection {
+  // Default to `field_section` so the post-apply BE validator
+  // (validateSection in pageLayoutService) accepts the layout. Without a
+  // type it rejects every AI-added section.
   return {
     id: input.id ?? generateId(ID_PREFIX_SECTION),
+    type: input.type ?? DEFAULT_SECTION_TYPE,
     label: input.label,
     columns: input.columns,
     ...(input.collapsed !== undefined ? { collapsed: input.collapsed } : {}),
@@ -846,6 +865,7 @@ function applyReplaceSection(
   return updateSection(layout, loc, (existing) => ({
     ...existing,
     ...(op.section.label !== undefined ? { label: op.section.label } : {}),
+    ...(op.section.type !== undefined ? { type: op.section.type } : {}),
     ...(op.section.columns !== undefined ? { columns: op.section.columns } : {}),
     ...(op.section.collapsed !== undefined
       ? { collapsed: op.section.collapsed }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1120,3 +1120,9 @@ export interface ComponentDefinition {
   /** Default config values when a new component is added */
   defaultConfig: Record<string, unknown>;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AI page-editor edit contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+export * from './aiEdit.js';

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary
Introduces a comprehensive type contract and pure reducer for AI-driven page layout edits, shared between frontend and backend. This establishes a single source of truth for layout mutations, ensuring consistency across the page builder.

## Key Changes

- **New `aiEdit.ts` module** with:
  - Layout shape types (`AiPageLayout`, `AiLayoutTab`, `AiLayoutSection`, `AiLayoutComponent`) mirroring the frontend layout structure
  - Context types for AI model requests (`AiEditContext`, `AiEditContextField`, `AiEditContextRelationship`)
  - 8 operation types for layout mutations: `add_component`, `remove_component`, `move_component`, `update_component_config`, `add_section`, `remove_section`, `replace_section`, `reorder_section`
  - Response type (`AiEditResponse`) with summary, operations list, and optional clarification field
  - Zod schemas for runtime validation of all types with strict object checking
  - Pure `applyOp` reducer function that immutably applies operations to layouts

- **Comprehensive test suite** (`aiEdit.test.ts`) covering:
  - Immutability guarantees
  - All 8 operation types with multiple scenarios
  - Error handling for missing references
  - Schema validation and rejection cases
  - Three worked examples demonstrating realistic operation sequences

- **Build configuration updates**:
  - Added Vitest configuration for test execution
  - Updated `package.json` test script to run Vitest
  - Updated `tsconfig.json` to exclude test files from compilation

## Notable Implementation Details

- The reducer is intentionally pure and never mutates input layouts, enabling safe accumulation with `reduce(applyOp, layout)`
- Reference validation (component/section/tab existence) is delegated to a separate validator; the reducer throws on missing references to fail loudly
- ID generation uses `crypto.randomUUID()` where available, falling back to `Math.random()` for compatibility
- Compile-time type guards ensure Zod schemas and TypeScript interfaces remain synchronized
- Clarification responses must have an empty ops list (enforced by schema refinement)

https://claude.ai/code/session_01AB7Vizp4or6tYwyyppTeZw